### PR TITLE
fix: ImportYeti scraper 用系统 Python 调用 + 修复转义警告

### DIFF
--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -352,10 +352,10 @@ import re
 name = '''$company'''
 for suffix in [' China', ' USA', ' US', ' Europe', ' Asia', ' Japan', ' Korea',
                ' International', ' Global', ' Worldwide',
-               ' Corporation', ' Corp\\.', ' Corp', ' Incorporated', ' Inc\\.', ' Inc',
-               ' Limited', ' Ltd\\.', ' Ltd', ' Company', ' Co\\.', ' Co',
+               ' Corporation', r' Corp\.', ' Corp', ' Incorporated', r' Inc\.', ' Inc',
+               ' Limited', r' Ltd\.', ' Ltd', ' Company', r' Co\.', ' Co',
                ' Group', ' Holdings', ' Holding',
-               ' AG', ' GmbH', ' S\\.A\\.', ' SA', ' SE', ' PLC', ' NV', ' BV',
+               ' AG', ' GmbH', r' S\.A\.', ' SA', ' SE', ' PLC', ' NV', ' BV',
                ' LLC', ' LLP', ' LP']:
     name = re.sub(re.escape(suffix) + r'$', '', name, flags=re.IGNORECASE)
 name = re.sub(r'[®™©]', '', name).strip()
@@ -366,7 +366,8 @@ print(name)
     done < "$HIGH_STARS"
 
     # 一次启动 Playwright 批量查询所有企业（避免重复启动浏览器）
-    python3 "$SCRAPER" "${CLEAN_NAMES[@]}" > "$ENRICHED_FILE" 2>"$CACHE/scraper.log" || true
+    # 注意：playwright 装在系统 Python 3.9 下，homebrew Python 3.14 没有
+    /usr/bin/python3 "$SCRAPER" "${CLEAN_NAMES[@]}" > "$ENRICHED_FILE" 2>"$CACHE/scraper.log" || true
     cat "$CACHE/scraper.log" >&2
     echo "[freight] ImportYeti 深挖完成"
 


### PR DESCRIPTION
根因：run_freight.sh 第8行 export PATH 把 homebrew Python 3.14 排在 系统 Python 3.9 前面，但 playwright 只装在系统 Python 下。
脚本内 `python3` 解析为 /opt/homebrew/bin/python3 → ImportError。

修复：
1. scraper 调用改为 /usr/bin/python3（playwright 所在的 Python）
2. 名称清洗的 `\.` 改为 r-string 消除 SyntaxWarning

https://claude.ai/code/session_01Fss9p8n518iDaYxTNuRkVG