### PR TITLE
feat: V28 五项改进 — 校验器单测、原则精简、文档自动生成、smoke test、开发流程

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — openclaw-model-bridge 项目背景
 
-> 每次新会话开始时自动读取。当前版本：v27.1（2026-03-10）
+> 每次新会话开始时自动读取。当前版本：v28（2026-03-11）
 
 ---
 
@@ -40,6 +40,9 @@ WhatsApp <-> OpenClaw Gateway (18789) <-> Tool Proxy (5002) <-> Adapter (5001) <
 | `kb_save_arxiv.sh` | ArXiv监控结果写入KB + rsync备份 |
 | `auto_deploy.sh` | **V27.1新增** 仓库→部署自动同步 + 漂移检测（md5全量比对+WhatsApp告警） |
 | `test_tool_proxy.py` | proxy_filters 单测（43个用例） |
+| `test_check_registry.py` | **V28新增** check_registry.py 单测（18个用例） |
+| `gen_jobs_doc.py` | **V28新增** 从 registry 自动生成任务文档 + 漂移检测 |
+| `smoke_test.sh` | **V28新增** 端到端 smoke test（单测+注册表+连通性） |
 | `docs/config.md` | 完整系统配置文档（含所有历史变更） |
 | `docs/GUIDE.md` | 完整中英文集成指南 |
 
@@ -61,6 +64,14 @@ WhatsApp <-> OpenClaw Gateway (18789) <-> Tool Proxy (5002) <-> Adapter (5001) <
 6. **漂移检测**：`auto_deploy.sh` 新增每小时全量 md5 比对 + WhatsApp 告警
 7. **每日文档刷新宪法**：CLAUDE.md 和 config.md 在"开始/结束今天的工作"时强制 read+write
 
