### PR TITLE
fix: 社区新动态推送失败 — 添加 PATH export + 替换 openclaw agent

### DIFF
--- a/jobs/openclaw_official/run.sh
+++ b/jobs/openclaw_official/run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
 blog_new_count=0
 blog_new_events_file=""
@@ -122,7 +124,11 @@ now_hkt="$(TZ=Asia/Hong_Kong date "+%Y-%m-%d %H:%M HKT")"
 原标题：${title}
 链接：${url}"
 
-    ENRICH="$(openclaw agent --to "$TO" --session-id "$(date +%s%N)" --message "$PROMPT" --thinking minimal 2>/dev/null || true)"
+    # 规则 #8: 纯推理直接 curl adapter，禁止用 openclaw agent（#94教训）
+    ENRICH="$(curl -sS --max-time 30 http://localhost:5001/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -nc --arg p "$PROMPT" '{model:"any",messages:[{role:"user",content:$p}],max_tokens:200}')" \
+      2>/dev/null | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
 
     # fallback：LLM失败或429限流时用原标题
     if [ -z "${ENRICH// }" ] || echo "$ENRICH" | grep -q "429"; then

--- a/jobs/openclaw_official/run_discussions.sh
+++ b/jobs/openclaw_official/run_discussions.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
 
 ROOT="${ROOT:-$HOME/.openclaw}"
@@ -74,7 +76,11 @@ while IFS='|' read -r title url date; do
 原标题：${title}
 链接：${url}"
 
-    ENRICH="$(openclaw agent --to "$TO" --session-id "$(date +%s%N)" --message "$PROMPT" --thinking minimal 2>/dev/null || true)"
+    # 规则 #8: 纯推理直接 curl adapter，禁止用 openclaw agent（#94教训）
+    ENRICH="$(curl -sS --max-time 30 http://localhost:5001/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -nc --arg p "$PROMPT" '{model:"any",messages:[{role:"user",content:$p}],max_tokens:200}')" \
+      2>/dev/null | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
 
     # fallback：LLM失败或429限流时用原标题
     if [ -z "${ENRICH// }" ] || echo "$ENRICH" | grep -q "429"; then

--- a/jobs_registry.yaml
+++ b/jobs_registry.yaml
@@ -77,8 +77,8 @@ jobs:
     interval: ""
     log: ~/openclaw_discussions.log
     needs_api_key: true
-    enabled: true
-    description: GitHub Discussions 监控
+    enabled: false                   # 已由 run_discussions (system cron, 每时15分) 统一处理
+    description: GitHub Discussions 监控（冗余条目，实际由 run_discussions 执行）
 
   - id: kb_review
     scheduler: openclaw

--- a/run_discussions.sh
+++ b/run_discussions.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
 
 ROOT="${ROOT:-$HOME/.openclaw}"
@@ -74,7 +76,11 @@ while IFS='|' read -r title url date; do
 原标题：${title}
 链接：${url}"
 
-    ENRICH="$(openclaw agent --to "$TO" --session-id "$(date +%s%N)" --message "$PROMPT" --thinking minimal 2>/dev/null || true)"
+    # 规则 #8: 纯推理直接 curl adapter，禁止用 openclaw agent（#94教训）
+    ENRICH="$(curl -sS --max-time 30 http://localhost:5001/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -nc --arg p "$PROMPT" '{model:"any",messages:[{role:"user",content:$p}],max_tokens:200}')" \
+      2>/dev/null | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
 
     # fallback：LLM失败或429限流时用原标题
     if [ -z "${ENRICH// }" ] || echo "$ENRICH" | grep -q "429"; then


### PR DESCRIPTION
根因：run_discussions.sh 和 run.sh 缺少 export PATH（规则 #13）， cron 环境下 curl/python3/openclaw 命令找不到，脚本静默失败。

修复：
1. 三个 cron 脚本添加 export PATH="/opt/homebrew/bin:..."
2. LLM 富摘要从 openclaw agent 改为直接 curl adapter:5001（规则 #8） 避免 Gateway 注入工具导致循环调用（#94教训）
3. 注册表 openclaw_discussions 标记 disabled（与 run_discussions 冗余）

https://claude.ai/code/session_01ABCUdABmgGWBqT5A814qua