### PR TITLE
Update architecture SVG to reflect V27 dual-layer Tool Proxy split

### DIFF
--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" width="900" height="560" font-family="'Courier New', monospace">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" width="900" height="620" font-family="'Courier New', monospace">
   <defs>
     <!-- Background gradient -->
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -19,6 +19,14 @@
       <stop offset="0%" style="stop-color:#58a6ff;stop-opacity:0.2" />
       <stop offset="100%" style="stop-color:#58a6ff;stop-opacity:0.07" />
     </linearGradient>
+    <linearGradient id="httpGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#79c0ff;stop-opacity:0.15" />
+      <stop offset="100%" style="stop-color:#79c0ff;stop-opacity:0.05" />
+    </linearGradient>
+    <linearGradient id="policyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#3fb950;stop-opacity:0.15" />
+      <stop offset="100%" style="stop-color:#3fb950;stop-opacity:0.05" />
+    </linearGradient>
     <linearGradient id="adapterGrad" x1="0%" y1="0%" x2="0%" y2="100%">
       <stop offset="0%" style="stop-color:#bc8cff;stop-opacity:0.15" />
       <stop offset="100%" style="stop-color:#bc8cff;stop-opacity:0.05" />
@@ -33,12 +41,8 @@
       <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
       <feMerge><feMergeNode in="coloredBlur"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
-    <filter id="glowOrange">
-      <feGaussianBlur stdDeviation="2.5" result="coloredBlur"/>
-      <feMerge><feMergeNode in="coloredBlur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
 
-    <!-- Arrow marker -->
+    <!-- Arrow markers -->
     <marker id="arrowBlue" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
       <path d="M0,0 L0,6 L8,3 z" fill="#58a6ff" opacity="0.8"/>
     </marker>
@@ -48,144 +52,169 @@
     <marker id="arrowGrayLeft" markerWidth="8" markerHeight="8" refX="2" refY="3" orient="auto">
       <path d="M8,0 L8,6 L0,3 z" fill="#484f58" opacity="0.8"/>
     </marker>
+    <marker id="arrowPurple" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#bc8cff" opacity="0.8"/>
+    </marker>
+    <marker id="arrowRed" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#ff7b72" opacity="0.8"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#3fb950" opacity="0.8"/>
+    </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="900" height="560" fill="url(#bgGrad)" rx="12"/>
+  <rect width="900" height="620" fill="url(#bgGrad)" rx="12"/>
 
   <!-- Subtle grid pattern -->
   <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
     <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#ffffff" stroke-width="0.3" opacity="0.04"/>
   </pattern>
-  <rect width="900" height="560" fill="url(#grid)" rx="12"/>
+  <rect width="900" height="620" fill="url(#grid)" rx="12"/>
 
   <!-- Top border accent -->
-  <rect x="0" y="0" width="900" height="3" rx="2" fill="url(#proxyGrad)" opacity="1"/>
   <rect x="0" y="0" width="900" height="3" rx="2" fill="#58a6ff" opacity="0.4"/>
 
   <!-- ═══════════════════════════════════ -->
   <!-- TITLE -->
   <!-- ═══════════════════════════════════ -->
-  <text x="450" y="38" text-anchor="middle" font-size="13" fill="#8b949e" font-family="'Courier New', monospace" letter-spacing="4">OPENCLAW MODEL BRIDGE</text>
-  <text x="450" y="62" text-anchor="middle" font-size="11" fill="#484f58" font-family="'Courier New', monospace" letter-spacing="2">Two-Layer Middleware Architecture</text>
+  <text x="450" y="38" text-anchor="middle" font-size="13" fill="#8b949e" letter-spacing="4">OPENCLAW MODEL BRIDGE</text>
+  <text x="450" y="62" text-anchor="middle" font-size="11" fill="#484f58" letter-spacing="2">Two-Layer Middleware Architecture  v27</text>
 
   <!-- ═══════════════════════════════════ -->
-  <!-- ROW 1: WhatsApp + Gateway (horizontal) -->
+  <!-- ROW 1: WhatsApp + Gateway -->
   <!-- ═══════════════════════════════════ -->
 
   <!-- WhatsApp Box -->
