### PR TITLE
fix: preflight scraper.log grep 兼容 macOS BSD grep

### DIFF
--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -382,7 +382,7 @@ except Exception:
     # 检查 scraper.log 最近是否有错误
     SCRAPER_LOG="$HOME/.openclaw/jobs/freight_watcher/cache/scraper.log"
     if [ -f "$SCRAPER_LOG" ]; then
-        SCRAPER_ERRORS=$(grep -ci "error\|traceback\|exception" "$SCRAPER_LOG" 2>/dev/null || echo "0")
+        SCRAPER_ERRORS=$(grep -ciE "error|traceback|exception" "$SCRAPER_LOG" 2>/dev/null || echo "0")
         if [ "$SCRAPER_ERRORS" -gt 0 ]; then
             warn "ImportYeti scraper.log 有 $SCRAPER_ERRORS 处错误记录"
         else


### PR DESCRIPTION
BSD grep 不支持 \| 语法，改用 grep -E 扩展正则

https://claude.ai/code/session_01Fss9p8n518iDaYxTNuRkVG