### PR TITLE
feat: 可观测性与可靠性增强（外部审计建议 #2/#3/#4/#9）

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import http.server, socketserver, json, ssl, sys, os, threading
+import http.server, socketserver, json, ssl, sys, os, threading, time
 from datetime import datetime
 from urllib.request import Request, urlopen
 
@@ -100,21 +100,24 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             self.send_error(502, str(e))
 
     def do_POST(self):
+        rid = self.headers.get("X-Request-ID", "")
+        tag = f"[{rid}] " if rid else ""
+        t0 = time.monotonic()
         length = int(self.headers.get("Content-Length", 0))
         raw = self.rfile.read(length)
         path = self.path.replace("/v1", "", 1) if self.path.startswith("/v1") else self.path
         url = f"{TARGET_BASE}{path}"
-        log(f"POST {url} ({length} bytes)")
+        log(f"{tag}POST {url} ({length} bytes)")
 
         if "/chat/completions" in self.path:
             try:
                 body = json.loads(raw)
             except (json.JSONDecodeError, ValueError) as e:
-                log(f"Bad JSON: {e}")
+                log(f"{tag}Bad JSON: {e}")
                 self.send_error(400, "Bad JSON")
                 return
 
-            log(f"INCOMING KEYS: {list(body.keys())}")
+            log(f"{tag}INCOMING KEYS: {list(body.keys())}")
 
             # Clean messages - remove unsupported content types
             msgs = body.get("messages", [])
@@ -160,10 +163,10 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             if "stream" in body:
                 clean["stream"] = body["stream"]
 
-            log(f"CLEAN KEYS: {list(clean.keys())}")
-            log(f"MSG COUNT: {len(clean_msgs)}, ROLES: {[m['role'] for m in clean_msgs]}")
+            log(f"{tag}CLEAN KEYS: {list(clean.keys())}")
+            log(f"{tag}MSG COUNT: {len(clean_msgs)}, ROLES: {[m['role'] for m in clean_msgs]}")
             data = json.dumps(clean).encode()
-            log(f"FORWARDING: {len(data)} bytes")
+            log(f"{tag}FORWARDING: {len(data)} bytes")
         else:
             data = raw
 
@@ -174,14 +177,16 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
         try:
             with urlopen(req, timeout=300, context=ctx) as resp:
                 resp_body = resp.read()
-                log(f"RESPONSE: {resp.status} ({len(resp_body)} bytes)")
+                elapsed = int((time.monotonic() - t0) * 1000)
+                log(f"{tag}RESPONSE: {resp.status} ({len(resp_body)} bytes) {elapsed}ms")
                 self.send_response(resp.status)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(resp_body)))
                 self.end_headers()
                 self.wfile.write(resp_body)
         except Exception as e:
-            log(f"FORWARD ERROR: {e}")
+            elapsed = int((time.monotonic() - t0) * 1000)
+            log(f"{tag}FORWARD ERROR ({elapsed}ms): {e}")
             err = json.dumps({"error": str(e)}).encode()
             self.send_response(502)
             self.send_header("Content-Type", "application/json")

--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -6,6 +6,11 @@
 
 set -euo pipefail
 
+# 防重叠执行（flock）
+LOCK="/tmp/auto_deploy.lock"
+exec 200>"$LOCK"
+flock -n 200 || { echo "[auto_deploy] Already running, skip"; exit 0; }
+
 # crontab 环境 PATH 不含 homebrew，手动补充
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 

--- a/job_watchdog.sh
+++ b/job_watchdog.sh
@@ -6,6 +6,11 @@
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -eo pipefail
 
+# 防重叠执行（flock）
+LOCK="/tmp/job_watchdog.lock"
+exec 200>"$LOCK"
+flock -n 200 || { echo "[watchdog] Already running, skip"; exit 0; }
+
 OPENCLAW="${OPENCLAW:-/opt/homebrew/bin/openclaw}"
 TO="${OPENCLAW_PHONE:-+85200000000}"
 TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"

--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -7,6 +7,11 @@ export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 # 设计原则：结构化数据(作者/链接/日期)由XML提取，LLM只负责翻译+评价
 set -eo pipefail
 