-  <rect x="40" y="100" width="150" height="90" rx="8" fill="url(#waGrad)" stroke="#25d366" stroke-width="1" opacity="0.9"/>
-  <text x="115" y="128" text-anchor="middle" font-size="18" fill="#25d366">📱</text>
-  <text x="115" y="148" text-anchor="middle" font-size="12" fill="#25d366" font-weight="bold" letter-spacing="1">WhatsApp</text>
-  <text x="115" y="164" text-anchor="middle" font-size="9" fill="#8b949e">User Interface</text>
-  <text x="115" y="178" text-anchor="middle" font-size="9" fill="#484f58">+852 xxxxxxxx</text>
+  <rect x="40" y="95" width="150" height="90" rx="8" fill="url(#waGrad)" stroke="#25d366" stroke-width="1" opacity="0.9"/>
+  <text x="115" y="125" text-anchor="middle" font-size="18" fill="#25d366">&#x1F4F1;</text>
+  <text x="115" y="145" text-anchor="middle" font-size="12" fill="#25d366" font-weight="bold" letter-spacing="1">WhatsApp</text>
+  <text x="115" y="161" text-anchor="middle" font-size="9" fill="#8b949e">User Interface</text>
+  <text x="115" y="175" text-anchor="middle" font-size="9" fill="#484f58">+852 xxxxxxxx</text>
 
