### PR TITLE
feat: V28 防护增强 — crontab 校验 + FILE_MAP 完整性检查

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -184,6 +184,28 @@ if [ "$MINUTE" -lt 2 ]; then
         DRIFT_MSG="⚠️ 漂移检测: 修复 ${DRIFT} 个部署文件不一致，已自动覆盖。详见 auto_deploy.log"
         openclaw message send --target "${OPENCLAW_PHONE:-+85200000000}" --message "$DRIFT_MSG" --json >/dev/null 2>&1 || true
     fi
+
+    # ── 3c. Crontab 引号完整性检查（每小时整点，与漂移检测同步）──────────
+    CRONTAB_ISSUES=""
+    while IFS= read -r cline; do
+        [ -z "$cline" ] && continue
+        echo "$cline" | grep -q '^#' && continue
+        if echo "$cline" | grep -q "bash -lc"; then
+            QUOTE_COUNT=$(echo "$cline" | tr -cd "'" | wc -c | tr -d ' ')
+            if [ $((QUOTE_COUNT % 2)) -ne 0 ]; then
+                CRONTAB_ISSUES="${CRONTAB_ISSUES}• 引号未闭合: ${cline:0:60}...\n"
+            fi
+        fi
+    done < <(crontab -l 2>/dev/null)
+
+    if [ -n "$CRONTAB_ISSUES" ]; then
+        echo "$(date) 🔴 crontab 语法异常:" >> "$LOG"
+        echo -e "$CRONTAB_ISSUES" >> "$LOG"
+        CRON_MSG="🔴 Crontab 语法异常（自动检测）：
+${CRONTAB_ISSUES}
+请立即检查: crontab -l"
+        openclaw message send --target "${OPENCLAW_PHONE:-+85200000000}" --message "$CRON_MSG" --json >/dev/null 2>&1 || true
+    fi
 fi
 
 # ── 4. 按需重启服务 ──────────────────────────────────────────────────

--- a/check_registry.py
+++ b/check_registry.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
-check_registry.py — V27 任务注册表校验器
+check_registry.py — V28 任务注册表校验器
 用法：python3 check_registry.py [path_to_yaml]
+      python3 check_registry.py --check-crontab   # 校验实际 crontab
 
 检查项：
   1. YAML 可解析
@@ -9,6 +10,8 @@ check_registry.py — V27 任务注册表校验器
   3. 所有 entry 路径存在（相对于仓库根目录）
   4. 启用任务有 scheduler / interval / log / description
   5. scheduler 值合法
