### PR TITLE
feat: WhatsApp session 保活 — 每30分钟 dry-run 探测防止断连

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ WhatsApp <-> OpenClaw Gateway (18789) <-> Tool Proxy (5002) <-> Adapter (5001) <
 | `test_check_registry.py` | **V28新增** check_registry.py 单测（18个用例） |
 | `gen_jobs_doc.py` | **V28新增** 从 registry 自动生成任务文档 + 漂移检测 |
 | `smoke_test.sh` | **V28新增** 端到端 smoke test（单测+注册表+连通性） |
+| `wa_keepalive.sh` | **V28新增** WhatsApp session 保活（每30分钟 dry-run 探测） |
 | `docs/config.md` | 完整系统配置文档（含所有历史变更） |
 | `docs/GUIDE.md` | 完整中英文集成指南 |
 
@@ -71,6 +72,9 @@ WhatsApp <-> OpenClaw Gateway (18789) <-> Tool Proxy (5002) <-> Adapter (5001) <
 3. **文档自动生成**：`gen_jobs_doc.py` 从 `jobs_registry.yaml` 自动生成任务表格 + `--check` 漂移检测模式
 4. **端到端 smoke test**：`smoke_test.sh` 一键验证单测 + 注册表 + 文档漂移 + 5002/5001 连通性
 5. **开发流程明确化**：Claude Code 只推 `claude/` 分支，Mac Mini 只从 main 拉取，写入 CLAUDE.md 原则
+6. **WhatsApp CLI 语法修复**：3个脚本从废弃的 `--channel whatsapp -t -m` 改为 `--target --message --json`
+7. **stderr 可观测性**：8个 job 脚本从 `2>&1` 改为 `2>"$SEND_ERR"`，失败时记录具体错误
+8. **WhatsApp session 保活**：`wa_keepalive.sh` 每30分钟 dry-run 探测，防止手机休眠导致 session 断连
 
 ## 常用命令
 

--- a/jobs_registry.yaml
+++ b/jobs_registry.yaml
@@ -119,3 +119,12 @@ jobs:
     needs_api_key: false
     enabled: true
     description: 社区 Issues 监控（每小时轮询 GitHub REST API，Discussions 已禁用）
+
+  - id: wa_keepalive
+    scheduler: system
+    entry: wa_keepalive.sh
+    interval: "*/30 * * * *"        # 每30分钟
+    log: ~/wa_keepalive.log
+    needs_api_key: false
+    enabled: true
+    description: WhatsApp session 保活（dry-run 探测，防止手机休眠导致断连）

--- a/wa_keepalive.sh
+++ b/wa_keepalive.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# wa_keepalive.sh — WhatsApp session 保活（每30分钟由 crontab 触发）
+# 目的：防止 WhatsApp Web session 因手机休眠/网络不活跃而断连
+# 原理：向 Gateway 发一个轻量 HTTP 请求，触发 session 保活
+# 遵循原则 #33：只检目标组件（Gateway），不走 LLM 链路
+# 遵循原则 #31：不重启任何进程，只做连接探测
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+
+GATEWAY_URL="http://localhost:18789"
+LOG="$HOME/wa_keepalive.log"
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+
+# 1. 检查 Gateway 端口是否存活（不走 LLM 链路）
+HTTP_CODE=$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' "$GATEWAY_URL" 2>/dev/null)
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 400 ]; then
+    echo "[$TS] WARN: Gateway 不可达 (HTTP $HTTP_CODE)，跳过 keepalive" >> "$LOG"
+    exit 0  # 不报错，Gateway 由 launchd 管理
+fi
+
+# 2. 发送一个空的 status 查询保持 WhatsApp session 活跃
+# 使用 openclaw 的 health/status 接口（如果有），否则用最轻量的 message dry-run
+OPENCLAW="${OPENCLAW:-/opt/homebrew/bin/openclaw}"
+if command -v "$OPENCLAW" >/dev/null 2>&1; then
+    # dry-run 模式：不实际发送消息，但会触发 Gateway 检查 WhatsApp 连接状态
+    RESULT=$("$OPENCLAW" message send \
+        --target "${OPENCLAW_PHONE:-+85200000000}" \
+        --message "keepalive" \
+        --dry-run \
+        --json 2>/dev/null || true)
+
+    if echo "$RESULT" | grep -q '"dryRun": true' 2>/dev/null; then
+        # dry-run 成功，session 活跃
+        echo "[$TS] OK: session active" >> "$LOG"
+    else
+        echo "[$TS] WARN: dry-run 响应异常: $(echo "$RESULT" | head -1)" >> "$LOG"
+    fi
+else
+    echo "[$TS] WARN: openclaw 未找到，跳过" >> "$LOG"
+fi
+
+# 日志保留最近 200 行
+if [ -f "$LOG" ] && [ "$(wc -l < "$LOG" | tr -d ' ')" -gt 200 ]; then
+    tail -100 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+fi


### PR DESCRIPTION
根因：手机休眠/网络不活跃导致 WhatsApp Web session 断连，
Gateway 排队消息直到手动交互触发重连才一次性发出。
wa_keepalive.sh 通过 openclaw message send --dry-run 定期 触发 session 检查，遵循原则 #31（不重启）和 #33（只检目标组件）。

https://claude.ai/code/session_01RYFof4GNmHmptJePryAi7p