-  <!-- Arrow WA → GW -->
-  <line x1="190" y1="145" x2="250" y2="145" stroke="#484f58" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowGray)" marker-start="url(#arrowGrayLeft)"/>
+  <!-- Arrow WA <-> GW -->
+  <line x1="190" y1="140" x2="250" y2="140" stroke="#484f58" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowGray)" marker-start="url(#arrowGrayLeft)"/>
 
   <!-- Gateway Box -->
-  <rect x="250" y="100" width="170" height="90" rx="8" fill="url(#gwGrad)" stroke="#e36209" stroke-width="1" opacity="0.9"/>
-  <text x="335" y="128" text-anchor="middle" font-size="16" fill="#e36209">🦞</text>
-  <text x="335" y="148" text-anchor="middle" font-size="12" fill="#e36209" font-weight="bold" letter-spacing="0.5">OpenClaw Gateway</text>
-  <text x="335" y="163" text-anchor="middle" font-size="9" fill="#8b949e">Session · Tools · Events</text>
-  <rect x="290" y="172" width="90" height="12" rx="3" fill="#e36209" opacity="0.15"/>
-  <text x="335" y="181" text-anchor="middle" font-size="9" fill="#e36209" font-weight="bold">PORT 18789</text>
+  <rect x="250" y="95" width="170" height="90" rx="8" fill="url(#gwGrad)" stroke="#e36209" stroke-width="1" opacity="0.9"/>
+  <text x="335" y="123" text-anchor="middle" font-size="16" fill="#e36209">&#x1F99E;</text>
+  <text x="335" y="143" text-anchor="middle" font-size="12" fill="#e36209" font-weight="bold" letter-spacing="0.5">OpenClaw Gateway</text>
+  <text x="335" y="158" text-anchor="middle" font-size="9" fill="#8b949e">Session · Tools · Events</text>
+  <rect x="290" y="167" width="90" height="12" rx="3" fill="#e36209" opacity="0.15"/>
+  <text x="335" y="176" text-anchor="middle" font-size="9" fill="#e36209" font-weight="bold">PORT 18789</text>
 
   <!-- ═══════════════════════════════════ -->
-  <!-- TOOL PROXY — CENTER CORE (tall box) -->
+  <!-- TOOL PROXY — DUAL LAYER -->
   <!-- ═══════════════════════════════════ -->
 
-  <!-- Vertical arrow GW → Proxy -->
-  <line x1="335" y1="193" x2="335" y2="235" stroke="#58a6ff" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <!-- Vertical arrow GW -> Proxy -->
+  <line x1="335" y1="188" x2="335" y2="218" stroke="#58a6ff" stroke-width="2" marker-end="url(#arrowBlue)"/>
 
-  <!-- Tool Proxy — main card -->
-  <rect x="110" y="240" width="450" height="195" rx="10" fill="url(#proxyGrad)" stroke="#58a6ff" stroke-width="1.5" filter="url(#glowBlue)"/>
-  <rect x="110" y="240" width="450" height="38" rx="10" fill="#58a6ff" opacity="0.12"/>
-  <rect x="110" y="265" width="450" height="13" fill="#58a6ff" opacity="0.06"/>
+  <!-- Tool Proxy — outer container -->
+  <rect x="90" y="222" width="490" height="260" rx="10" fill="url(#proxyGrad)" stroke="#58a6ff" stroke-width="1.5" filter="url(#glowBlue)"/>
 
-  <!-- Proxy Header -->
-  <text x="335" y="261" text-anchor="middle" font-size="13" fill="#58a6ff" font-weight="bold" letter-spacing="2">⚙  TOOL PROXY</text>
-  <rect x="480" y="247" width="70" height="14" rx="3" fill="#58a6ff" opacity="0.2"/>
-  <text x="515" y="258" text-anchor="middle" font-size="9" fill="#58a6ff" font-weight="bold">PORT 5002</text>
+  <!-- Proxy Header bar -->
+  <rect x="90" y="222" width="490" height="32" rx="10" fill="#58a6ff" opacity="0.12"/>
+  <text x="335" y="244" text-anchor="middle" font-size="13" fill="#58a6ff" font-weight="bold" letter-spacing="2">TOOL PROXY</text>
+  <rect x="498" y="230" width="70" height="14" rx="3" fill="#58a6ff" opacity="0.2"/>
+  <text x="533" y="241" text-anchor="middle" font-size="9" fill="#58a6ff" font-weight="bold">PORT 5002</text>
 
-  <!-- 5 feature pills inside proxy -->
-  <!-- Row 1 -->
-  <rect x="128" y="292" width="190" height="44" rx="6" fill="#0d1117" opacity="0.5" stroke="#58a6ff" stroke-width="0.5" stroke-opacity="0.4"/>
-  <text x="223" y="309" text-anchor="middle" font-size="10" fill="#58a6ff">🔽  Tool Filter</text>
-  <text x="223" y="325" text-anchor="middle" font-size="9" fill="#8b949e">24 tools → 12 whitelisted</text>
+  <!-- ─── HTTP Layer (tool_proxy.py) ─── -->
+  <rect x="108" y="264" width="455" height="58" rx="7" fill="url(#httpGrad)" stroke="#79c0ff" stroke-width="1" stroke-opacity="0.6"/>
 
-  <rect x="342" y="292" width="200" height="44" rx="6" fill="#0d1117" opacity="0.5" stroke="#58a6ff" stroke-width="0.5" stroke-opacity="0.4"/>
-  <text x="442" y="309" text-anchor="middle" font-size="10" fill="#58a6ff">📐  Schema Simplifier</text>
-  <text x="442" y="325" text-anchor="middle" font-size="9" fill="#8b949e">required params only</text>
+  <!-- HTTP layer label -->
+  <text x="175" y="283" text-anchor="middle" font-size="10" fill="#79c0ff" font-weight="bold" letter-spacing="1">HTTP Layer</text>
+  <text x="175" y="296" text-anchor="middle" font-size="8" fill="#484f58">tool_proxy.py</text>
 
-  <!-- Row 2 -->
-  <rect x="128" y="346" width="190" height="44" rx="6" fill="#0d1117" opacity="0.5" stroke="#58a6ff" stroke-width="0.5" stroke-opacity="0.4"/>
-  <text x="223" y="363" text-anchor="middle" font-size="10" fill="#58a6ff">🔁  SSE Converter</text>
-  <text x="223" y="379" text-anchor="middle" font-size="9" fill="#8b949e">JSON → streaming SSE</text>
+  <!-- HTTP layer feature pills -->
+  <rect x="260" y="272" width="130" height="22" rx="4" fill="#0d1117" opacity="0.6" stroke="#79c0ff" stroke-width="0.5" stroke-opacity="0.3"/>
+  <text x="325" y="287" text-anchor="middle" font-size="9" fill="#79c0ff">Request Routing</text>
 
-  <rect x="342" y="346" width="200" height="44" rx="6" fill="#0d1117" opacity="0.5" stroke="#58a6ff" stroke-width="0.5" stroke-opacity="0.4"/>
-  <text x="442" y="363" text-anchor="middle" font-size="10" fill="#58a6ff">✂  Message Truncator</text>
-  <text x="442" y="379" text-anchor="middle" font-size="9" fill="#8b949e">byte-based 200KB limit</text>
+  <rect x="400" y="272" width="150" height="22" rx="4" fill="#0d1117" opacity="0.6" stroke="#79c0ff" stroke-width="0.5" stroke-opacity="0.3"/>
+  <text x="475" y="287" text-anchor="middle" font-size="9" fill="#79c0ff">Logging · Error Handling</text>
 
-  <!-- Row 3 center -->
-  <rect x="235" y="400" width="200" height="24" rx="6" fill="#0d1117" opacity="0.5" stroke="#58a6ff" stroke-width="0.5" stroke-opacity="0.4"/>
-  <text x="335" y="416" text-anchor="middle" font-size="10" fill="#58a6ff">🔧  Param Alias Mapper  |  file_path → path</text>
+  <text x="335" y="316" text-anchor="middle" font-size="8" fill="#484f58">calls pure functions from policy layer below</text>
+
+  <!-- Arrow HTTP -> Policy -->
+  <line x1="335" y1="322" x2="335" y2="336" stroke="#3fb950" stroke-width="1.5" marker-end="url(#arrowGreen)" opacity="0.6"/>
+
+  <!-- ─── Policy Layer (proxy_filters.py) ─── -->
+  <rect x="108" y="338" width="455" height="132" rx="7" fill="url(#policyGrad)" stroke="#3fb950" stroke-width="1" stroke-opacity="0.6"/>
+
+  <!-- Policy layer label -->
+  <text x="175" y="358" text-anchor="middle" font-size="10" fill="#3fb950" font-weight="bold" letter-spacing="1">Policy Layer</text>
+  <text x="175" y="371" text-anchor="middle" font-size="8" fill="#484f58">proxy_filters.py</text>
+  <text x="335" y="371" text-anchor="middle" font-size="8" fill="#3fb950" opacity="0.6">pure functions · no network · independently testable</text>
+
+  <!-- Policy feature pills - Row 1 -->
+  <rect x="122" y="382" width="205" height="36" rx="5" fill="#0d1117" opacity="0.5" stroke="#3fb950" stroke-width="0.5" stroke-opacity="0.4"/>
+  <text x="224" y="397" text-anchor="middle" font-size="10" fill="#3fb950">filter_tools()</text>
+  <text x="224" y="410" text-anchor="middle" font-size="8" fill="#8b949e">24 tools -> 12 whitelisted</text>
+
+  <rect x="343" y="382" width="205" height="36" rx="5" fill="#0d1117" opacity="0.5" stroke="#3fb950" stroke-width="0.5" stroke-opacity="0.4"/>
+  <text x="445" y="397" text-anchor="middle" font-size="10" fill="#3fb950">truncate_messages()</text>
+  <text x="445" y="410" text-anchor="middle" font-size="8" fill="#8b949e">byte-based 200KB limit</text>
+
+  <!-- Policy feature pills - Row 2 -->
+  <rect x="122" y="426" width="135" height="36" rx="5" fill="#0d1117" opacity="0.5" stroke="#3fb950" stroke-width="0.5" stroke-opacity="0.4"/>
+  <text x="189" y="441" text-anchor="middle" font-size="10" fill="#3fb950">fix_tool_args()</text>
+  <text x="189" y="454" text-anchor="middle" font-size="8" fill="#8b949e">param alias mapping</text>
+
+  <rect x="268" y="426" width="145" height="36" rx="5" fill="#0d1117" opacity="0.5" stroke="#3fb950" stroke-width="0.5" stroke-opacity="0.4"/>
+  <text x="340" y="441" text-anchor="middle" font-size="10" fill="#3fb950">build_sse_response()</text>
+  <text x="340" y="454" text-anchor="middle" font-size="8" fill="#8b949e">JSON -> streaming SSE</text>
+
+  <rect x="424" y="426" width="124" height="36" rx="5" fill="#0d1117" opacity="0.5" stroke="#3fb950" stroke-width="0.5" stroke-opacity="0.4"/>
+  <text x="486" y="441" text-anchor="middle" font-size="10" fill="#3fb950">is_allowed()</text>
+  <text x="486" y="454" text-anchor="middle" font-size="8" fill="#8b949e">tool whitelist check</text>
 
   <!-- ═══════════════════════════════════ -->
   <!-- ADAPTER -->
   <!-- ═══════════════════════════════════ -->
 
-  <!-- Arrow Proxy → Adapter -->
-  <line x1="335" y1="435" x2="335" y2="465" stroke="#bc8cff" stroke-width="2" marker-end="url(#arrowBlue)"/>
-  <defs>
-    <marker id="arrowPurple" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#bc8cff" opacity="0.8"/>
-    </marker>
-  </defs>
-  <line x1="335" y1="435" x2="335" y2="465" stroke="#bc8cff" stroke-width="2" marker-end="url(#arrowPurple)"/>
+  <!-- Arrow Proxy -> Adapter -->
+  <line x1="335" y1="482" x2="335" y2="510" stroke="#bc8cff" stroke-width="2" marker-end="url(#arrowPurple)"/>
 
   <!-- Adapter Box -->
-  <rect x="180" y="468" width="310" height="62" rx="8" fill="url(#adapterGrad)" stroke="#bc8cff" stroke-width="1"/>
-  <text x="335" y="490" text-anchor="middle" font-size="12" fill="#bc8cff" font-weight="bold" letter-spacing="1">🔌  ADAPTER</text>
-  <text x="335" y="506" text-anchor="middle" font-size="9" fill="#8b949e">Auth · User-Agent: curl/8.0 · Param Filter</text>
-  <rect x="422" y="474" width="58" height="14" rx="3" fill="#bc8cff" opacity="0.2"/>
-  <text x="451" y="485" text-anchor="middle" font-size="9" fill="#bc8cff" font-weight="bold">PORT 5001</text>
+  <rect x="180" y="514" width="310" height="62" rx="8" fill="url(#adapterGrad)" stroke="#bc8cff" stroke-width="1"/>
+  <text x="335" y="536" text-anchor="middle" font-size="12" fill="#bc8cff" font-weight="bold" letter-spacing="1">ADAPTER</text>
+  <text x="335" y="553" text-anchor="middle" font-size="9" fill="#8b949e">Auth ($REMOTE_API_KEY) · User-Agent · Param Filter</text>
+  <rect x="422" y="520" width="58" height="14" rx="3" fill="#bc8cff" opacity="0.2"/>
+  <text x="451" y="531" text-anchor="middle" font-size="9" fill="#bc8cff" font-weight="bold">PORT 5001</text>
 
   <!-- ═══════════════════════════════════ -->
   <!-- GPU / Remote API -->
   <!-- ═══════════════════════════════════ -->
 
-  <!-- Arrow Adapter → GPU -->
-  <defs>
-    <marker id="arrowRed" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#ff7b72" opacity="0.8"/>
-    </marker>
-  </defs>
-  <line x1="490" y1="499" x2="680" y2="390" stroke="#ff7b72" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowRed)" opacity="0.7"/>
+  <!-- Arrow Adapter -> GPU -->
+  <line x1="490" y1="545" x2="680" y2="430" stroke="#ff7b72" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowRed)" opacity="0.7"/>
 
   <!-- GPU Box -->
