### PR TITLE
feat: unified observability for all watcher scripts

### DIFF
--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -17,6 +17,11 @@ MAX_AGE_DAYS=14
 
 ARXIV_URL="https://export.arxiv.org/api/query?search_query=ti:LLM+OR+ti:%22Large+Language+Model%22+OR+ti:%22AI+Agent%22+OR+ti:RAG+OR+ti:RLHF+OR+ti:Multimodal+OR+ti:DeepSeek+OR+ti:Gemini+OR+ti:ChatGPT+OR+ti:GPT-4+OR+ti:GPT-5+OR+ti:Claude+OR+ti:Llama+OR+ti:Mistral+OR+ti:Qwen&sortBy=submittedDate&sortOrder=descending&max_results=50"
 
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+STATUS_FILE="$CACHE/last_run.json"
+
+log() { echo "[$TS] arxiv: $1"; }
+
 mkdir -p "$CACHE" "${KB_BASE:-$HOME/.kb}/sources"
 test -f "$KB_SRC" || echo "# ArXiv AI论文监控" > "$KB_SRC"
 DAY="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d')"
@@ -107,7 +112,8 @@ PYEOF
 
 PAPER_COUNT="$(wc -l < "$PAPERS_FILE" | tr -d ' ')"
 if [ "$PAPER_COUNT" -eq 0 ]; then
-    echo "[arxiv] 无新论文（全部已发送或过去${MAX_AGE_DAYS}天无结果），跳过推送。"
+    log "无新论文（全部已发送或过去${MAX_AGE_DAYS}天无结果），跳过推送。"
+    printf '{"time":"%s","status":"ok","new":0}\n' "$TS" > "$STATUS_FILE"
     exit 0
 fi
 echo "[arxiv] 新论文: ${PAPER_COUNT} 篇"
@@ -245,8 +251,13 @@ print(f"[arxiv] 消息组装完成: {len(papers)} 篇", file=sys.stderr)
 PYEOF
 
 # ── 6. 推送WhatsApp ─────────────────────────────────────────────────────
-"$OPENCLAW" message send --target "$TO" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1 || true
-echo "[arxiv] 已推送 ${PAPER_COUNT} 篇论文"
+if "$OPENCLAW" message send --target "$TO" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1; then
+    log "已推送 ${PAPER_COUNT} 篇论文"
+    printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$PAPER_COUNT" > "$STATUS_FILE"
+else
+    log "ERROR: 推送失败（${PAPER_COUNT} 篇待发），请检查 gateway。"
+    printf '{"time":"%s","status":"send_failed","new":%d,"sent":false}\n' "$TS" "$PAPER_COUNT" > "$STATUS_FILE"
+fi
 
 # ── 7. KB归档（合并原 kb-save-arxiv 功能）──────────────────────────────
 SUMMARY="$(cat "$MSG_FILE")"
@@ -274,4 +285,4 @@ fi
 
 # ── 10. rsync备份 ───────────────────────────────────────────────────────
 rsync -a --quiet "$HOME/.kb/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true
-echo "[arxiv] 完成"
+log "完成"

--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -21,6 +21,10 @@ KB_SRC="${KB_BASE:-$HOME/.kb}/sources/freight_daily.md"
 KB_INBOX="${KB_BASE:-$HOME/.kb}/inbox.md"
 TO="${OPENCLAW_PHONE:-+85200000000}"
 LLM_RAW="$CACHE/llm_raw_last.txt"
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+STATUS_FILE="$CACHE/last_run.json"
+
+log() { echo "[$TS] freight: $1"; }
 
 mkdir -p "$CACHE" "${KB_BASE:-$HOME/.kb}/sources"
 test -f "$KB_SRC"   || echo "# 货代商机 Watcher" > "$KB_SRC"
@@ -127,7 +131,8 @@ PYEOF
 # ── 2. 计算新条目数 ──────────────────────────────────────────────────────
 NEW_COUNT="$(wc -l < "$NEW_FILE" | tr -d ' ')"
 if [ "$NEW_COUNT" -eq 0 ]; then
-    echo "[freight] 暂无新商机，本轮跳过。"
+    log "暂无新商机，本轮跳过。"
+    printf '{"time":"%s","status":"ok","new":0}\n' "$TS" > "$STATUS_FILE"
     exit 0
 fi
 