+## V28 变更摘要（2026-03-11）
+
+1. **check_registry.py 单测**：`test_check_registry.py` 新增 18 个用例，覆盖 YAML 解析（含 inline comment、boolean、空文件）、validate()、FILE_MAP 完整性检查
+2. **原则精简分级**：34 条工作原则 → 5 条"每次必查" + 13 条"按需查阅"（折叠），降低认知负担
+3. **文档自动生成**：`gen_jobs_doc.py` 从 `jobs_registry.yaml` 自动生成任务表格 + `--check` 漂移检测模式
+4. **端到端 smoke test**：`smoke_test.sh` 一键验证单测 + 注册表 + 文档漂移 + 5002/5001 连通性
+5. **开发流程明确化**：Claude Code 只推 `claude/` 分支，Mac Mini 只从 main 拉取，写入 CLAUDE.md 原则
+
 ## 常用命令
 
 ```bash
@@ -76,9 +87,17 @@ bash ~/restart.sh
 
 # 运行单测
 python3 test_tool_proxy.py
+python3 test_check_registry.py
 
 # 校验任务注册表
 python3 check_registry.py
+
+# 一键 smoke test（单测+注册表+连通性）
+bash smoke_test.sh
+
+# 生成任务文档 / 检测文档漂移
+python3 gen_jobs_doc.py           # 输出 markdown 表格
+python3 gen_jobs_doc.py --check   # 对比 docs/config.md 检测漂移
 
 # 查询远端当前模型ID
 curl -s https://hkagentx.hkopenlab.com/v1/models \
@@ -120,29 +139,41 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 - 配置文档（含真实手机号/密钥）永不入库（已在 .gitignore）
 - 公开仓库手机号统一用 `+85200000000` 占位
 
-## 工作原则（精简版）
+## 工作原则
 
-### 🔴 宪法级（每日必做，无例外）
-0. **每日文档刷新** — `CLAUDE.md` + `docs/config.md` 在"开始今天的工作"和"结束今天的工作"时强制 read → 同步当日变更 → write。其他文档按需刷新。**此为工作宪法，每日必做。**
-1. **每次开始先读 `docs/config.md`** — 获取完整系统状态和历史踩坑
-2. **收工全量同步** — 用户说"今天工作结束"时，扫描全部文档（CLAUDE.md、docs/*.md、README.md等），同步当日变更，确保信息一致 → 安全扫描 → 提交推送
+### 🔴 每次必查（5条，优先级最高）
 
-### 🟡 操作原则
-3. **测试先于注册** — 新脚本必须手动验证后才能注册cron
-4. **任务先登记** — 新增定时任务必须先写入 `jobs_registry.yaml` 并校验通过
-5. **根因定位** — 多任务同时失败 → 第一反应检查远端模型ID
-6. **push前必扫描** — 见上方安全扫描命令
-7. **macOS sed禁用OR语法** — 用Python替代（`\|` 在BSD sed不支持）
-8. **回滚优先** — 线上故障 → 先 `git checkout v26-snapshot` 恢复，再排查
-9. **纯推理绕过Gateway** — 不需要工具的LLM任务直接curl调API，禁止用`openclaw agent`（会注入工具导致循环调用，#94）
-10. **禁用交互式编辑器** — 禁止触发 vim/nano 等交互式编辑器。git merge 用 `--no-edit`，commit 用 `-m`，rebase 禁用 `-i`。crontab 禁用 `crontab -e`，改用管道 `(crontab -l; echo '新行') | crontab -`。
-11. **分支合并由用户在GitHub操作** — 开发完成后推送到 `claude/xxx` 分支，**必须提醒用户去 GitHub 创建 PR 合并到 main**，用户在 Mac Mini 用 `git pull origin main --no-rebase --no-edit` 拉取。禁止在终端执行本地 merge。
+| # | 原则 | 一句话 |
+|---|------|--------|
+| 1 | **开工先读 config** | 读 `docs/config.md` 获取系统状态 + 踩坑记录，避免重复犯错 |
+| 2 | **改完先测** | 新脚本手动验证 → 新任务先写 `jobs_registry.yaml` 并 `python3 check_registry.py` 通过 → 才能注册 cron |
+| 3 | **push前必扫描** | 安全扫描（见上方命令）全部为空才允许 push |
+| 4 | **故障先回滚** | 线上故障 → `git checkout v26-snapshot` 恢复服务 → 再排查根因；多任务同时挂 → 先查远端模型ID |
+| 5 | **做减法不做加法** | 新增防护/监控前先问"谁已经在管这件事"；每加一层保险 = 多一个故障源（#95教训） |
 
-### 🟢 架构原则
-12. **进程管理单一主控** — 每个进程只能有一个生命周期管理者。Gateway 由 launchd (KeepAlive=true) 管理，禁止再加 cron watchdog 或其他自愈机制。双主控制必然导致互相干扰（#95教训）。
-13. **cron 脚本显式声明 PATH** — 所有 cron 调用的脚本首行必须 `export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"`。cron 环境与用户 shell 环境完全不同，禁止假设 PATH 已正确设置。
-14. **健康检查只检目标组件** — 健康检查应只检查目标组件本身（如 `curl localhost:18789`），不应走完整 LLM 链路。链路中任何一环超时都会误判为目标组件故障。
-15. **AI 生成的"保险机制"需审查** — AI 倾向于叠加防护层（watchdog、自愈、重试），但每加一层都可能与现有机制冲突。新增任何自愈/监控脚本前，必须先确认"谁已经在管这件事"。
+### 🟡 按需查阅（操作 & 架构参考）
+
+<details>
+<summary>展开查看完整原则列表（13条）</summary>
+
+**操作类**
+- **收工全量同步** — "今天工作结束" → 扫描全部文档同步当日变更 → 安全扫描 → 提交推送
+- **每日文档刷新** — `CLAUDE.md` + `docs/config.md` 在开工/收工时强制 read → write
+- **纯推理绕过Gateway** — 不需要工具的LLM任务直接 curl 调 API，禁止用 `openclaw agent`（#94）
+- **macOS sed禁用OR语法** — `\|` 在 BSD sed 不支持，用 Python 替代
+- **禁用交互式编辑器** — git merge 用 `--no-edit`，commit 用 `-m`，crontab 用管道
+- **分支合并由用户在GitHub操作** — 推送到 `claude/xxx` 分支 → 提醒用户创建 PR → 用户 `git pull origin main`
+
+**架构类**
+- **进程管理单一主控** — Gateway 由 launchd 管理，禁止再加 cron watchdog（#95）
+- **cron 脚本显式声明 PATH** — 首行 `export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"`
+- **健康检查只检目标组件** — `curl localhost:18789`，不走完整 LLM 链路
+- **`--thinking` 参数** — 合法值：`off, minimal, low, medium, high, adaptive`（禁止 `none`，#92）
+- **工具数量 <= 12** — 超出导致模型混乱；每任务工具调用 <= 2次
+- **双 cron 职责分工** — 确定性脚本用 system crontab；需 LLM 参与的用 openclaw cron
+- **开发流程** — Claude Code 只推 `claude/` 分支，Mac Mini 只从 main 拉取，避免双向提交同一分支
+
+</details>
 
 ## 当前待办（v27遗留）
 

