### PR TITLE
fix: 全面修复所有 cron 脚本的静默失败问题

### DIFF
--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -30,14 +30,19 @@ DAY="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d')"
 
 # ── 1. 抓取 ArXiv API XML ────────────────────────────────────────────────
 FEED_FILE="$CACHE/arxiv_feed.xml"
-curl -fsSL --max-time 30 "$ARXIV_URL" > "$FEED_FILE"
+# 去掉 -f：HTTP 错误不再触发 set -e 静默退出，改为手动检测
+if ! curl -sSL --max-time 30 "$ARXIV_URL" -o "$FEED_FILE" 2>"$CACHE/curl_feed.err"; then
+  log "ERROR: ArXiv API 抓取失败: $(head -1 "$CACHE/curl_feed.err" 2>/dev/null)"
+  printf '{"time":"%s","status":"fetch_failed","new":0}\n' "$TS" > "$STATUS_FILE"
+  exit 1
+fi
 echo "[arxiv] XML抓取完成"
 
 # ── 2. 解析XML → 结构化JSONL（标题/作者/日期/ID/摘要）─────────────────
 PAPERS_FILE="$CACHE/papers.jsonl"
 SEEN_FILE="$CACHE/seen_ids.txt"
 touch "$SEEN_FILE"
-python3 - "$FEED_FILE" "$MAX_AGE_DAYS" "$MAX_PAPERS" "$SEEN_FILE" << 'PYEOF' > "$PAPERS_FILE"
+if ! python3 - "$FEED_FILE" "$MAX_AGE_DAYS" "$MAX_PAPERS" "$SEEN_FILE" << 'PYEOF' > "$PAPERS_FILE"
 import sys, json, re, xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 
@@ -111,6 +116,11 @@ if new_ids:
 
 print(f"[arxiv] 解析完成: {count} 篇新论文（跳过 {len(seen_ids)} 篇已发送）", file=sys.stderr)
 PYEOF
+then
+  log "WARN: XML解析失败"
+  printf '{"time":"%s","status":"parse_failed","new":0}\n' "$TS" > "$STATUS_FILE"
+  exit 1
+fi
 
 PAPER_COUNT="$(wc -l < "$PAPERS_FILE" | tr -d ' ')"
 if [ "$PAPER_COUNT" -eq 0 ]; then

--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -54,7 +54,7 @@ fi
 
 if [ "$TEST_MODE" -eq 0 ]; then
 # ── 1. 抓取多源RSS + Google News ────────────────────────────────────────
-python3 - "$KB_INBOX" "$NEW_FILE" << 'PYEOF'
+if ! python3 - "$KB_INBOX" "$NEW_FILE" << 'PYEOF'
 import sys, json, re, urllib.request, xml.etree.ElementTree as ET
 from datetime import datetime, timezone, timedelta
 
@@ -129,6 +129,9 @@ with open(OUT_FILE, "w") as f:
             count += 1
 print(f"[freight] 抓取完成，新条目: {count}", file=sys.stderr)
 PYEOF
+then
+  log "WARN: RSS抓取Python脚本失败"
+fi
 
 # ── 2. 计算新条目数 ──────────────────────────────────────────────────────
 NEW_COUNT="$(wc -l < "$NEW_FILE" | tr -d ' ')"

--- a/jobs/openclaw_official/run_blog.sh
+++ b/jobs/openclaw_official/run_blog.sh
@@ -18,7 +18,13 @@ mkdir -p "$CACHE" "$HOME/.kb/sources"
 test -f "$KB_SRC" || echo "# OpenClaw Official Watcher" > "$KB_SRC"
 test -f "$KB_INBOX" || echo "# INBOX" > "$KB_INBOX"
 
-BLOG_HTML="$("$JOB/fetch_official_blog.sh")"
+# fetch 失败时记录日志而非静默退出
+BLOG_HTML=""
+if ! BLOG_HTML="$("$JOB/fetch_official_blog.sh" 2>"$CACHE/fetch_blog.err")"; then
+  log "ERROR: fetch_official_blog.sh 失败: $(head -1 "$CACHE/fetch_blog.err" 2>/dev/null)"
+  printf '{"time":"%s","status":"fetch_failed","new":0}\n' "$TS" > "$STATUS_FILE"
+  exit 1
+fi
 BLOG_NEW="$CACHE/blog_new.jsonl"
 PARSE_TMP="$CACHE/blog_parse.jsonl"
 : > "$BLOG_NEW"

