### PR TITLE
fix: run.sh WhatsApp send 使用 $TO 变量替代重复展开

### DIFF
--- a/jobs/openclaw_official/run.sh
+++ b/jobs/openclaw_official/run.sh
@@ -239,7 +239,7 @@ rsync -a --quiet "$HOME/.kb/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true
 # OPTIONAL: announce hook (adapt to your environment)
 # "$ROOT/bin/announce.sh" < "$MSG"
 total_new=$((new_count + blog_new_count))
-if openclaw message send --target "${OPENCLAW_PHONE:-+85200000000}" --message "$(cat "$MSG")" --json >/dev/null 2>&1; then
+if openclaw message send --target "$TO" --message "$(cat "$MSG")" --json >/dev/null 2>&1; then
     log "已推送 ${total_new} 条更新（releases=${new_count}, blog=${blog_new_count}）"
     printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$total_new" > "$STATUS_FILE"
 else


### PR DESCRIPTION
run.sh 第242行直接展开 ${OPENCLAW_PHONE:-...} 而非使用已定义的 $TO 变量， 与 run_blog.sh 和 run_discussions.sh 风格不一致。统一使用 $TO。

https://claude.ai/code/session_01ABCUdABmgGWBqT5A814qua