--- a/gen_jobs_doc.py
+++ b/gen_jobs_doc.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+gen_jobs_doc.py — 从 jobs_registry.yaml 自动生成定时任务文档片段
+用法：python3 gen_jobs_doc.py [--check]
+  默认模式：输出 markdown 表格到 stdout
+  --check：对比 docs/config.md 中的任务表格，检测漂移（不修改文件）
+"""
+import os
+import sys
+
+# Reuse the existing YAML loader from check_registry
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from check_registry import load_yaml
+
+
+def generate_table(registry_path="jobs_registry.yaml"):
+    """Generate a markdown table from jobs_registry.yaml."""
+    data = load_yaml(registry_path)
+    if not data:
+        return "ERROR: 无法解析 jobs_registry.yaml"
+
+    jobs = data.get("jobs", [])
+    if not jobs:
+        return "ERROR: 注册表中无任务"
+
+    lines = []
+    lines.append("| ID | 调度器 | 触发时间 | 脚本 | 状态 | 说明 |")
+    lines.append("|------|--------|----------|------|------|------|")
+
+    for j in jobs:
+        jid = j.get("id", "?")
+        scheduler = j.get("scheduler", "?")
+        interval = j.get("interval", "-")
+        entry = j.get("entry", "-")
+        enabled = j.get("enabled", False)
+        desc = j.get("description", "-")
+
+        status = "✅" if enabled else "❌ 已废弃"
+        lines.append(f"| {jid} | {scheduler} | `{interval}` | `{entry}` | {status} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def check_drift(registry_path="jobs_registry.yaml", config_path="docs/config.md"):
+    """Check if docs/config.md job list is out of sync with registry."""
+    if not os.path.exists(config_path):
+        print(f"WARN: {config_path} 不存在，跳过漂移检测")
+        return 0
+
+    data = load_yaml(registry_path)
+    if not data:
+        print("ERROR: 无法解析 jobs_registry.yaml")
+        return 1
+
+    with open(config_path) as f:
+        config_content = f.read()
+
+    jobs = data.get("jobs", [])
+    drift_count = 0
+
+    for j in jobs:
+        jid = j.get("id", "")
+        entry = j.get("entry", "")
+        enabled = j.get("enabled", False)
+        script_name = os.path.basename(entry) if entry else ""
+
+        # Check if enabled jobs are mentioned in config
+        if enabled and script_name and script_name not in config_content:
+            print(f"  DRIFT: [{jid}] 脚本 '{script_name}' 在 registry 中已启用但 config.md 未提及")
+            drift_count += 1
+
+        # Check if disabled jobs are still marked as active in config
+        if not enabled and jid and f"| {jid}" in config_content:
+            # Look for the job being marked active (✅) in config when it's disabled
+            import re
+            pattern = rf"\|\s*{re.escape(jid)}.*?✅"
+            if re.search(pattern, config_content):
+                print(f"  DRIFT: [{jid}] 在 registry 中已废弃但 config.md 仍标记为 ✅")
+                drift_count += 1
+
+    if drift_count == 0:
+        print("OK: 注册表与 config.md 任务列表一致")
+    else:
+        print(f"\nDRIFT: 发现 {drift_count} 处不一致")
+
+    return drift_count
+
+
+def main():
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    registry_path = os.path.join(repo_root, "jobs_registry.yaml")
+
+    if "--check" in sys.argv:
+        config_path = os.path.join(repo_root, "docs", "config.md")
+        drift = check_drift(registry_path, config_path)
+        sys.exit(1 if drift > 0 else 0)
+    else:
+        print(generate_table(registry_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# smoke_test.sh — 端到端连通性 smoke test（不走完整 LLM 推理）
+# 用法：bash smoke_test.sh
+# 检查 5002→5001→远程GPU 链路通畅，以及本地单测
+# 遵循原则：健康检查只检目标组件，不走完整 LLM 链路
+set -euo pipefail
+
+PASS=0
+FAIL=0
+WARN=0
+
+check() {
+    local name="$1"
+    local result="$2"
+    local expected="${3:-0}"
+    if [ "$result" -eq "$expected" ]; then
+        echo "  ✅ $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  ❌ $name (exit=$result)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+warn() {
+    local name="$1"
+    local msg="$2"
+    echo "  ⚠️  $name: $msg"
+    WARN=$((WARN + 1))
+}
+
+echo "=== OpenClaw Smoke Test ==="
+echo ""
+
+# --- 1. 本地单测 ---
+echo "📋 1/5 单测"
+python3 test_tool_proxy.py > /dev/null 2>&1 && RC=0 || RC=$?
+check "proxy_filters 单测 (test_tool_proxy.py)" $RC
+
+python3 test_check_registry.py > /dev/null 2>&1 && RC=0 || RC=$?
+check "registry 校验器单测 (test_check_registry.py)" $RC
+
+# --- 2. 注册表校验 ---
+echo ""
+echo "📋 2/5 注册表校验"
+python3 check_registry.py > /dev/null 2>&1 && RC=0 || RC=$?
+check "jobs_registry.yaml 校验" $RC
+
+# --- 3. 文档漂移检测 ---
+echo ""
+echo "📋 3/5 文档漂移检测"
+python3 gen_jobs_doc.py --check > /dev/null 2>&1 && RC=0 || RC=$?
+if [ $RC -ne 0 ]; then
+    warn "文档漂移检测" "docs/config.md 与 registry 存在不一致（运行 python3 gen_jobs_doc.py --check 查看详情）"
+else
+    check "文档漂移检测" $RC
+fi
+
+# --- 4. Tool Proxy 连通性 ---
+echo ""
+echo "📋 4/5 Tool Proxy 健康检查 (localhost:5002)"
+HEALTH_RESP=$(curl -s --max-time 5 http://localhost:5002/health 2>/dev/null) && RC=0 || RC=$?
+if [ $RC -ne 0 ]; then
+    warn "Proxy 5002" "无法连接（服务未启动或不在本机运行）"
+else
+    check "Proxy 5002 /health 端点" $RC
+    # 检查响应中是否包含 OK 或 status
+    if echo "$HEALTH_RESP" | grep -qi "ok\|status\|healthy" > /dev/null 2>&1; then
+        check "Proxy 5002 健康响应" 0
+    else
+        warn "Proxy 5002" "响应内容异常: ${HEALTH_RESP:0:100}"
+    fi
+fi
+
+# --- 5. Adapter 连通性 ---
+echo ""
+echo "📋 5/5 Adapter 健康检查 (localhost:5001)"
+curl -s --max-time 5 http://localhost:5001/v1/models > /dev/null 2>&1 && RC=0 || RC=$?
+if [ $RC -ne 0 ]; then
+    warn "Adapter 5001" "无法连接（服务未启动或不在本机运行）"
+else
+    check "Adapter 5001 连通性" $RC
+fi
+
+# --- 汇总 ---
+echo ""
+echo "=== 结果汇总 ==="
+echo "  通过: $PASS | 失败: $FAIL | 警告: $WARN"
+
+if [ $FAIL -gt 0 ]; then
+    echo ""
+    echo "❌ FAILED: $FAIL 项检查未通过"
+    exit 1
+elif [ $WARN -gt 0 ]; then
+    echo ""
+    echo "⚠️  WARN: 全部通过但有 $WARN 条警告（网络检查需在 Mac Mini 上运行）"
+    exit 0
+else
+    echo ""
+    echo "✅ ALL PASSED"
+    exit 0
+fi

--- a/test_check_registry.py
+++ b/test_check_registry.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Unit tests for check_registry.py — V28 校验器单测
+Run: python3 -m pytest test_check_registry.py -v
+  or: python3 test_check_registry.py
+"""
+import json
+import os
+import tempfile
+import textwrap
+import unittest
+
+from check_registry import validate, load_yaml, check_filemap_completeness
+
+
+# ---------------------------------------------------------------------------
+# Helper: write temp YAML for testing
+# ---------------------------------------------------------------------------
+
+def write_temp_yaml(content, tmpdir=None):
+    """Write content to a temp .yaml file, return its path."""
+    fd, path = tempfile.mkstemp(suffix=".yaml", dir=tmpdir)
+    with os.fdopen(fd, "w") as f:
+        f.write(content)
+    return path
+
+
+VALID_YAML = textwrap.dedent("""\
+    version: 1
+    jobs:
+      - id: test_job_1
+        scheduler: system
+        entry: test_check_registry.py
+        interval: "0 * * * *"
+        log: ~/test.log
+        needs_api_key: false
+        enabled: true
+        description: A test job
+      - id: test_job_2
+        scheduler: openclaw
+        entry: proxy_filters.py
+        interval: "0 8 * * *"
+        log: ~/test2.log
+        needs_api_key: false
+        enabled: false
+        description: Disabled test job
+""")
+
+
+# ---------------------------------------------------------------------------
+# load_yaml tests
+# ---------------------------------------------------------------------------
+
+class TestLoadYaml(unittest.TestCase):
+
+    def test_basic_parse(self):
+        path = write_temp_yaml(VALID_YAML)
+        try:
+            data = load_yaml(path)
+            self.assertEqual(data["version"], 1)
+            self.assertEqual(len(data["jobs"]), 2)
+            self.assertEqual(data["jobs"][0]["id"], "test_job_1")
+            self.assertEqual(data["jobs"][1]["id"], "test_job_2")
+        finally:
+            os.unlink(path)
+
+    def test_boolean_parsing(self):
+        """enabled: false should parse as Python False, not string 'false'."""
+        path = write_temp_yaml(VALID_YAML)
+        try:
+            data = load_yaml(path)
+            self.assertIs(data["jobs"][0]["enabled"], True)
+            self.assertIs(data["jobs"][1]["enabled"], False)
+        finally:
+            os.unlink(path)
+
+    def test_inline_comment_stripped(self):
+        """Inline comments like 'false  # reason' should be stripped."""
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: commented_job
+                scheduler: system
+                entry: test_check_registry.py
+                enabled: false  # disabled for now
+                description: test
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            data = load_yaml(path)
+            self.assertIs(data["jobs"][0]["enabled"], False)
+        finally:
+            os.unlink(path)
+
+    def test_quoted_value_with_hash(self):
+        """Values like interval: '0 9 * * 1' should not be broken by # stripping."""
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: quoted_job
+                scheduler: system
+                entry: test_check_registry.py
+                interval: "0 9 * * 1"
+                enabled: true
+                description: "a job # with hash in desc"
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            data = load_yaml(path)
+            self.assertEqual(data["jobs"][0]["interval"], "0 9 * * 1")
+        finally:
+            os.unlink(path)
+
+    def test_empty_file(self):
+        """Empty/comment-only YAML returns None (PyYAML) or empty dict."""
+        path = write_temp_yaml("# only comments\n")
+        try:
+            data = load_yaml(path)
+            # PyYAML safe_load returns None for empty files; validate() handles this
+            if data is None:
+                data = {}
+            self.assertEqual(data.get("jobs", []), [])
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# validate() tests
+# ---------------------------------------------------------------------------
+
+class TestValidate(unittest.TestCase):
+
+    def test_valid_registry_no_errors(self):
+        """A well-formed registry should produce zero errors."""
+        path = write_temp_yaml(VALID_YAML)
+        try:
+            errors, warnings = validate(path)
+            self.assertEqual(errors, [], f"Unexpected errors: {errors}")
+        finally:
+            os.unlink(path)
+
+    def test_duplicate_id_detected(self):
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: dup_job
+                scheduler: system
+                entry: test_check_registry.py
+                enabled: false
+              - id: dup_job
+                scheduler: system
+                entry: proxy_filters.py
+                enabled: false
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            errors, _ = validate(path)
+            dup_errors = [e for e in errors if "Duplicate" in e]
+            self.assertTrue(len(dup_errors) >= 1, f"Expected duplicate error, got: {errors}")
+        finally:
+            os.unlink(path)
+
+    def test_missing_required_field(self):
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: incomplete_job
+                scheduler: system
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            errors, _ = validate(path)
+            missing_errors = [e for e in errors if "missing field" in e]
+            self.assertTrue(len(missing_errors) >= 1, f"Expected missing field error, got: {errors}")
+        finally:
+            os.unlink(path)
+
+    def test_invalid_scheduler(self):
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: bad_sched
+                scheduler: kubernetes
+                entry: test_check_registry.py
+                enabled: false
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            errors, _ = validate(path)
+            sched_errors = [e for e in errors if "invalid scheduler" in e]
+            self.assertTrue(len(sched_errors) >= 1)
+        finally:
+            os.unlink(path)
+
+    def test_nonexistent_entry_warns(self):
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: ghost_job
+                scheduler: system
+                entry: this_file_does_not_exist.sh
+                enabled: true
+                log: ~/ghost.log
+                description: ghost
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            _, warnings = validate(path)
+            entry_warnings = [w for w in warnings if "entry not found" in w]
+            self.assertTrue(len(entry_warnings) >= 1)
+        finally:
+            os.unlink(path)
+
+    def test_enabled_without_log_warns(self):
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: no_log_job
+                scheduler: system
+                entry: test_check_registry.py
+                enabled: true
+                description: has desc but no log
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            _, warnings = validate(path)
+            log_warnings = [w for w in warnings if "missing: log" in w]
+            self.assertTrue(len(log_warnings) >= 1)
+        finally:
+            os.unlink(path)
+
+    def test_enabled_without_description_warns(self):
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: no_desc_job
+                scheduler: system
+                entry: test_check_registry.py
+                enabled: true
+                log: ~/test.log
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            _, warnings = validate(path)
+            desc_warnings = [w for w in warnings if "missing: description" in w]
+            self.assertTrue(len(desc_warnings) >= 1)
+        finally:
+            os.unlink(path)
+
+    def test_system_enabled_without_interval_warns(self):
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: no_interval
+                scheduler: system
+                entry: test_check_registry.py
+                enabled: true
+                log: ~/test.log
+                description: no interval
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            _, warnings = validate(path)
+            interval_warnings = [w for w in warnings if "without interval" in w]
+            self.assertTrue(len(interval_warnings) >= 1)
+        finally:
+            os.unlink(path)
+
+    def test_no_jobs_is_error(self):
+        yaml_content = "version: 1\njobs:\n"
+        path = write_temp_yaml(yaml_content)
+        try:
+            errors, _ = validate(path)
+            self.assertTrue(any("No jobs" in e for e in errors))
+        finally:
+            os.unlink(path)
+
+    def test_unparseable_file(self):
+        path = write_temp_yaml("{{{{invalid yaml!!!!!")
+        try:
+            errors, _ = validate(path)
+            self.assertTrue(any("parse error" in e.lower() or "No jobs" in e for e in errors))
+        finally:
+            os.unlink(path)
+
+    def test_disabled_job_skips_extra_checks(self):
+        """Disabled jobs should not trigger 'missing log/description' warnings."""
+        yaml_content = textwrap.dedent("""\
+            version: 1
+            jobs:
+              - id: disabled_bare
+                scheduler: system
+                entry: test_check_registry.py
+                enabled: false
+        """)
+        path = write_temp_yaml(yaml_content)
+        try:
+            errors, warnings = validate(path)
+            self.assertEqual(errors, [])
+            log_warns = [w for w in warnings if "missing: log" in w or "missing: description" in w]
+            self.assertEqual(log_warns, [], f"Disabled job should not warn: {log_warns}")
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# check_filemap_completeness() tests
+# ---------------------------------------------------------------------------
+
+class TestFileMapCompleteness(unittest.TestCase):
+
+    def test_missing_auto_deploy_skips(self):
+        """If auto_deploy.sh doesn't exist, should return warning and skip."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_content = textwrap.dedent("""\
+                version: 1
+                jobs:
+                  - id: test_job
+                    scheduler: system
+                    entry: test.sh
+                    enabled: true
+            """)
+            path = os.path.join(tmpdir, "jobs_registry.yaml")
+            with open(path, "w") as f:
+                f.write(yaml_content)
+            errors, warnings = check_filemap_completeness(path)
+            self.assertTrue(any("auto_deploy.sh" in w for w in warnings))
+
+
+# ---------------------------------------------------------------------------
+# Integration: validate the actual jobs_registry.yaml
+# ---------------------------------------------------------------------------
+
+class TestRealRegistry(unittest.TestCase):
+    """Validate the actual project registry file."""
+
+    def test_actual_registry_no_errors(self):
+        real_path = os.path.join(os.path.dirname(__file__), "jobs_registry.yaml")
+        if not os.path.exists(real_path):
+            self.skipTest("jobs_registry.yaml not found")
+        errors, warnings = validate(real_path)
+        self.assertEqual(errors, [], f"Real registry has errors: {errors}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
1. test_check_registry.py: 18个用例覆盖 YAML 解析、validate()、FILE_MAP 检查
2. CLAUDE.md 原则精简: 34条 → 5条"每次必查" + 13条折叠"按需查阅"
3. gen_jobs_doc.py: 从 registry 自动生成任务表格 + --check 漂移检测
4. smoke_test.sh: 一键验证单测+注册表+文档漂移+端口连通性
5. 开发流程明确化写入原则: Claude Code 只推 claude/ 分支

https://claude.ai/code/session_01RYFof4GNmHmptJePryAi7p