-  <rect x="680" y="290" width="190" height="130" rx="10" fill="url(#gpuGrad)" stroke="#ff7b72" stroke-width="1"/>
-  <text x="775" y="318" text-anchor="middle" font-size="16" fill="#ff7b72">🖥</text>
-  <text x="775" y="338" text-anchor="middle" font-size="11" fill="#ff7b72" font-weight="bold" letter-spacing="0.5">Remote GPU</text>
-  <text x="775" y="354" text-anchor="middle" font-size="9" fill="#8b949e">Qwen3-235B-A22B</text>
-  <text x="775" y="368" text-anchor="middle" font-size="9" fill="#8b949e">W8A8 · 262K ctx</text>
-  <line x1="710" y1="378" x2="840" y2="378" stroke="#ff7b72" stroke-width="0.5" opacity="0.3"/>
-  <text x="775" y="392" text-anchor="middle" font-size="9" fill="#484f58">native tool calling</text>
-  <text x="775" y="406" text-anchor="middle" font-size="9" fill="#484f58">xinference API</text>
+  <rect x="680" y="320" width="190" height="130" rx="10" fill="url(#gpuGrad)" stroke="#ff7b72" stroke-width="1"/>
+  <text x="775" y="348" text-anchor="middle" font-size="16" fill="#ff7b72">&#x1F5A5;</text>
+  <text x="775" y="368" text-anchor="middle" font-size="11" fill="#ff7b72" font-weight="bold" letter-spacing="0.5">Remote GPU</text>
+  <text x="775" y="384" text-anchor="middle" font-size="9" fill="#8b949e">Qwen3-235B-A22B</text>
+  <text x="775" y="398" text-anchor="middle" font-size="9" fill="#8b949e">W8A8 · 262K ctx</text>
+  <line x1="710" y1="408" x2="840" y2="408" stroke="#ff7b72" stroke-width="0.5" opacity="0.3"/>
+  <text x="775" y="422" text-anchor="middle" font-size="9" fill="#484f58">native tool calling</text>
+  <text x="775" y="436" text-anchor="middle" font-size="9" fill="#484f58">xinference API</text>
 
   <!-- ═══════════════════════════════════ -->
