### PR TITLE
fix: deploy importyeti_scraper.py + add ArXiv User-Agent header

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -105,6 +105,7 @@ declare -a FILE_MAP=(
 
     # 货代 Watcher
     "jobs/freight_watcher/run_freight.sh|$HOME/.openclaw/jobs/freight_watcher/run_freight.sh"
+    "jobs/freight_watcher/importyeti_scraper.py|$HOME/.openclaw/jobs/freight_watcher/importyeti_scraper.py"
 
     # ArXiv 监控
     "jobs/arxiv_monitor/run_arxiv.sh|$HOME/.openclaw/jobs/arxiv_monitor/run_arxiv.sh"

--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -31,7 +31,7 @@ DAY="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d')"
 # ── 1. 抓取 ArXiv API XML ────────────────────────────────────────────────
 FEED_FILE="$CACHE/arxiv_feed.xml"
 # 去掉 -f：HTTP 错误不再触发 set -e 静默退出，改为手动检测
-if ! curl -sSL --max-time 30 "$ARXIV_URL" -o "$FEED_FILE" 2>"$CACHE/curl_feed.err"; then
+if ! curl -sSL --max-time 30 -H "User-Agent: openclaw-arxiv-monitor/1.0 (mailto:bisdom@example.com)" "$ARXIV_URL" -o "$FEED_FILE" 2>"$CACHE/curl_feed.err"; then
   log "ERROR: ArXiv API 抓取失败: $(head -1 "$CACHE/curl_feed.err" 2>/dev/null)"
   printf '{"time":"%s","status":"fetch_failed","new":0}\n' "$TS" > "$STATUS_FILE"
   exit 1


### PR DESCRIPTION
1. auto_deploy.sh: add importyeti_scraper.py to FILE_MAP so it gets deployed to ~/.openclaw/jobs/freight_watcher/ (fixes "No such file")
2. run_arxiv.sh: add User-Agent header to ArXiv API curl (fixes 429)

https://claude.ai/code/session_01RYFof4GNmHmptJePryAi7p