--- a/kb_evening.sh
+++ b/kb_evening.sh
@@ -17,7 +17,7 @@ if [ -z "$TODAY_FILES" ]; then
 else
     TOTAL=$(echo "$TODAY_FILES" | wc -l | tr -d ' ')
     FIRST_FILE=$(echo "$TODAY_FILES" | head -1)
-    CONTENT=$(head -20 "$KB_DIR/notes/$FIRST_FILE" | grep -v '^---' | grep -v '^#' | grep -v '^$' | head -3 | tr '\n' ' ')
+    CONTENT=$(head -20 "$KB_DIR/notes/$FIRST_FILE" | { grep -v '^---' || true; } | { grep -v '^#' || true; } | { grep -v '^$' || true; } | head -3 | tr '\n' ' ')
     FILE_LIST=$(echo "$TODAY_FILES" | head -5 | while read -r f; do echo "  · $f"; done)
     MSG="[kb_evening] 今日知识摘要 $DATE
 新增笔记：$TOTAL 条

--- a/kb_review.sh
+++ b/kb_review.sh
@@ -6,7 +6,7 @@ KB_DIR="${KB_BASE:-/Users/bisdom/.kb}"
 REVIEW_FILE="$KB_DIR/daily/review_${DATE}.md"
 mkdir -p "$KB_DIR/daily"
 
-NOTE_COUNT=$(ls "$KB_DIR/notes/"*.md 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+NOTE_COUNT=$(ls "$KB_DIR/notes/"*.md 2>/dev/null | wc -l | tr -d ' ' || echo 0)
 INDEX_TOTAL=$(python3 - "$KB_DIR/index.json" << 'PYEOF'
 import json, sys
 try:
@@ -33,7 +33,7 @@ PYEOF
 )
 
 NOTES_TEXT=$(for f in $(ls -t "$KB_DIR/notes/"*.md 2>/dev/null | head -5); do
-    echo "- $(basename "$f"): $(head -5 "$f" | grep -v '^---' | grep -v '^#' | head -1)"
+    echo "- $(basename "$f"): $(head -5 "$f" | { grep -v '^---' || true; } | { grep -v '^#' || true; } | head -1)"
 done || true)
 
 cat > "$REVIEW_FILE" << MDEOF

--- a/run_hn_fixed.sh
+++ b/run_hn_fixed.sh
@@ -32,6 +32,7 @@ touch "$KB_SOURCE"
 curl -s --max-time 30 "https://hnrss.org/frontpage" -o "$RSS_FILE" 2>/dev/null
 if [ ! -s "$RSS_FILE" ]; then
     echo "$(date '+%Y-%m-%d %H:%M:%S') hn_watcher: curl失败，跳过。"
+    printf '{"time":"%s","status":"fetch_failed","new":0}\n' "$TS" > "$STATUS_FILE"
     exit 0
 fi
 


### PR DESCRIPTION
审计所有定时任务脚本，修复同类 bug：

1. run_blog.sh: fetch_official_blog.sh 失败时 set -e 静默退出 → 添加 if/! 错误处理，失败写入 STATUS_FILE

2. run_arxiv.sh: curl -fsSL + set -eo 导致 ArXiv API 抓取失败时静默退出； Python XML 解析失败同样静默退出 → 去掉 -f，手动检测；Python 块加 if/! 保护

3. kb_evening.sh: grep -v 管道无匹配时返回 1，触发 set -e 退出 → 所有 grep 加 { grep || true; } 保护

4. kb_review.sh: 同样的 grep -v 管道问题 → 加 { grep || true; } 保护

5. run_hn_fixed.sh: curl 失败早退时未写状态文件 → 补写 STATUS_FILE

6. run_freight.sh: RSS 抓取 Python 块失败时硬退出 → 加 if/! 保护，失败记录日志但继续

https://claude.ai/code/session_01ABCUdABmgGWBqT5A814qua