@@ -254,8 +259,13 @@ PYEOF2
 } > "$MSG_FILE"
 
 # ── 5. 推送WhatsApp ─────────────────────────────────────────────────────
-"$OPENCLAW" message send --target "$TO" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1 || true
-echo "[freight] 已推送 ${NEW_COUNT} 条商机（${DAY}）"
+if "$OPENCLAW" message send --target "$TO" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1; then
+    log "已推送 ${NEW_COUNT} 条商机（${DAY}）"
+    printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$NEW_COUNT" > "$STATUS_FILE"
+else
+    log "ERROR: 推送失败（${NEW_COUNT} 条待发），请检查 gateway。"
+    printf '{"time":"%s","status":"send_failed","new":%d,"sent":false}\n' "$TS" "$NEW_COUNT" > "$STATUS_FILE"
+fi
 
 # ── 6. KB归档 ───────────────────────────────────────────────────────────
 {
@@ -406,15 +416,17 @@ except Exception:
 
         # 推送客户画像
         if [ -n "${PROFILE_OUT// }" ]; then
-            "$OPENCLAW" message send --target "$TO" \
+            if "$OPENCLAW" message send --target "$TO" \
                 --message "📊 货代客户画像 (${DAY})
 
 ${PROFILE_OUT}
 
 💡 数据来源：ImportYeti美国海关提单 + 行业新闻
-⚠ 预算为运价推算值，仅供参考" --json >/dev/null 2>&1 || true
-
-            echo "[freight] 已推送客户画像"
+⚠ 预算为运价推算值，仅供参考" --json >/dev/null 2>&1; then
+                log "已推送客户画像"
+            else
+                log "ERROR: 客户画像推送失败，请检查 gateway。"
+            fi
 
             # KB归档
             {

--- a/jobs/openclaw_official/run.sh
+++ b/jobs/openclaw_official/run.sh
@@ -19,6 +19,11 @@ MSG="$CACHE_DIR/system_message.txt"
 KB_SRC="${KB_BASE:-$HOME/.kb}/sources/openclaw_official.md"
 KB_INBOX="${KB_BASE:-$HOME/.kb}/inbox.md"
 
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+STATUS_FILE="$CACHE_DIR/last_run.json"
+
+log() { echo "[$TS] openclaw_releases: $1"; }
+
 mkdir -p "$CACHE_DIR" "$HOME/.kb/sources" "$ROOT/logs/jobs"
 
 # init files if absent
@@ -77,7 +82,8 @@ done < "$JSONL_FILE"
 rm -f "$JSONL_FILE"
 
 if [ "$new_count" -eq 0 ] && [ "$blog_new_count" -eq 0 ]; then
-  echo "openclaw_official/github_releases: no new releases."
+  log "no new releases."
+  printf '{"time":"%s","status":"ok","new":0}\n' "$TS" > "$STATUS_FILE"
   rm -f "$new_ids_file" "$new_events_file" "$blog_new_events_file"
   exit 0
 fi
@@ -212,4 +218,11 @@ cat "$MSG"
 
 # OPTIONAL: announce hook (adapt to your environment)
 # "$ROOT/bin/announce.sh" < "$MSG"
-openclaw message send --target "${OPENCLAW_PHONE:-+85200000000}" --message "$(cat "$MSG")" --json >/dev/null 2>&1 || true
+total_new=$((new_count + blog_new_count))
+if openclaw message send --target "${OPENCLAW_PHONE:-+85200000000}" --message "$(cat "$MSG")" --json >/dev/null 2>&1; then
+    log "已推送 ${total_new} 条更新（releases=${new_count}, blog=${blog_new_count}）"
+    printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$total_new" > "$STATUS_FILE"
+else
+    log "ERROR: 推送失败（${total_new} 条待发），请检查 gateway。"
+    printf '{"time":"%s","status":"send_failed","new":%d,"sent":false}\n' "$TS" "$total_new" > "$STATUS_FILE"
+fi

--- a/jobs/openclaw_official/run_blog.sh
+++ b/jobs/openclaw_official/run_blog.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+
 ROOT="${ROOT:-$HOME/.openclaw}"
 JOB="$ROOT/jobs/openclaw_official"
 KB_SRC="$HOME/.kb/sources/openclaw_official.md"
 KB_INBOX="$HOME/.kb/inbox.md"
 CACHE="$JOB/cache"
+STATUS_FILE="$CACHE/last_run_blog.json"
+
+log() { echo "[$TS] openclaw_blog: $1"; }
+
 mkdir -p "$CACHE" "$HOME/.kb/sources"
 test -f "$KB_SRC" || echo "# OpenClaw Official Watcher" > "$KB_SRC"
 test -f "$KB_INBOX" || echo "# INBOX" > "$KB_INBOX"
@@ -27,7 +34,8 @@ done < "$PARSE_TMP"
 
 cnt="$(wc -l < "$BLOG_NEW" | tr -d " ")"
 if [ "$cnt" -eq 0 ]; then
-  echo "openclaw_official/blog: no new posts."
+  log "no new posts."
+  printf '{"time":"%s","status":"ok","new":0}\n' "$TS" > "$STATUS_FILE"
   exit 0
 fi
 
@@ -93,6 +101,11 @@ TO="${OPENCLAW_PHONE:-+85200000000}"
   done < "$BLOG_NEW"
 } > "$MSG"
 
-openclaw message send --target "$TO" --message "$(cat "$MSG")" --json 2>&1 || echo "⚠️ 发送失败 $(date)" >>~/.openclaw/logs/jobs/openclaw_blog.log
-echo "openclaw_official/blog: sent ${cnt} new post(s). msg=${MSG}"
+if openclaw message send --target "$TO" --message "$(cat "$MSG")" --json >/dev/null 2>&1; then
+    log "已推送 ${cnt} 篇博客。"
+    printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$cnt" > "$STATUS_FILE"
+else
+    log "ERROR: 推送失败（${cnt} 篇待发），请检查 gateway。"
+    printf '{"time":"%s","status":"send_failed","new":%d,"sent":false}\n' "$TS" "$cnt" > "$STATUS_FILE"
+fi
 rsync -a --quiet "$HOME/.kb/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true

--- a/jobs/openclaw_official/run_discussions.sh
+++ b/jobs/openclaw_official/run_discussions.sh
@@ -10,6 +10,10 @@ FEED_URL="https://github.com/openclaw/openclaw/discussions.atom"
 FEED_FILE="$CACHE/discussions.atom"
 NEW_FILE="$CACHE/discussions_new.txt"
 TO="${OPENCLAW_PHONE:-+85200000000}"
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+STATUS_FILE="$CACHE/last_run_discussions.json"
+
+log() { echo "[$TS] openclaw_discussions: $1"; }
 
 mkdir -p "$CACHE" "$HOME/.kb/sources"
 test -f "$KB_SRC"   || echo "# OpenClaw Official Watcher" > "$KB_SRC"
@@ -49,7 +53,8 @@ done < "$NEW_FILE"
 
 cnt="$(wc -l < "$CACHE/discussions_send.txt" | tr -d ' ')"
 if [ "$cnt" -eq 0 ]; then
-    echo "openclaw_official/discussions: 暂无新讨论。"
+    log "暂无新讨论。"
+    printf '{"time":"%s","status":"ok","new":0}\n' "$TS" > "$STATUS_FILE"
     exit 0
 fi
 
@@ -91,6 +96,11 @@ while IFS='|' read -r title url date; do
 
 done < "$CACHE/discussions_send.txt"
 
-openclaw message send --target "$TO" --message "$(cat "$MSG")" --json >/dev/null 2>&1 || true
-echo "openclaw_official/discussions: 已推送 ${cnt} 条新讨论（含LLM富摘要）。"
+if openclaw message send --target "$TO" --message "$(cat "$MSG")" --json >/dev/null 2>&1; then
+    log "已推送 ${cnt} 条新讨论（含LLM富摘要）。"
+    printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$cnt" > "$STATUS_FILE"
+else
+    log "ERROR: 推送失败（${cnt} 条待发），请检查 gateway。"
+    printf '{"time":"%s","status":"send_failed","new":%d,"sent":false}\n' "$TS" "$cnt" > "$STATUS_FILE"
+fi
 rsync -a --quiet "$HOME/.kb/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true

--- a/kb_evening.sh
+++ b/kb_evening.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 DATE=$(date +%Y%m%d)
 KB_DIR="${KB_BASE:-/Users/bisdom/.kb}"
 PHONE="${OPENCLAW_PHONE:-+85200000000}"
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+STATUS_FILE="$KB_DIR/last_run_evening.json"
+
+log() { echo "[$TS] kb_evening: $1"; }
 
 TODAY_FILES=$(ls "$KB_DIR/notes/" 2>/dev/null | grep "^$DATE" || true)
 
@@ -20,5 +24,10 @@ else
 $FILE_LIST"
 fi
 
-openclaw message send --channel whatsapp -t "$PHONE" -m "$MSG" || echo "[kb_evening] WARN: 消息发送失败"
-echo "[kb_evening] 发送完成: $DATE"
+if openclaw message send --channel whatsapp -t "$PHONE" -m "$MSG" >/dev/null 2>&1; then
+    log "发送完成: $DATE"
+    printf '{"time":"%s","status":"ok","sent":true}\n' "$TS" > "$STATUS_FILE"
+else
+    log "ERROR: 消息发送失败，请检查 gateway。"
+    printf '{"time":"%s","status":"send_failed","sent":false}\n' "$TS" > "$STATUS_FILE"
+fi

--- a/run_hn_fixed.sh
+++ b/run_hn_fixed.sh
@@ -18,6 +18,10 @@ NEW_FILE="$CACHE_DIR/hn_new.jsonl"
 RSS_FILE="$CACHE_DIR/hn_frontpage.xml"
 LLM_RAW_LOG="$CACHE_DIR/llm_raw_last.txt"
 TO="${OPENCLAW_PHONE:-+85200000000}"
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+STATUS_FILE="$CACHE_DIR/last_run.json"
+
+log() { echo "[$TS] hn_watcher: $1"; }
 
 mkdir -p "$CACHE_DIR"
 touch "$INBOX"
@@ -105,7 +109,8 @@ PYEOF
 
 NEW_COUNT=$(wc -l < "$NEW_FILE" 2>/dev/null || echo 0)
 if [ "$NEW_COUNT" -eq 0 ]; then
-    echo "$(date '+%Y-%m-%d %H:%M:%S') hn_watcher: 暂无新AI/Tech内容。"
+    log "暂无新AI/Tech内容。"
+    printf '{"time":"%s","status":"ok","new":0}\n' "$TS" > "$STATUS_FILE"
     exit 0
 fi
 
@@ -268,8 +273,16 @@ PYEOF
 <<< "$RESULT")
 
 if [ "$SENT_COUNT" -gt 0 ]; then