+  6. [V28] --check-crontab: 对比实际 crontab 与 registry，发现缺失/引号错误
+  7. [V28] FILE_MAP 完整性：检查仓库中可部署文件是否全部在 auto_deploy.sh 的 FILE_MAP 中
 """
 import os
 import sys
@@ -121,8 +124,155 @@ def validate(path):
     return errors, warnings
 
 
+def check_crontab(registry_path):
+    """V28: 对比实际 crontab 与 registry，检查缺失条目和语法错误。"""
+    import subprocess
+    errors = []
+    warnings = []
+
+    # 读取实际 crontab
+    try:
+        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True, timeout=5)
+        crontab_lines = result.stdout.strip().split("\n") if result.stdout.strip() else []
+    except Exception as e:
+        errors.append(f"无法读取 crontab: {e}")
+        return errors, warnings
+
+    # 读取 registry
+    try:
+        data = load_yaml(registry_path)
+    except Exception as e:
+        errors.append(f"YAML parse error: {e}")
+        return errors, warnings
+
+    active_lines = [l.strip() for l in crontab_lines if l.strip() and not l.strip().startswith("#")]
+
+    # 检查1: 引号配对（所有 bash -lc 行必须有闭合单引号）
+    for i, line in enumerate(active_lines):
+        if "bash -lc" in line:
+            # 提取 bash -lc 后面的部分
+            after_lc = line.split("bash -lc", 1)[1]
+            single_quotes = after_lc.count("'")
+            if single_quotes % 2 != 0:
+                errors.append(f"crontab 第{i+1}行: 单引号未闭合 — {line[:80]}...")
+
+    # 检查2: registry 中 enabled=true 且 scheduler=system 的任务在 crontab 中有对应条目
+    crontab_text = "\n".join(active_lines)
+    for job in data.get("jobs", []):
+        if not job.get("enabled") or job.get("scheduler") != "system":
+            continue
+        jid = job.get("id", "?")
+        entry = job.get("entry", "")
+
+        # 用脚本文件名作为匹配关键字
+        script_name = os.path.basename(entry) if entry else ""
+        if script_name and script_name not in crontab_text:
+            # 也检查完整路径
+            if entry not in crontab_text:
+                warnings.append(f"[{jid}] registry 已启用但 crontab 中未找到 '{script_name}'")
+
+    # 检查3: 重复条目检测
+    seen_scripts = {}
+    for line in active_lines:
+        # 提取脚本名
+        for part in line.split():
+            if part.endswith(".sh") or part.endswith(".py"):
+                base = os.path.basename(part)
+                if base in seen_scripts:
+                    warnings.append(f"crontab 疑似重复: '{base}' 出现在多个条目中")
+                seen_scripts[base] = seen_scripts.get(base, 0) + 1
+                break
+
+    return errors, warnings
+
+
+def check_filemap_completeness(registry_path):
+    """V28: 检查仓库中可部署的脚本是否全部在 auto_deploy.sh FILE_MAP 中。"""
+    import re
+    errors = []
+    warnings = []
+    repo_root = os.path.dirname(os.path.abspath(registry_path))
+
+    # 读取 auto_deploy.sh 中的 FILE_MAP
+    deploy_script = os.path.join(repo_root, "auto_deploy.sh")
+    if not os.path.exists(deploy_script):
+        warnings.append("auto_deploy.sh 不存在，跳过 FILE_MAP 检查")
+        return errors, warnings
+
+    with open(deploy_script) as f:
+        deploy_content = f.read()
+
+    # 提取 FILE_MAP 中的源文件路径
+    mapped_sources = set()
+    for match in re.finditer(r'"([^"|]+)\|', deploy_content):
+        mapped_sources.add(match.group(1))
+
+    # 读取 registry 中所有 entry
+    try:
+        data = load_yaml(registry_path)
+    except Exception:
+        return errors, warnings
+
+    for job in data.get("jobs", []):
+        if not job.get("enabled"):
+            continue
+        entry = job.get("entry", "")
+        jid = job.get("id", "?")
+        if not entry:
+            continue
+
+        entry_path = os.path.join(repo_root, entry)
+        if os.path.exists(entry_path) and entry not in mapped_sources:
+            warnings.append(f"[{jid}] '{entry}' 存在于仓库但不在 auto_deploy FILE_MAP 中（不会自动部署）")
+
+        # 检查 jobs/ 子目录下的关联文件（只检查子目录，跳过仓库根目录的开发工具）
+        entry_dir = os.path.dirname(entry_path)
+        entry_rel_dir = os.path.dirname(entry)
+        if entry_rel_dir and entry_rel_dir != "." and os.path.isdir(entry_dir):
+            for fname in os.listdir(entry_dir):
+                rel_path = os.path.join(entry_rel_dir, fname)
+                full_path = os.path.join(entry_dir, fname)
+                if os.path.isfile(full_path) and rel_path not in mapped_sources:
+                    if fname.endswith((".py", ".sh")) and not fname.startswith("."):
+                        warnings.append(f"[{jid}] '{rel_path}' 未在 FILE_MAP 中（不会自动部署）")
+
+    return errors, warnings
+
+
 def main():
     path = sys.argv[1] if len(sys.argv) > 1 else "jobs_registry.yaml"
+
+    # V28: --check-crontab 模式
+    if "--check-crontab" in sys.argv:
+        if not os.path.exists(path):
+            path = "jobs_registry.yaml"
+        print("=== Crontab 校验 ===")
+        errors, warnings = check_crontab(path)
+        for w in warnings:
+            print(f"  WARN: {w}")
+        for e in errors:
+            print(f"  ERROR: {e}")
+        if not errors and not warnings:
+            print("  OK: crontab 与 registry 一致")
+
+        print("\n=== FILE_MAP 完整性 ===")
+        e2, w2 = check_filemap_completeness(path)
+        for w in w2:
+            print(f"  WARN: {w}")
+        for e in e2:
+            print(f"  ERROR: {e}")
+        if not e2 and not w2:
+            print("  OK: 所有可部署文件已在 FILE_MAP 中")
+
+        total_errors = len(errors) + len(e2)
+        if total_errors:
+            print(f"\nFAILED: {total_errors} error(s)")
+            sys.exit(1)
+        else:
+            print(f"\nOK: crontab + FILE_MAP 检查通过")
+            sys.exit(0)
+
+    # 原有 registry 校验逻辑
     if not os.path.exists(path):
         print(f"ERROR: {path} not found")
         sys.exit(1)


### PR DESCRIPTION
堵住三个导致今日故障的结构性盲区：

1. check_registry.py --check-crontab:
   - 检查 bash -lc 引号闭合（今日根因）
   - 对比 registry enabled 条目与实际 crontab
   - 检测重复 crontab 条目

2. check_registry.py FILE_MAP 完整性:
   - 检查 jobs/ 子目录中可部署文件是否在 auto_deploy FILE_MAP 中
   - 防止 importyeti_scraper.py 类文件遗漏

3. auto_deploy.sh 3c 步骤:
   - 每小时整点自动检查 crontab 引号完整性
   - 发现异常立即 WhatsApp 告警

https://claude.ai/code/session_01RYFof4GNmHmptJePryAi7p