-  <!-- LEGEND bottom -->
+  <!-- LEGEND -->
   <!-- ═══════════════════════════════════ -->
-  <line x1="40" y1="530" x2="870" y2="530" stroke="#21262d" stroke-width="1"/>
+  <line x1="40" y1="592" x2="870" y2="592" stroke="#21262d" stroke-width="1"/>
 
-  <line x1="60" y1="548" x2="90" y2="548" stroke="#484f58" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <text x="98" y="552" font-size="9" fill="#8b949e">local IPC</text>
+  <line x1="50" y1="608" x2="80" y2="608" stroke="#484f58" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="88" y="612" font-size="9" fill="#8b949e">local IPC</text>
 
-  <line x1="160" y1="548" x2="190" y2="548" stroke="#58a6ff" stroke-width="2"/>
-  <text x="198" y="552" font-size="9" fill="#8b949e">middleware data flow</text>
+  <line x1="145" y1="608" x2="175" y2="608" stroke="#58a6ff" stroke-width="2"/>
+  <text x="183" y="612" font-size="9" fill="#8b949e">middleware flow</text>
 
-  <line x1="310" y1="548" x2="340" y2="548" stroke="#ff7b72" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <text x="348" y="552" font-size="9" fill="#8b949e">HTTPS remote API</text>
+  <line x1="270" y1="608" x2="300" y2="608" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="308" y="612" font-size="9" fill="#8b949e">internal call</text>
 
-  <text x="870" y="552" text-anchor="end" font-size="9" fill="#484f58">github.com/bisdom-cell/openclaw-model-bridge</text>
+  <line x1="380" y1="608" x2="410" y2="608" stroke="#ff7b72" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="418" y="612" font-size="9" fill="#8b949e">HTTPS remote API</text>
+
+  <text x="870" y="612" text-anchor="end" font-size="9" fill="#484f58">github.com/bisdom-cell/openclaw-model-bridge</text>
 </svg>


### PR DESCRIPTION
Split the Tool Proxy section into two clearly labeled sub-regions:
- HTTP Layer (tool_proxy.py): request routing, logging, error handling
- Policy Layer (proxy_filters.py): pure functions for tool filtering, message truncation, param alias mapping, SSE conversion, whitelist check

Also added green "internal call" arrow between layers, updated legend, and bumped diagram version label to v27.

https://claude.ai/code/session_01JGR1WivD61P3Aa62RmjKqt