-    openclaw message send --target "$TO" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1 || true
+    if openclaw message send --target "$TO" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1; then
+        log "已推送 ${SENT_COUNT} 条AI/Tech精选（单次批量LLM）。"
+        printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$SENT_COUNT" > "$STATUS_FILE"
+    else
+        log "ERROR: 推送失败（${SENT_COUNT} 条待发），请检查 gateway。"
+        printf '{"time":"%s","status":"send_failed","new":%d,"sent":false}\n' "$TS" "$SENT_COUNT" > "$STATUS_FILE"
+    fi
+else
+    log "LLM解析完成但无有效条目。"
+    printf '{"time":"%s","status":"ok","new":0}\n' "$TS" > "$STATUS_FILE"
 fi
 
 rsync -a --quiet "$KB_DIR/" "$SSD_BACKUP" 2>/dev/null || true
-echo "$(date '+%Y-%m-%d %H:%M:%S') hn_watcher: 已推送 ${SENT_COUNT} 条AI/Tech精选（单次批量LLM）。"


### PR DESCRIPTION
Apply consistent pattern across 7 scripts:
- Timestamped log output (HKT) via log() helper
- last_run.json status file for quick health check
- Detect openclaw message send failures instead of || true

Scripts updated:
- run_hn_fixed.sh
- jobs/arxiv_monitor/run_arxiv.sh
- jobs/freight_watcher/run_freight.sh
- jobs/openclaw_official/run.sh
- jobs/openclaw_official/run_blog.sh
- jobs/openclaw_official/run_discussions.sh
- kb_evening.sh

https://claude.ai/code/session_019eHArsHKLi7BSkewJif5a5