### PR TITLE
fix: grep -c 返回0行时退出码为1，|| echo 产生双行输出

### DIFF
--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -382,7 +382,8 @@ except Exception:
     # 检查 scraper.log 最近是否有错误
     SCRAPER_LOG="$HOME/.openclaw/jobs/freight_watcher/cache/scraper.log"
     if [ -f "$SCRAPER_LOG" ]; then
-        SCRAPER_ERRORS=$(grep -ciE "error|traceback|exception" "$SCRAPER_LOG" 2>/dev/null || echo "0")
+        SCRAPER_ERRORS=$(grep -ciE "error|traceback|exception" "$SCRAPER_LOG" 2>/dev/null || true)
+        SCRAPER_ERRORS=${SCRAPER_ERRORS:-0}
         if [ "$SCRAPER_ERRORS" -gt 0 ]; then
             warn "ImportYeti scraper.log 有 $SCRAPER_ERRORS 处错误记录"
         else


### PR DESCRIPTION
grep -c 匹配0行时 exit 1 → || echo "0" 追加第二个 "0"
→ SCRAPER_ERRORS="0\n0" → [: integer expression expected 改用 || true 保留原始输出，${:-0} 兜底

https://claude.ai/code/session_01Fss9p8n518iDaYxTNuRkVG