+# 防重叠执行（flock）
+LOCK="/tmp/arxiv_monitor.lock"
+exec 200>"$LOCK"
+flock -n 200 || { echo "[arxiv] Already running, skip"; exit 0; }
+
 OPENCLAW="${OPENCLAW:-/opt/homebrew/bin/openclaw}"
 JOB_DIR="${HOME}/.openclaw/jobs/arxiv_monitor"
 CACHE="$JOB_DIR/cache"

--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -8,6 +8,11 @@
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -eo pipefail
 
+# 防重叠执行（flock）
+LOCK="/tmp/freight_watcher.lock"
+exec 200>"$LOCK"
+flock -n 200 || { echo "[freight] Already running, skip"; exit 0; }
+
 # ── --test 模式：跳过 RSS 抓取和 LLM 分析，直接从 Step 9 (ImportYeti) 开始 ──
 TEST_MODE=0
 if [ "${1:-}" = "--test" ]; then

--- a/jobs/openclaw_official/run.sh
+++ b/jobs/openclaw_official/run.sh
@@ -2,6 +2,12 @@
 # cron 环境 PATH 极简，必须显式声明（规则 #13）
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
+
+# 防重叠执行（flock）
+LOCK="/tmp/openclaw_releases.lock"
+exec 200>"$LOCK"
+flock -n 200 || { echo "[releases] Already running, skip"; exit 0; }
+
 day="$(TZ=Asia/Hong_Kong date "+%Y-%m-%d")"
 
 ROOT="${ROOT:-$HOME/.openclaw}"

--- a/jobs/openclaw_official/run_discussions.sh
+++ b/jobs/openclaw_official/run_discussions.sh
@@ -3,6 +3,11 @@
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
 
+# 防重叠执行（flock）
+LOCK="/tmp/openclaw_discussions.lock"
+exec 200>"$LOCK"
+flock -n 200 || { echo "[discussions] Already running, skip"; exit 0; }
+
 ROOT="${ROOT:-$HOME/.openclaw}"
 JOB="$ROOT/jobs/openclaw_official"
 KB_SRC="${KB_BASE:-$HOME/.kb}/sources/openclaw_official.md"

--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -222,7 +222,7 @@ def fix_tool_args(rj):
         tcs = msg.get("tool_calls")
         if tcs:
             for tc in tcs:
-                fn = tc.get("function", {})
+                fn = tc.get("function") or {}
                 name = fn.get("name", "")
                 args_str = fn.get("arguments", "{}")
                 try:

--- a/run_hn_fixed.sh
+++ b/run_hn_fixed.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # cron 环境 PATH 极简，必须显式声明（规则 #13）
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+
+# 防重叠执行（flock）
+LOCK="/tmp/hn_watcher.lock"
+exec 200>"$LOCK"
+flock -n 200 || { echo "[hn] Already running, skip"; exit 0; }
+
 # run_hn.sh - Hacker News AI/Tech精选 Watcher
 # 触发时间：每3小时:45分 HKT（系统crontab，与 ArXiv 错开45分钟）
 # v23fix2：

--- a/test_tool_proxy.py
+++ b/test_tool_proxy.py
@@ -385,5 +385,175 @@ class TestShouldStripTools(unittest.TestCase):
         self.assertTrue(should_strip_tools(msgs))
 
 
