### PR TITLE
fix: add local /health endpoints to adapter and tool_proxy

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -69,6 +69,16 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
         log(fmt % args)
 
     def do_GET(self):
+        # Local health check — never forward to remote
+        if self.path in ("/health", "/v1/health"):
+            resp = json.dumps({"ok": True, "provider": PROVIDER_NAME, "model": REAL_MODEL_ID}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+            return
+
         path = self.path.replace("/v1", "", 1) if self.path.startswith("/v1") else self.path
         url = f"{TARGET_BASE}{path}"
         log(f"GET {url}")

--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -49,6 +49,24 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(stats)
             return
 
+        # /health 端点：检查 proxy 自身 + adapter 连通性
+        if self.path == "/health":
+            adapter_ok = False
+            try:
+                with urlopen(f"{BACKEND}/health", timeout=5) as resp:
+                    adapter_ok = resp.status == 200
+            except Exception:
+                pass
+            status = {"ok": adapter_ok, "proxy": True, "adapter": adapter_ok}
+            code = 200 if adapter_ok else 503
+            body = json.dumps(status).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
         url = f"{BACKEND}{self.path}"
         req = Request(url)
         try:


### PR DESCRIPTION
The /health endpoint was being forwarded to the remote GPU API which doesn't have a /health path, causing 404→502 errors. This broke health checks in job scripts and wa_keepalive.sh, contributing to missed WhatsApp push notifications.

- adapter.py: intercept /health locally, return provider/model info
- tool_proxy.py: /health now checks proxy + adapter connectivity

https://claude.ai/code/session_01RYFof4GNmHmptJePryAi7p