### PR TITLE
feat: Qwen token/error 监控 — proxy 层实时跟踪 + watchdog 集成

### DIFF
--- a/job_watchdog.sh
+++ b/job_watchdog.sh
@@ -85,9 +85,50 @@ except Exception:
     esac
 done
 
+# ── Proxy 监控：token 用量 + 错误率 ──────────────────────────────────
+PROXY_STATS="$HOME/proxy_stats.json"
+if [ -f "$PROXY_STATS" ]; then
+    PROXY_CHECK=$(python3 -c "
+import json, time
+try:
+    with open('$PROXY_STATS') as f:
+        s = json.load(f)
+    alerts = []
+    # 连续错误检查
+    ce = s.get('consecutive_errors', 0)
+    if ce >= 3:
+        last_err = s.get('last_error', {})
+        alerts.append(f'Proxy 连续 {ce} 次错误 (HTTP {last_err.get(\"code\",\"?\")}: {last_err.get(\"msg\",\"\")[:60]})')
+    # Context 用量检查
+    pct = s.get('context_usage_pct', 0)
+    pt = s.get('last_prompt_tokens', 0)
+    if pct >= 90:
+        alerts.append(f'Qwen context 临界: {pt:,} tokens ({pct}% of 260K)')
+    elif pct >= 75:
+        alerts.append(f'Qwen context 预警: {pt:,} tokens ({pct}% of 260K)')
+    # stats 文件本身过期（proxy 可能挂了）
+    updated = s.get('updated', '')
+    if updated:
+        from datetime import datetime, timedelta
+        try:
+            ut = datetime.strptime(updated, '%Y-%m-%d %H:%M:%S')
+            if datetime.now() - ut > timedelta(hours=2):
+                alerts.append(f'proxy_stats.json 超过2小时未更新（proxy可能已停止）')
+        except ValueError:
+            pass
+    print('\\n'.join(alerts))
+except Exception as e:
+    print(f'proxy_stats.json 读取失败: {e}')
+" 2>/dev/null)
+
+    while IFS= read -r line; do
+        [ -n "$line" ] && ALERTS+=("$line")
+    done <<< "$PROXY_CHECK"
+fi
+
 # ── 汇总告警 ────────────────────────────────────────────────────────
 if [ ${#ALERTS[@]} -eq 0 ]; then
-    echo "[$TS] watchdog: 全部 ${#JOBS[@]} 个任务正常"
+    echo "[$TS] watchdog: 全部 ${#JOBS[@]} 个任务 + Proxy 监控正常"
     exit 0
 fi
 

--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -4,6 +4,8 @@ proxy_filters.py — V27 提取自 tool_proxy.py
 所有过滤、修复、截断、SSE转换逻辑。纯函数 + 配置数据，无 HTTP/网络依赖。
 """
 import json
+import time
+import os
 
 # ---------------------------------------------------------------------------
 # 配置数据
@@ -305,3 +307,145 @@ def build_sse_response(rj):
         chunks_out.append(f"data: {json.dumps(chunk)}\n\n")
     chunks_out.append("data: [DONE]\n\n")
     return "".join(chunks_out).encode()
+
+
+# ---------------------------------------------------------------------------
+# Token / Error 监控
+# ---------------------------------------------------------------------------
+
+# Qwen3-235B context window limit (tokens)
+CONTEXT_LIMIT = 260000
+# 告警阈值：prompt_tokens 超过此值时触发预警
+TOKEN_WARN_THRESHOLD = int(CONTEXT_LIMIT * 0.75)  # 195K
+TOKEN_CRITICAL_THRESHOLD = int(CONTEXT_LIMIT * 0.90)  # 234K
+# 连续错误告警阈值
+CONSECUTIVE_ERROR_ALERT = 3
+
+STATS_FILE = os.path.expanduser("~/proxy_stats.json")
+
+
+class ProxyStats:
+    """轻量级请求统计跟踪器（进程内单例）。"""
+
+    def __init__(self):
+        self.total_requests = 0
+        self.total_errors = 0
+        self.consecutive_errors = 0
+        self.last_prompt_tokens = 0
+        self.last_total_tokens = 0
+        self.max_prompt_tokens_today = 0
+        self.last_error_code = 0
+        self.last_error_msg = ""
+        self.last_success_time = 0
+        self.last_error_time = 0
+        self.alerts = []  # 待发送告警列表
+        self._today = time.strftime("%Y-%m-%d")
+
+    def _check_day_reset(self):
+        today = time.strftime("%Y-%m-%d")
+        if today != self._today:
+            self.max_prompt_tokens_today = 0
+            self.total_requests = 0
+            self.total_errors = 0
+            self._today = today
+
+    def record_success(self, usage: dict):
+        """记录一次成功请求的 token 用量。"""
+        self._check_day_reset()
+        self.total_requests += 1
+        self.consecutive_errors = 0
+        self.last_success_time = time.time()
+
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        total_tokens = usage.get("total_tokens", 0)
+        self.last_prompt_tokens = prompt_tokens
+        self.last_total_tokens = total_tokens
+        if prompt_tokens > self.max_prompt_tokens_today:
+            self.max_prompt_tokens_today = prompt_tokens
+
+        # Token 阈值告警
+        if prompt_tokens >= TOKEN_CRITICAL_THRESHOLD:
+            self.alerts.append(
+                f"🔴 Qwen context 临界！prompt_tokens={prompt_tokens:,} "
+                f"(limit={CONTEXT_LIMIT:,}, 已用{prompt_tokens*100//CONTEXT_LIMIT}%)"
+                f"\n下一次请求大概率触发 403/502，建议立即重置 session"
+            )
+        elif prompt_tokens >= TOKEN_WARN_THRESHOLD:
+            self.alerts.append(
+                f"🟡 Qwen context 预警：prompt_tokens={prompt_tokens:,} "
+                f"(limit={CONTEXT_LIMIT:,}, 已用{prompt_tokens*100//CONTEXT_LIMIT}%)"
+            )
+
+        self._write_stats()
+
+    def record_error(self, status_code: int, error_msg: str = ""):
+        """记录一次错误响应。"""
+        self._check_day_reset()
+        self.total_requests += 1
+        self.total_errors += 1
+        self.consecutive_errors += 1
+        self.last_error_code = status_code
+        self.last_error_msg = error_msg[:200]
+        self.last_error_time = time.time()
+
+        # 连续错误告警
+        if self.consecutive_errors >= CONSECUTIVE_ERROR_ALERT:
+            self.alerts.append(
+                f"🔴 Proxy 连续 {self.consecutive_errors} 次错误！"
+                f"\n最近错误: HTTP {status_code} — {error_msg[:100]}"
+                f"\n可能原因: context 超限(260K) / 远端模型下线 / 网络故障"
+            )
+
+        self._write_stats()
+
+    def pop_alerts(self) -> list:
+        """取出并清空待发送告警。"""
+        alerts = self.alerts[:]
+        self.alerts = []
+        return alerts
+
+    def _write_stats(self):
+        """写入统计文件供 watchdog 读取。"""
+        try:
+            data = {
+                "updated": time.strftime("%Y-%m-%d %H:%M:%S"),
+                "total_requests": self.total_requests,
+                "total_errors": self.total_errors,
+                "consecutive_errors": self.consecutive_errors,
+                "last_prompt_tokens": self.last_prompt_tokens,
+                "last_total_tokens": self.last_total_tokens,
+                "max_prompt_tokens_today": self.max_prompt_tokens_today,
+                "context_limit": CONTEXT_LIMIT,
+                "context_usage_pct": round(self.last_prompt_tokens * 100 / CONTEXT_LIMIT, 1) if CONTEXT_LIMIT else 0,
+                "last_error": {
+                    "code": self.last_error_code,
+                    "msg": self.last_error_msg,
+                    "time": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.last_error_time)) if self.last_error_time else "",
+                },
+                "last_success_time": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.last_success_time)) if self.last_success_time else "",
+            }
+            with open(STATS_FILE, "w") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+        except OSError:
+            pass
+
+    def get_stats_dict(self) -> dict:
+        """返回当前统计数据（用于 /stats 端点）。"""
+        self._check_day_reset()
+        return {
+            "updated": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "total_requests": self.total_requests,
+            "total_errors": self.total_errors,
+            "consecutive_errors": self.consecutive_errors,
+            "last_prompt_tokens": self.last_prompt_tokens,
+            "last_total_tokens": self.last_total_tokens,
+            "max_prompt_tokens_today": self.max_prompt_tokens_today,
+            "context_limit": CONTEXT_LIMIT,
+            "context_usage_pct": round(self.last_prompt_tokens * 100 / CONTEXT_LIMIT, 1) if CONTEXT_LIMIT else 0,
+            "last_error_code": self.last_error_code,
+            "last_success_time": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.last_success_time)) if self.last_success_time else "",
+        }
+
+
+# 进程级单例
+proxy_stats = ProxyStats()

--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -2,14 +2,16 @@
 """
 tool_proxy.py — V27 HTTP 层
 策略逻辑已提取到 proxy_filters.py，本文件只负责 HTTP 收发和日志。
+V28: + token/error 监控（proxy_stats）
 """
-import http.server, socketserver, json, sys
+import http.server, socketserver, json, sys, subprocess, os
 from urllib.request import Request, urlopen
 
 from proxy_filters import (
     ALLOWED_TOOLS, ALLOWED_PREFIXES,
     is_allowed, filter_tools, truncate_messages,
     fix_tool_args, build_sse_response, should_strip_tools,
+    proxy_stats,
 )
 
 BACKEND = "http://127.0.0.1:5001"
@@ -19,11 +21,34 @@ def log(msg):
     print(f"[proxy] {msg}", flush=True)
 
 
+def _send_alert(msg):
+    """后台发送 WhatsApp 告警（不阻塞请求处理）。"""
+    try:
+        openclaw = os.environ.get("OPENCLAW", "/opt/homebrew/bin/openclaw")
+        phone = os.environ.get("OPENCLAW_PHONE", "+85200000000")
+        subprocess.Popen(
+            [openclaw, "message", "send", "--target", phone, "--message", msg, "--json"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        log(f"WARN: Failed to send alert: {msg[:80]}")
+
+
 class ProxyHandler(http.server.BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         log(fmt % args)
 
     def do_GET(self):
+        # /stats 端点：返回 proxy 监控数据
+        if self.path == "/stats":
+            stats = json.dumps(proxy_stats.get_stats_dict(), indent=2, ensure_ascii=False).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(stats)))
+            self.end_headers()
+            self.wfile.write(stats)
+            return
+
         url = f"{BACKEND}{self.path}"
         req = Request(url)
         try:
@@ -101,6 +126,21 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                             elif m.get("content"):
                                 log(f"TEXT: {len(str(m['content']))} chars")
 
+                        # Token 监控：记录 usage
+                        usage = rj.get("usage", {})
+                        if usage:
+                            pt = usage.get("prompt_tokens", 0)
+                            tt = usage.get("total_tokens", 0)
+                            log(f"TOKENS: prompt={pt:,} total={tt:,} ({pt*100//260000}% of 260K)")
+                            proxy_stats.record_success(usage)
+                        else:
+                            proxy_stats.record_success({})
+
+                        # 发送待处理告警
+                        for alert in proxy_stats.pop_alerts():
+                            log(f"ALERT: {alert}")
+                            _send_alert(alert)
+
                         if was_streaming:
                             sse_body = build_sse_response(rj)
                             self.send_response(200)
@@ -122,7 +162,17 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 self.wfile.write(resp_body)
         except Exception as e:
             log(f"Backend error: {e}")
-            err = json.dumps({"error": str(e)}).encode()
+            # 记录错误到监控
+            error_code = 502
+            error_str = str(e)
+            if "403" in error_str:
+                error_code = 403
+            proxy_stats.record_error(error_code, error_str)
+            for alert in proxy_stats.pop_alerts():
+                log(f"ALERT: {alert}")
+                _send_alert(alert)
+
+            err = json.dumps({"error": error_str}).encode()
             self.send_response(502)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(err)))


### PR DESCRIPTION
proxy_filters.py:
- 新增 ProxyStats 类：跟踪 prompt_tokens / 连续错误 / 每日峰值
- token 预警阈值: 75% (195K) 黄色, 90% (234K) 红色
- 连续 3 次错误自动 WhatsApp 告警
- 每次请求写入 ~/proxy_stats.json 供 watchdog 消费

tool_proxy.py:
- 响应中提取 usage.prompt_tokens 并记录到 stats
- 新增 /stats 端点: curl localhost:5002/stats
- 502/403 错误自动记录 + 告警触发
- 告警通过 subprocess 后台发送，不阻塞请求

job_watchdog.sh:
- 新增 proxy_stats.json 检查（连续错误 / context 用量 / 文件过期）

https://claude.ai/code/session_01RYFof4GNmHmptJePryAi7p