+# ---- Abnormal response handling tests (contract-style) ----
+
+class TestAbnormalResponses(unittest.TestCase):
+    """异常响应处理：模拟 provider 返回各种非正常响应。"""
+
+    def test_fix_tool_args_empty_arguments_string(self):
+        """工具调用 arguments 为空字符串"""
+        rj = {"choices": [{"message": {"role": "assistant", "tool_calls": [
+            {"function": {"name": "exec", "arguments": ""}}
+        ]}}]}
+        modified = fix_tool_args(rj)
+        # 应不崩溃，空字符串解析为空 dict
+        self.assertFalse(modified)
+
+    def test_fix_tool_args_arguments_is_dict(self):
+        """部分 provider 返回 arguments 为 dict 而非 JSON string"""
+        rj = {"choices": [{"message": {"role": "assistant", "tool_calls": [
+            {"function": {"name": "exec", "arguments": {"command": "ls"}}}
+        ]}}]}
+        modified = fix_tool_args(rj)
+        self.assertFalse(modified)
+
+    def test_fix_tool_args_nested_null_fields(self):
+        """tool_calls 列表中包含残缺的 function 字段"""
+        rj = {"choices": [{"message": {"role": "assistant", "tool_calls": [
+            {"function": None},
+            {"function": {"name": "exec", "arguments": '{"command": "pwd"}'}},
+        ]}}]}
+        # Should handle None function gracefully
+        fix_tool_args(rj)
+
+    def test_build_sse_with_usage(self):
+        """SSE 转换应忽略 usage 字段（只输出 choices）"""
+        rj = {
+            "id": "x", "created": 0, "model": "m",
+            "usage": {"prompt_tokens": 100, "total_tokens": 200},
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}]
+        }
+        sse = build_sse_response(rj)
+        text = sse.decode()
+        self.assertIn('"content": "ok"', text)
+        self.assertIn("[DONE]", text)
+
+    def test_build_sse_multiple_choices(self):
+        """多个 choices（n>1 场景）"""
+        rj = {
+            "id": "x", "created": 0, "model": "m",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "a"}, "finish_reason": "stop"},
+                {"index": 1, "message": {"role": "assistant", "content": "b"}, "finish_reason": "stop"},
+            ]
+        }
+        sse = build_sse_response(rj)
+        text = sse.decode()
+        # 应有两个 data: 事件 + [DONE]
+        data_lines = [l for l in text.split('\n') if l.startswith('data:') and '[DONE]' not in l]
+        self.assertEqual(len(data_lines), 2)
+
+    def test_build_sse_content_with_special_chars(self):
+        """SSE 内容含换行、引号、unicode"""
+        rj = {
+            "id": "x", "created": 0, "model": "m",
+            "choices": [{"index": 0,
+                         "message": {"role": "assistant", "content": '你好\n"世界"\t🌍'},
+                         "finish_reason": "stop"}]
+        }
+        sse = build_sse_response(rj)
+        # 应该能正确 JSON 序列化
+        text = sse.decode()
+        self.assertIn("data:", text)
+        self.assertIn("[DONE]", text)
+
+    def test_truncate_tool_messages_preserved(self):
+        """截断时 tool role 消息不应被拆散（orphan tool_call_id）"""
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "A" * 1000},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "tc1", "function": {"name": "exec", "arguments": "{}"}}]},
+            {"role": "tool", "content": "result", "tool_call_id": "tc1"},
+            {"role": "user", "content": "B" * 1000},
+        ]
+        result, dropped = truncate_messages(msgs, max_bytes=5000)
+        # system 始终保留
+        self.assertEqual(result[0]["role"], "system")
+
+    def test_truncate_all_dropped_except_system(self):
+        """极端截断：system 消息占满预算"""
+        msgs = [
+            {"role": "system", "content": "S" * 100000},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+        ]
+        result, dropped = truncate_messages(msgs, max_bytes=60000)
+        # system 被截断但保留，其他消息尽量保留
+        self.assertEqual(result[0]["role"], "system")
+        self.assertIn("[truncated]", result[0]["content"])
+
+    def test_fix_tool_args_unknown_tool_passthrough(self):
+        """未知工具名（不在 TOOL_PARAMS 中）不应被修改"""
+        rj = make_response("custom_unknown_tool", {"foo": "bar", "baz": 42})
+        modified = fix_tool_args(rj)
+        args = get_args(rj)
+        self.assertFalse(modified)
+        self.assertEqual(args["foo"], "bar")
+        self.assertEqual(args["baz"], 42)
+
+    def test_filter_tools_malformed_entries(self):
+        """工具列表中包含残缺条目"""
+        tools = [
+            {"function": {"name": "exec", "parameters": {}}},
+            {"function": {}},  # 缺 name
+            {},  # 缺 function
+            {"function": {"name": "web_search", "parameters": {}}},
+        ]
+        filtered, all_names, kept = filter_tools(tools)
+        self.assertEqual(len(filtered), 2)
+        self.assertIn("exec", kept)
+        self.assertIn("web_search", kept)
+
+
+class TestProxyStats(unittest.TestCase):
+    """ProxyStats 监控状态机测试。"""
+
+    def test_consecutive_errors_alert(self):
+        """连续错误达到阈值应产生告警"""
+        from proxy_filters import ProxyStats, CONSECUTIVE_ERROR_ALERT
+        stats = ProxyStats()
+        for i in range(CONSECUTIVE_ERROR_ALERT):
+            stats.record_error(502, "timeout")
+        alerts = stats.pop_alerts()
+        self.assertTrue(len(alerts) > 0)
+        self.assertIn("连续", alerts[0])
+
+    def test_success_resets_consecutive(self):
+        """成功请求应重置连续错误计数"""
+        from proxy_filters import ProxyStats
+        stats = ProxyStats()
+        stats.record_error(502, "timeout")
+        stats.record_error(502, "timeout")
+        stats.record_success({"prompt_tokens": 100, "total_tokens": 200})
+        self.assertEqual(stats.consecutive_errors, 0)
+
+    def test_token_critical_alert(self):
+        """prompt_tokens 超过临界阈值应触发告警"""
+        from proxy_filters import ProxyStats, TOKEN_CRITICAL_THRESHOLD
+        stats = ProxyStats()
+        stats.record_success({"prompt_tokens": TOKEN_CRITICAL_THRESHOLD + 1, "total_tokens": TOKEN_CRITICAL_THRESHOLD + 100})
+        alerts = stats.pop_alerts()
+        self.assertTrue(len(alerts) > 0)
+        self.assertIn("临界", alerts[0])
+
+    def test_no_alert_below_threshold(self):
+        """正常 token 用量不应触发告警"""
+        from proxy_filters import ProxyStats
+        stats = ProxyStats()
+        stats.record_success({"prompt_tokens": 1000, "total_tokens": 2000})
+        alerts = stats.pop_alerts()
+        self.assertEqual(len(alerts), 0)
+
+    def test_pop_alerts_clears(self):
+        """pop_alerts 后告警列表应清空"""
+        from proxy_filters import ProxyStats
+        stats = ProxyStats()
+        stats.record_success({"prompt_tokens": 250000, "total_tokens": 260000})
+        alerts1 = stats.pop_alerts()
+        alerts2 = stats.pop_alerts()
+        self.assertTrue(len(alerts1) > 0)
+        self.assertEqual(len(alerts2), 0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -4,7 +4,7 @@ tool_proxy.py — V27 HTTP 层
 策略逻辑已提取到 proxy_filters.py，本文件只负责 HTTP 收发和日志。
 V28: + token/error 监控（proxy_stats）
 """
-import http.server, socketserver, json, sys, subprocess, os, threading
+import http.server, socketserver, json, sys, subprocess, os, threading, uuid, time
 from datetime import datetime
 from urllib.request import Request, urlopen
 
@@ -83,6 +83,8 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             self.send_error(502, str(e))
 
     def do_POST(self):
+        rid = uuid.uuid4().hex[:8]
+        t0 = time.monotonic()
         length = int(self.headers.get("Content-Length", 0))
         raw = self.rfile.read(length)
 
@@ -98,12 +100,12 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 truncated, dropped = truncate_messages(msgs)
                 if dropped:
                     body["messages"] = truncated
-                    log(f"WARN: Truncated {dropped} old messages ({len(msgs)} -> {len(truncated)} msgs)")
+                    log(f"[{rid}] WARN: Truncated {dropped} old messages ({len(msgs)} -> {len(truncated)} msgs)")
 
                 # [NO_TOOLS] 标记：强制清空工具（纯推理模式）
                 if should_strip_tools(body.get("messages", [])):
                     if "tools" in body:
-                        log(f"[NO_TOOLS] Stripping all {len(body['tools'])} tools (pure inference mode)")
+                        log(f"[{rid}] [NO_TOOLS] Stripping all {len(body['tools'])} tools (pure inference mode)")
                         del body["tools"]
                     if "tool_choice" in body:
                         del body["tool_choice"]
@@ -111,8 +113,8 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 elif "tools" in body:
                     orig = len(body["tools"])
                     body["tools"], all_names, kept_names = filter_tools(body["tools"])
-                    log(f"ALL tools ({orig}): {all_names}")
-                    log(f"Kept tools ({len(body['tools'])}): {kept_names}")
+                    log(f"[{rid}] ALL tools ({orig}): {all_names}")
+                    log(f"[{rid}] Kept tools ({len(body['tools'])}): {kept_names}")
                     if not body["tools"]:
                         del body["tools"]
                         if "tool_choice" in body:
@@ -125,10 +127,12 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
         url = f"{BACKEND}{self.path}"
         req = Request(url, data=raw, method="POST")
         req.add_header("Content-Type", "application/json")
+        req.add_header("X-Request-ID", rid)
         try:
             with urlopen(req, timeout=300) as resp:
                 resp_body = resp.read()
-                log(f"Backend: {resp.status} {len(resp_body)}b stream={was_streaming}")
+                elapsed = int((time.monotonic() - t0) * 1000)
+                log(f"[{rid}] Backend: {resp.status} {len(resp_body)}b {elapsed}ms stream={was_streaming}")
 
                 if "/chat/completions" in self.path and resp_body:
                     try:
@@ -142,16 +146,16 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                                 for tc in m["tool_calls"]:
                                     fn_name = tc.get('function', {}).get('name', '?')
                                     fn_args = tc.get('function', {}).get('arguments', '')
-                                    log(f"CALL: {fn_name} ({len(fn_args)} bytes)")
+                                    log(f"[{rid}] CALL: {fn_name} ({len(fn_args)} bytes)")
                             elif m.get("content"):
-                                log(f"TEXT: {len(str(m['content']))} chars")
+                                log(f"[{rid}] TEXT: {len(str(m['content']))} chars")
 
                         # Token 监控：记录 usage
                         usage = rj.get("usage", {})
                         if usage:
                             pt = usage.get("prompt_tokens", 0)
                             tt = usage.get("total_tokens", 0)
-                            log(f"TOKENS: prompt={pt:,} total={tt:,} ({pt*100//260000}% of 260K)")
+                            log(f"[{rid}] TOKENS: prompt={pt:,} total={tt:,} ({pt*100//260000}% of 260K)")
                             proxy_stats.record_success(usage)
                         else:
                             proxy_stats.record_success({})
@@ -173,7 +177,7 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                         else:
                             resp_body = json.dumps(rj).encode()
                     except Exception as e:
-                        log(f"Parse error: {e}")
+                        log(f"[{rid}] Parse error: {e}")
 
                 self.send_response(resp.status)
                 self.send_header("Content-Type", "application/json")
@@ -181,7 +185,8 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(resp_body)
         except Exception as e:
-            log(f"Backend error: {e}")
+            elapsed = int((time.monotonic() - t0) * 1000)
+            log(f"[{rid}] Backend error ({elapsed}ms): {e}")
             # 记录错误到监控
             error_code = 502
             error_str = str(e)


### PR DESCRIPTION
1. X-Request-ID 贯穿日志（#2）
   - proxy 生成 uuid[:8]，通过 X-Request-ID header 传给 adapter
   - 两端所有日志行带 [rid] 前缀，支持跨组件请求关联

2. latency_ms 记录（#3）
   - proxy/adapter 每个请求记录耗时（毫秒），含成功和失败路径
   - 日志示例：[proxy] [a1b2c3d4] Backend: 200 1234b 5678ms

3. 异常响应测试补全 + bug fix（#4）
   - test_tool_proxy.py 从 43 → 58 用例（+15 新增）
   - 覆盖：空 arguments、dict arguments、null function、多 choices SSE、 特殊字符、残缺工具条目、ProxyStats 状态机（连续错误/token 告警/重置）
   - 修复真实 bug：proxy_filters.py fix_tool_args 处理 function:None 时 AttributeError（tc.get("function", {}) → tc.get("function") or {}）

4. flock 防重叠执行（#9）
   - 7 个 cron 脚本统一加 flock -n 互斥锁
   - 覆盖：auto_deploy(2min)、arxiv_monitor、freight_watcher、 openclaw_releases、openclaw_discussions、hn_watcher、job_watchdog
   - 上一次未完成时新实例静默退出，不会堆积

https://claude.ai/code/session_015MvcCjuMLMFrndBMf4HnXQ