### PR TITLE
fix: replace flock with mkdir-based atomic lock for macOS compatibility

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -6,30 +6,17 @@
 
 set -euo pipefail
 
-# 防重叠执行（flock）
-LOCK="/tmp/auto_deploy.lock"
-exec 200>"$LOCK"
-flock -n 200 || { echo "[auto_deploy] Already running, skip"; exit 0; }
+# 防重叠执行（mkdir 原子锁，macOS 兼容）
+LOCK="/tmp/auto_deploy.lockdir"
+mkdir "$LOCK" 2>/dev/null || { echo "[auto_deploy] Already running, skip"; exit 0; }
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
 # crontab 环境 PATH 不含 homebrew，手动补充
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 REPO_DIR="$HOME/openclaw-model-bridge"
 LOG="$HOME/.openclaw/logs/auto_deploy.log"
-LOCK="/tmp/auto_deploy.lock"
-
 mkdir -p "$(dirname "$LOG")"
-
-# 防止并发执行
-if [ -f "$LOCK" ]; then
-    LOCK_PID=$(cat "$LOCK" 2>/dev/null || true)
-    if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
-        exit 0
-    fi
-    rm -f "$LOCK"
-fi
-echo $$ > "$LOCK"
-trap 'rm -f "$LOCK"' EXIT
 
 cd "$REPO_DIR" || { echo "$(date) ERROR: cannot cd to $REPO_DIR" >> "$LOG"; exit 1; }
 

--- a/job_watchdog.sh
+++ b/job_watchdog.sh
@@ -6,10 +6,10 @@
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -eo pipefail
 
-# 防重叠执行（flock）
-LOCK="/tmp/job_watchdog.lock"
-exec 200>"$LOCK"
-flock -n 200 || { echo "[watchdog] Already running, skip"; exit 0; }
+# 防重叠执行（mkdir 原子锁，macOS 兼容）
+LOCK="/tmp/job_watchdog.lockdir"
+mkdir "$LOCK" 2>/dev/null || { echo "[watchdog] Already running, skip"; exit 0; }
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
 OPENCLAW="${OPENCLAW:-/opt/homebrew/bin/openclaw}"
 TO="${OPENCLAW_PHONE:-+85200000000}"

--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -7,10 +7,10 @@ export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 # 设计原则：结构化数据(作者/链接/日期)由XML提取，LLM只负责翻译+评价
 set -eo pipefail
 
-# 防重叠执行（flock）
-LOCK="/tmp/arxiv_monitor.lock"
-exec 200>"$LOCK"
-flock -n 200 || { echo "[arxiv] Already running, skip"; exit 0; }
+# 防重叠执行（mkdir 原子锁，macOS 兼容）
+LOCK="/tmp/arxiv_monitor.lockdir"
+mkdir "$LOCK" 2>/dev/null || { echo "[arxiv] Already running, skip"; exit 0; }
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
 OPENCLAW="${OPENCLAW:-/opt/homebrew/bin/openclaw}"
 JOB_DIR="${HOME}/.openclaw/jobs/arxiv_monitor"

--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -8,10 +8,10 @@
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -eo pipefail
 
-# 防重叠执行（flock）
-LOCK="/tmp/freight_watcher.lock"
-exec 200>"$LOCK"
-flock -n 200 || { echo "[freight] Already running, skip"; exit 0; }
+# 防重叠执行（mkdir 原子锁，macOS 兼容）
+LOCK="/tmp/freight_watcher.lockdir"
+mkdir "$LOCK" 2>/dev/null || { echo "[freight] Already running, skip"; exit 0; }
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
 # ── --test 模式：跳过 RSS 抓取和 LLM 分析，直接从 Step 9 (ImportYeti) 开始 ──
 TEST_MODE=0

--- a/jobs/openclaw_official/run.sh
+++ b/jobs/openclaw_official/run.sh
@@ -3,10 +3,10 @@
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
 
-# 防重叠执行（flock）
-LOCK="/tmp/openclaw_releases.lock"
-exec 200>"$LOCK"
-flock -n 200 || { echo "[releases] Already running, skip"; exit 0; }
+# 防重叠执行（mkdir 原子锁，macOS 兼容）
+LOCK="/tmp/openclaw_releases.lockdir"
+mkdir "$LOCK" 2>/dev/null || { echo "[releases] Already running, skip"; exit 0; }
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
 day="$(TZ=Asia/Hong_Kong date "+%Y-%m-%d")"
 

--- a/jobs/openclaw_official/run_discussions.sh
+++ b/jobs/openclaw_official/run_discussions.sh
@@ -3,10 +3,10 @@
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
 
-# 防重叠执行（flock）
-LOCK="/tmp/openclaw_discussions.lock"
-exec 200>"$LOCK"
-flock -n 200 || { echo "[discussions] Already running, skip"; exit 0; }
+# 防重叠执行（mkdir 原子锁，macOS 兼容）
+LOCK="/tmp/openclaw_discussions.lockdir"
+mkdir "$LOCK" 2>/dev/null || { echo "[discussions] Already running, skip"; exit 0; }
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
 ROOT="${ROOT:-$HOME/.openclaw}"
 JOB="$ROOT/jobs/openclaw_official"

--- a/kb_write.sh
+++ b/kb_write.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# 使用 flock 文件锁替代目录忙等待锁，避免 CPU 空转且在进程异常退出后自动释放
+# 使用 mkdir 原子锁（macOS 兼容），进程退出后 trap 自动释放
 KB_BASE="${KB_BASE:-/Users/bisdom/.kb}"
-LOCKFILE="$KB_BASE/.write.lock"
-exec 9>"$LOCKFILE"
-flock -x 9
+LOCKDIR="$KB_BASE/.write.lockdir"
+while ! mkdir "$LOCKDIR" 2>/dev/null; do sleep 0.1; done
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
 
 CONTENT="$1"
 TAGS="${2:-技术/AI}"

--- a/run_hn_fixed.sh
+++ b/run_hn_fixed.sh
@@ -2,10 +2,10 @@
 # cron 环境 PATH 极简，必须显式声明（规则 #13）
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 
-# 防重叠执行（flock）
-LOCK="/tmp/hn_watcher.lock"
-exec 200>"$LOCK"
-flock -n 200 || { echo "[hn] Already running, skip"; exit 0; }
+# 防重叠执行（mkdir 原子锁，macOS 兼容）
+LOCK="/tmp/hn_watcher.lockdir"
+mkdir "$LOCK" 2>/dev/null || { echo "[hn] Already running, skip"; exit 0; }
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
 # run_hn.sh - Hacker News AI/Tech精选 Watcher
 # 触发时间：每3小时:45分 HKT（系统crontab，与 ArXiv 错开45分钟）


### PR DESCRIPTION
flock is a Linux-only utility not available on macOS. All 8 cron scripts using flock would silently exit 0 without executing on Mac Mini. Replaced with POSIX-portable mkdir atomic lock + trap cleanup.

Also removed duplicate PID-based lock mechanism in auto_deploy.sh that conflicted with the new lock.

https://claude.ai/code/session_015MvcCjuMLMFrndBMf4HnXQ