### PR TITLE
fix: YAML parser strip inline comments (false # comment → false)

### DIFF
--- a/check_registry.py
+++ b/check_registry.py
@@ -45,7 +45,11 @@ except ImportError:
             elif current and ":" in stripped:
                 key, val = stripped.split(":", 1)
                 key = key.strip()
-                val = val.strip().strip('"').strip("'")
+                val = val.strip()
+                # 移除行内注释（# 后面的内容）
+                if "#" in val:
+                    val = val[:val.index("#")].strip()
+                val = val.strip('"').strip("'")
                 if val.lower() == "true":
                     val = True
                 elif val.lower() == "false":


### PR DESCRIPTION
The minimal YAML parser didn't strip inline comments, causing "enabled: false  # V28: merged" to not match as boolean false.

https://claude.ai/code/session_01RYFof4GNmHmptJePryAi7p