### PR TITLE
fix: 修复除HN外所有Watcher静默失败的6个问题

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -101,6 +101,9 @@ declare -a FILE_MAP=(
 
     # 货代 Watcher
     "jobs/freight_watcher/run_freight.sh|$HOME/.openclaw/jobs/freight_watcher/run_freight.sh"
+
+    # ArXiv 监控
+    "jobs/arxiv_monitor/run_arxiv.sh|$HOME/.openclaw/jobs/arxiv_monitor/run_arxiv.sh"
 )
 
 SYNCED=0

--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 # ArXiv AI论文监控 v1 — 脚本控制格式，替代 --announce 模式
 # 每3小时整点 HKT 由系统crontab触发
 # 合并原 monitor-arxiv-ai-models + kb-save-arxiv 两个 openclaw cron 任务

--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -4,6 +4,8 @@
 # 调试记录：#84(信号源切换), #91(--session-id修复), 第31章(脚本设计宪法)
 # V2变更：⭐⭐⭐⭐+ 条目自动附加 ImportYeti 企业查询链接
 # V3变更：三层情报漏斗 — 信号捕获→ImportYeti深挖→客户画像生成
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -eo pipefail
 
 # ── --test 模式：跳过 RSS 抓取和 LLM 分析，直接从 Step 9 (ImportYeti) 开始 ──
@@ -159,14 +161,32 @@ for i, l in enumerate(lines, 1):
 行动：[≤30字可执行行动建议]
 评级：⭐（1-5个星）"
 
-LLM_OUT="$(
-    "$OPENCLAW" agent \
-        --to "$TO" \
-        --session-id "freight-$(date +%s)" \
-        --message "$PROMPT" \
-        --thinking off \
-        2>"$LLM_RAW.stderr" || true
-)"
+# 规则 #27: 纯推理直接 curl proxy:5002，禁止用 openclaw agent（#94教训）
+LLM_PAYLOAD=$(python3 -c "
+import json, sys
+prompt = sys.stdin.read()
+print(json.dumps({
+    'model': 'Qwen3-235B-A22B-Instruct-2507-W8A8',
+    'messages': [{'role': 'user', 'content': prompt}],
+    'max_tokens': 4096,
+    'temperature': 0.3
+}))
+" <<< "$PROMPT")
+
+LLM_RESP=$(curl -s --max-time 120 \
+    -H "Content-Type: application/json" \
+    -d "$LLM_PAYLOAD" \
+    http://127.0.0.1:5002/v1/chat/completions 2>"$LLM_RAW.stderr" || true)
+
+LLM_OUT=$(echo "$LLM_RESP" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d['choices'][0]['message']['content'])
+except Exception:
+    pass
+" 2>/dev/null || true)
+
 echo "returncode=$?" > "$LLM_RAW"
 echo "--- stderr ---" >> "$LLM_RAW"
 cat "$LLM_RAW.stderr" >> "$LLM_RAW" 2>/dev/null || true

--- a/jobs/openclaw_official/run_blog.sh
+++ b/jobs/openclaw_official/run_blog.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
 
 TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
@@ -81,7 +83,11 @@ TO="${OPENCLAW_PHONE:-+85200000000}"
 日期：${date}
 链接：${url}
 摘要：${summary}"
-    ENRICH="$(openclaw agent --to "$TO" --session-id "$(date +%s%N)" --message "$PROMPT" --thinking minimal 2>/dev/null || true)"
+    # 规则 #8: 纯推理直接 curl adapter，禁止用 openclaw agent（#94教训）
+    ENRICH="$(curl -sS --max-time 30 http://localhost:5001/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -nc --arg p "$PROMPT" '{model:"any",messages:[{role:"user",content:$p}],max_tokens:200}')" \
+      2>/dev/null | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
     # 429限流检测 + 空输出均fallback
     if [ -z "${ENRICH// }" ] || echo "$ENRICH" | grep -q "429"; then
       TITLE_CN="$title"

--- a/kb_evening.sh
+++ b/kb_evening.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
 DATE=$(date +%Y%m%d)
 KB_DIR="${KB_BASE:-/Users/bisdom/.kb}"

--- a/run_hn_fixed.sh
+++ b/run_hn_fixed.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 # run_hn.sh - Hacker News AI/Tech精选 Watcher
 # 触发时间：每3小时:45分（系统crontab）
 # v23fix2：


### PR DESCRIPTION
1. run_blog.sh: 添加 export PATH + 将 openclaw agent 替换为 直接 curl adapter:5001（修复 #94 工具注入循环）
2. run_freight.sh: 添加 export PATH + 将 $OPENCLAW agent 替换为 直接 curl proxy:5002（修复 #94 工具注入循环）
3. run_arxiv.sh: 添加 export PATH
4. run_hn_fixed.sh: 添加 export PATH
5. kb_evening.sh: 添加 export PATH
6. auto_deploy.sh: FILE_MAP 新增 arxiv_monitor 映射 （之前 run_arxiv.sh 永远不会被同步到 Mac Mini）

根因：cron 环境下 PATH 缺失导致命令找不到 + openclaw agent
注入工具导致 LLM 死循环或超时，错误被 2>/dev/null || true 静默吞掉

https://claude.ai/code/session_01ABCUdABmgGWBqT5A814qua