### PR TITLE
feat: KB 三件套 — 搜索/深度回顾/每日摘要

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -86,6 +86,8 @@ declare -a FILE_MAP=(
     "kb_review.sh|$HOME/kb_review.sh"
     "kb_evening.sh|$HOME/kb_evening.sh"
     "kb_save_arxiv.sh|$HOME/kb_save_arxiv.sh"
+    "kb_search.sh|$HOME/kb_search.sh"
+    "kb_inject.sh|$HOME/kb_inject.sh"
     "job_watchdog.sh|$HOME/job_watchdog.sh"
     "wa_keepalive.sh|$HOME/wa_keepalive.sh"
 

--- a/jobs_registry.yaml
+++ b/jobs_registry.yaml
@@ -42,6 +42,15 @@ jobs:
     enabled: true
     description: 晚间 KB 整理
 
+  - id: kb_inject
+    scheduler: system
+    entry: kb_inject.sh
+    interval: "0 7 * * *"           # 每天 07:00（LLM对话前生成当日摘要）
+    log: ~/kb_inject.log
+    needs_api_key: false
+    enabled: true
+    description: 每日 KB 摘要生成（~/.kb/daily_digest.md），供 LLM 对话时 read 查阅
+
   # ---- openclaw cron 任务（经过 LLM 链路） ----
 
   - id: freight_watcher
@@ -65,13 +74,13 @@ jobs:
   # openclaw_discussions 已删除 — 与 run_discussions (id: run_discussions) 完全重复
 
   - id: kb_review
-    scheduler: openclaw
+    scheduler: system
     entry: kb_review.sh
     interval: "0 21 * * 5"          # 每周五 21:00
     log: ~/kb_review.log
     needs_api_key: true
     enabled: true
-    description: KB 跨笔记回顾
+    description: "KB 跨笔记回顾（V29: LLM深度分析+WhatsApp推送）"
 
   # ---- HN 讨论抓取（独立脚本） ----
 

--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# kb_inject.sh — 每日 KB 摘要生成（供 LLM 对话时查阅）
+# 用法：bash kb_inject.sh [天数，默认3]
+# 功能：从 notes + sources 提取最近 N 天精华 → 写入 ~/.kb/daily_digest.md
+#        LLM 在对话中可通过 read 工具读取此文件，实现"知识库可查"
+# 建议 cron：每天 07:00 运行，确保 LLM 拿到最新内容
+# cron 环境 PATH 极简，必须显式声明（规则 #13）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+set -euo pipefail
+
+DAYS="${1:-3}"
+KB_DIR="${KB_BASE:-/Users/bisdom/.kb}"
+DIGEST_FILE="$KB_DIR/daily_digest.md"
+INDEX="$KB_DIR/index.json"
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M')"
+DATE=$(date +%Y%m%d)
+
+log() { echo "[$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')] kb_inject: $1"; }
+
+mkdir -p "$KB_DIR"
+
+# ── 生成摘要（Python 一次性处理，避免多次 shell 调用） ──
+python3 - "$KB_DIR" "$DAYS" "$TS" "$DIGEST_FILE" "$INDEX" << 'PYEOF'
+import os, sys, json, glob
+from datetime import datetime, timedelta
+from collections import Counter
+
+kb_dir, days_str, ts, digest_file, index_path = sys.argv[1:6]
+days = int(days_str)
+cutoff = (datetime.now() - timedelta(days=days)).strftime('%Y%m%d')
+cutoff_dash = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d')
+
+sections = []
+
+# ── 统计 ──
+try:
+    with open(index_path) as f:
+        entries = json.load(f).get('entries', [])
+    total = len(entries)
+    recent = [e for e in entries if e.get('date', '') >= cutoff]
+    tags = Counter()
+    for e in recent:
+        tags.update(e.get('tags', []))
+    top_tags = ', '.join(t for t, _ in tags.most_common(5)) or '无'
+except (OSError, json.JSONDecodeError):
+    total = 0
+    recent = []
+    top_tags = '无'
+
+sections.append(f"""# KB 每日摘要
+> 更新时间：{ts} | 范围：最近 {days} 天 | 总条目：{total}
+> 热门标签：{top_tags}
+> 本期新增：{len(recent)} 条""")
+
+# ── Notes 精华 ──
+notes_dir = os.path.join(kb_dir, 'notes')
+note_items = []
+total_chars = 0
+MAX_NOTE_CHARS = 3000
+
+for f in sorted(glob.glob(os.path.join(notes_dir, '*.md')), reverse=True):
+    basename = os.path.basename(f)
+    file_date = basename[:8]
+    if file_date < cutoff:
+        break
+    try:
+        with open(f) as fh:
+            content = fh.read().strip()
+        if content.startswith('---'):
+            parts = content.split('---', 2)
+            if len(parts) >= 3:
+                content = parts[2].strip()
+        # 提取第一个有意义的行作为标题
+        lines = [l.strip() for l in content.split('\n') if l.strip() and not l.startswith('#')]
+        title = lines[0][:120] if lines else basename
+        snippet = content[:200].replace('\n', ' ')
+        if total_chars + len(snippet) > MAX_NOTE_CHARS:
+            break
+        note_items.append(f"- [{file_date}] {title}")
+        total_chars += len(snippet)
+    except OSError:
+        continue
+
+if note_items:
+    sections.append("## 近期笔记\n" + '\n'.join(note_items[:20]))
+
+# ── Sources 归档精华（每个来源取最近内容） ──
+sources_map = {
+    'arxiv_daily.md': ('ArXiv 论文', 1500),
+    'hn_daily.md': ('HackerNews 热帖', 1500),
+    'freight_daily.md': ('货代动态', 800),
+    'openclaw_official.md': ('OpenClaw 更新', 800),
+}
+
+# 生成日期匹配模式
+date_patterns = []
+for i in range(days):
+    d = datetime.now() - timedelta(days=i)
+    date_patterns.append(d.strftime('%Y-%m-%d'))
+    date_patterns.append(d.strftime('%Y%m%d'))
+
+for filename, (label, max_chars) in sources_map.items():
+    path = os.path.join(kb_dir, 'sources', filename)
+    if not os.path.isfile(path):
+        continue
+    try:
+        with open(path) as f:
+            all_lines = f.readlines()
+    except OSError:
+        continue
+
+    # 提取含日期的行及其后续行
+    relevant = []
+    include_next = 0
+    for line in all_lines:
+        if any(dp in line for dp in date_patterns):
+            relevant.append(line.rstrip())
+            include_next = 4  # 包含后续4行作为上下文
+        elif include_next > 0:
+            relevant.append(line.rstrip())
+            include_next -= 1
+
+    if relevant:
+        text = '\n'.join(relevant)[:max_chars]
+        sections.append(f"## {label}\n{text}")
+
+# ── 使用提示 ──
+sections.append("""---
+> 此文件由 kb_inject.sh 每日自动生成。
+> 用户询问最近资讯/论文/新闻时，请参考以上内容回答。
+> 需要更详细信息，可用 read 工具读取 ~/.kb/sources/ 下的完整归档。""")
+
+# ── 写入 ──
+output = '\n\n'.join(sections) + '\n'
+with open(digest_file, 'w') as f:
+    f.write(output)
+
+print(f"OK: {digest_file} ({len(output)} chars, {len(note_items)} notes)")
+PYEOF
+
+log "摘要已生成: $DIGEST_FILE"
+
+# ── rsync 备份 ──
+rsync -a --quiet "$KB_DIR/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true

--- a/kb_review.sh
+++ b/kb_review.sh
@@ -1,24 +1,35 @@
 #!/bin/bash
+# kb_review.sh — KB 跨笔记回顾（V29: LLM 深度分析版）
+# 用法：bash kb_review.sh [天数，默认7]
+# 功能：收集最近 N 天的 KB 内容 → LLM 跨领域深度分析 → 推送 WhatsApp + 写入 KB
 # cron 环境 PATH 极简，必须显式声明（规则 #13）
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 set -euo pipefail
+
 DATE=$(date +%Y%m%d)
 DAYS="${1:-7}"
 KB_DIR="${KB_BASE:-/Users/bisdom/.kb}"
 REVIEW_FILE="$KB_DIR/daily/review_${DATE}.md"
+PHONE="${OPENCLAW_PHONE:-+85200000000}"
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+STATUS_FILE="$KB_DIR/last_run_review.json"
+
 mkdir -p "$KB_DIR/daily"
 
+log() { echo "[$TS] kb_review: $1"; }
+
+# ── 1. 统计基础信息 ──
 NOTE_COUNT=$(ls "$KB_DIR/notes/"*.md 2>/dev/null | wc -l | tr -d ' ' || echo 0)
 INDEX_TOTAL=$(python3 - "$KB_DIR/index.json" << 'PYEOF'
 import json, sys
 try:
     with open(sys.argv[1]) as f:
-        d = json.load(f)
-    print(len(d.get('entries', [])))
+        print(len(json.load(f).get('entries', [])))
 except (OSError, json.JSONDecodeError):
     print(0)
 PYEOF
 )
+
 THEMES=$(python3 - "$KB_DIR/index.json" << 'PYEOF'
 import json, sys
 from collections import Counter
@@ -28,13 +39,156 @@ try:
     tags = Counter()
     for e in d.get('entries', []):
         tags.update(e.get('tags', []))
-    print(' / '.join([t for t, _ in tags.most_common(3)]) or '技术/AI')
+    print(' / '.join([t for t, _ in tags.most_common(5)]) or '技术/AI')
 except (OSError, json.JSONDecodeError):
     print('技术/AI')
 PYEOF
 )
 
-NOTES_TEXT=$(for f in $(ls -t "$KB_DIR/notes/"*.md 2>/dev/null | head -5); do
+# ── 2. 收集最近 N 天的笔记内容 ──
+NOTES_CONTENT=$(python3 - "$KB_DIR" "$DAYS" << 'PYEOF'
+import os, sys, glob
+from datetime import datetime, timedelta
+
+kb_dir = sys.argv[1]
+days = int(sys.argv[2])
+cutoff = (datetime.now() - timedelta(days=days)).strftime('%Y%m%d')
+notes_dir = os.path.join(kb_dir, 'notes')
+collected = []
+total_chars = 0
+MAX_CHARS = 8000  # LLM context budget for notes
+
+for f in sorted(glob.glob(os.path.join(notes_dir, '*.md')), reverse=True):
+    basename = os.path.basename(f)
+    # 文件名格式: YYYYMMDDHHMMSS.md
+    file_date = basename[:8]
+    if file_date < cutoff:
+        break
+    try:
+        with open(f) as fh:
+            content = fh.read().strip()
+        # 去掉 frontmatter
+        if content.startswith('---'):
+            parts = content.split('---', 2)
+            if len(parts) >= 3:
+                content = parts[2].strip()
+        # 截取前 300 字
+        snippet = content[:300]
+        if total_chars + len(snippet) > MAX_CHARS:
+            break
+        collected.append(f"[{file_date}] {snippet}")
+        total_chars += len(snippet)
+    except OSError:
+        continue
+
+print('\n---\n'.join(collected) if collected else '（本期无笔记）')
+PYEOF
+)
+
+# ── 3. 收集来源归档的最近内容 ──
+SOURCES_CONTENT=$(python3 - "$KB_DIR" "$DAYS" << 'PYEOF'
+import os, sys, re
+from datetime import datetime, timedelta
+
+kb_dir = sys.argv[1]
+days = int(sys.argv[2])
+MAX_PER_SOURCE = 2000
+sources = {
+    'arxiv_daily.md': 'ArXiv论文',
+    'hn_daily.md': 'HackerNews',
+    'freight_daily.md': '货代动态',
+    'openclaw_official.md': 'OpenClaw更新',
+}
+output = []
+# 生成最近N天的日期字符串用于匹配
+date_patterns = []
+for i in range(days):
+    d = (datetime.now() - timedelta(days=i))
+    date_patterns.append(d.strftime('%Y-%m-%d'))
+    date_patterns.append(d.strftime('%Y%m%d'))
+
+for filename, label in sources.items():
+    path = os.path.join(kb_dir, 'sources', filename)
+    if not os.path.isfile(path):
+        continue
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError:
+        continue
+    # 提取包含最近日期的段落
+    relevant = []
+    for line in lines:
+        if any(dp in line for dp in date_patterns):
+            relevant.append(line.rstrip())
+            # 也收集后续几行作为上下文
+    if relevant:
+        text = '\n'.join(relevant[:30])[:MAX_PER_SOURCE]
+        output.append(f"### {label}\n{text}")
+
+print('\n\n'.join(output) if output else '（本期无来源归档更新）')
+PYEOF
+)
+
+# ── 4. 调用 LLM 进行跨领域深度分析 ──
+PROMPT="你是一位知识管理专家和技术趋势分析师。以下是用户知识库中最近 ${DAYS} 天的内容。
+请完成以下分析（用中文回答，总字数控制在 600 字以内）：
+
+1. **本期亮点**（3-5个要点）：最值得关注的信息，说明为什么重要
+2. **跨领域关联**（2-3条）：不同来源之间的联系（如 ArXiv 论文趋势 + HN 讨论热点 = 行业信号）
+3. **行动建议**（2-3条）：基于这些信息，用户应该关注或尝试什么
+4. **知识空白**（1-2条）：这些信息没有覆盖到但可能重要的领域
+
+═══ 笔记内容 ═══
+${NOTES_CONTENT}
+
+═══ 来源归档 ═══
+${SOURCES_CONTENT}
+
+═══ 统计信息 ═══
+知识库总条目: ${INDEX_TOTAL} 条
+本期笔记: ${NOTE_COUNT} 篇
+活跃标签: ${THEMES}"
+
+log "开始 LLM 深度分析（${DAYS} 天回顾）..."
+
+# 规则 #27: 纯推理直接 curl proxy:5002
+LLM_RESULT=$(curl -sS --max-time 60 http://localhost:5002/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d "$(python3 -c "
+import json, sys
+prompt = sys.stdin.read()
+print(json.dumps({
+    'model': 'any',
+    'messages': [{'role': 'user', 'content': prompt}],
+    'max_tokens': 1000
+}))
+" <<< "$PROMPT")" 2>/dev/null \
+    | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    print(data['choices'][0]['message']['content'])
+except:
+    print('')
+" 2>/dev/null || true)
+
+# Fallback：LLM 失败时用基础统计
+if [ -z "${LLM_RESULT// }" ]; then
+    log "WARN: LLM 分析失败，使用基础统计模式"
+    LLM_RESULT="（LLM 分析不可用，以下为基础统计）
+
+## 本期亮点
+- 知识库共 ${INDEX_TOTAL} 条记录，最新 ${NOTE_COUNT} 篇
+- 活跃标签：${THEMES}
+
+## 行动建议
+- 建议手动查阅来源归档，关注跨领域信息
+- 使用 \`bash kb_search.sh --days ${DAYS}\` 浏览近期内容"
+fi
+
+# ── 5. 生成回顾文件 ──
+NOTES_LIST=$(for f in $(ls -t "$KB_DIR/notes/"*.md 2>/dev/null | head -10); do
     echo "- $(basename "$f"): $(head -5 "$f" | { grep -v '^---' || true; } | { grep -v '^#' || true; } | head -1)"
 done || true)
 
@@ -43,31 +197,49 @@ cat > "$REVIEW_FILE" << MDEOF
 date: ${DATE}
 type: review
 period: ${DAYS}days
+llm_analyzed: true
 ---
 
-# 知识回顾 ${DATE}
+# 知识回顾 ${DATE}（最近 ${DAYS} 天）
 
-## 本期主题
-${THEMES}
-
-## 知识连接
+## 基础统计
 - 知识库共 ${INDEX_TOTAL} 条记录
-- 最活跃标签：${THEMES}
+- 活跃标签：${THEMES}
 
-## 本期笔记
-${NOTES_TEXT}
+## LLM 深度分析
 
-## 综合洞见
-- 基于最新 ${NOTE_COUNT} 条笔记的自动归档回顾
-- 建议关注跨领域知识点的连接
+${LLM_RESULT}
 
-## 知识空白
-- 待人工补充深度洞见
+## 本期笔记（最近 10 篇）
+${NOTES_LIST}
 MDEOF
 
-# ── rsync备份 ────────────────────────────────────────────────────────
+log "回顾文件已生成: $REVIEW_FILE"
+
+# ── 6. 推送 WhatsApp ──
+# 截取 LLM 分析的前 500 字作为推送（WhatsApp 消息不宜过长）
+LLM_SHORT=$(echo "$LLM_RESULT" | head -30 | cut -c1-500)
+WA_MSG="📚 知识回顾 ${DATE}（${DAYS}天）
+📊 总条目: ${INDEX_TOTAL} | 本期: ${NOTE_COUNT} 篇
+🏷️ 热门: ${THEMES}
+
+${LLM_SHORT}
+
+📄 详见: ${REVIEW_FILE}"
+
+SEND_ERR=$(mktemp)
+if openclaw message send --target "$PHONE" --message "$WA_MSG" --json >/dev/null 2>"$SEND_ERR"; then
+    log "回顾已推送 WhatsApp"
+    printf '{"time":"%s","status":"ok","notes":%d,"llm":true}\n' "$TS" "$NOTE_COUNT" > "$STATUS_FILE"
+else
+    log "ERROR: WhatsApp 推送失败: $(head -3 "$SEND_ERR" 2>/dev/null)"
+    printf '{"time":"%s","status":"send_failed","notes":%d,"llm":true}\n' "$TS" "$NOTE_COUNT" > "$STATUS_FILE"
+fi
+rm -f "$SEND_ERR"
+
+# ── 7. rsync 备份 ──
 rsync -a --quiet "$KB_DIR/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true
 
-echo "[kb_review] 知识回顾 ${DATE} | 主题：${THEMES}"
-echo "[kb_review] 知识库共 ${INDEX_TOTAL} 条，最新 ${NOTE_COUNT} 篇已归档"
-echo "[kb_review] 回顾文件：${REVIEW_FILE}"
+log "知识回顾 ${DATE} | 主题：${THEMES} | LLM分析：✓"
+log "知识库共 ${INDEX_TOTAL} 条，最新 ${NOTE_COUNT} 篇"
+log "回顾文件：${REVIEW_FILE}"

--- a/kb_search.sh
+++ b/kb_search.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+# kb_search.sh — KB 按需查询工具
+# 用法：
+#   bash kb_search.sh "关键词"              # 全文搜索
+#   bash kb_search.sh --tag "arxiv"         # 按 tag 过滤
+#   bash kb_search.sh --days 7              # 最近 N 天
+#   bash kb_search.sh --days 3 "RAG"        # 组合：最近3天 + 关键词
+#   bash kb_search.sh --source arxiv        # 按来源文件搜索（arxiv/hn/freight/openclaw）
+#   bash kb_search.sh --summary             # 当前 KB 统计概览
+
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+
+KB_DIR="${KB_BASE:-/Users/bisdom/.kb}"
+INDEX="$KB_DIR/index.json"
+
+# ── 颜色 ──
+BOLD="\033[1m"
+DIM="\033[2m"
+CYAN="\033[36m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+RESET="\033[0m"
+
+usage() {
+    cat << 'EOF'
+用法: bash kb_search.sh [选项] [关键词]
+
+选项:
+  --tag TAG        按标签过滤（支持部分匹配）
+  --days N         只看最近 N 天的条目
+  --source NAME    搜索来源文件（arxiv/hn/freight/openclaw）
+  --summary        显示 KB 统计概览
+  --limit N        最多显示 N 条结果（默认 20）
+  -h, --help       显示帮助
+
+示例:
+  bash kb_search.sh "RAG"
+  bash kb_search.sh --tag arxiv --days 7
+  bash kb_search.sh --source hn --days 3
+  bash kb_search.sh --summary
+EOF
+    exit 0
+}
+
+# ── 参数解析 ──
+MODE="search"
+KEYWORD=""
+TAG_FILTER=""
+DAYS_FILTER=""
+SOURCE_FILTER=""
+LIMIT=20
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)     TAG_FILTER="$2"; shift 2 ;;
+        --days)    DAYS_FILTER="$2"; shift 2 ;;
+        --source)  SOURCE_FILTER="$2"; MODE="source"; shift 2 ;;
+        --summary) MODE="summary"; shift ;;
+        --limit)   LIMIT="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        -*)        echo "未知选项: $1"; usage ;;
+        *)         KEYWORD="$1"; shift ;;
+    esac
+done
+
+# ── 统计概览 ──
+if [ "$MODE" = "summary" ]; then
+    echo -e "${BOLD}═══ KB 统计概览 ═══${RESET}"
+
+    # 总条目数
+    TOTAL=0
+    if [ -f "$INDEX" ]; then
+        TOTAL=$(python3 -c "
+import json
+try:
+    with open('$INDEX') as f:
+        print(len(json.load(f).get('entries', [])))
+except: print(0)
+")
+    fi
+
+    # notes 文件数
+    NOTE_COUNT=$(ls "$KB_DIR/notes/"*.md 2>/dev/null | wc -l | tr -d ' ')
+
+    # sources 文件列表和大小
+    echo -e "\n${CYAN}索引条目:${RESET} $TOTAL 条"
+    echo -e "${CYAN}笔记文件:${RESET} $NOTE_COUNT 篇"
+
+    echo -e "\n${BOLD}来源归档:${RESET}"
+    for src in "$KB_DIR/sources/"*.md; do
+        [ -f "$src" ] || continue
+        NAME=$(basename "$src" .md)
+        LINES=$(wc -l < "$src" | tr -d ' ')
+        SIZE=$(du -h "$src" | cut -f1 | tr -d ' ')
+        echo -e "  ${GREEN}$NAME${RESET}: ${LINES} 行 (${SIZE})"
+    done
+
+    # 热门 tags
+    if [ -f "$INDEX" ]; then
+        echo -e "\n${BOLD}热门标签 (Top 10):${RESET}"
+        python3 - "$INDEX" << 'PYEOF'
+import json, sys
+from collections import Counter
+try:
+    with open(sys.argv[1]) as f:
+        entries = json.load(f).get('entries', [])
+    tags = Counter()
+    for e in entries:
+        tags.update(e.get('tags', []))
+    for tag, count in tags.most_common(10):
+        print(f"  {tag}: {count} 条")
+except: pass
+PYEOF
+    fi
+
+    # 最近 7 天活跃度
+    echo -e "\n${BOLD}最近 7 天:${RESET}"
+    for i in $(seq 0 6); do
+        D=$(date -v-${i}d +%Y%m%d 2>/dev/null || date -d "-${i} days" +%Y%m%d 2>/dev/null)
+        COUNT=$(ls "$KB_DIR/notes/${D}"*.md 2>/dev/null | wc -l | tr -d ' ')
+        BAR=$(printf '%*s' "$COUNT" '' | tr ' ' '█')
+        echo -e "  ${DIM}$D${RESET}: ${COUNT} 条 ${GREEN}${BAR}${RESET}"
+    done
+    exit 0
+fi
+
+# ── 来源文件搜索 ──
+if [ "$MODE" = "source" ]; then
+    # 映射简写到文件名
+    case "$SOURCE_FILTER" in
+        arxiv)    SRC_FILE="$KB_DIR/sources/arxiv_daily.md" ;;
+        hn)       SRC_FILE="$KB_DIR/sources/hn_daily.md" ;;
+        freight)  SRC_FILE="$KB_DIR/sources/freight_daily.md" ;;
+        openclaw) SRC_FILE="$KB_DIR/sources/openclaw_official.md" ;;
+        *)        SRC_FILE="$KB_DIR/sources/${SOURCE_FILTER}.md" ;;
+    esac
+
+    if [ ! -f "$SRC_FILE" ]; then
+        echo "来源文件不存在: $SRC_FILE"
+        echo "可用来源: $(ls "$KB_DIR/sources/"*.md 2>/dev/null | xargs -I{} basename {} .md | tr '\n' ' ')"
+        exit 1
+    fi
+
+    echo -e "${BOLD}═══ 来源: $(basename "$SRC_FILE" .md) ═══${RESET}\n"
+
+    if [ -n "$DAYS_FILTER" ]; then
+        # 按日期过滤：提取最近N天的日期段
+        DATES=""
+        for i in $(seq 0 $((DAYS_FILTER - 1))); do
+            D=$(date -v-${i}d +%Y-%m-%d 2>/dev/null || date -d "-${i} days" +%Y-%m-%d 2>/dev/null)
+            DATES="$DATES|$D"
+        done
+        DATES="${DATES:1}"  # 去掉开头的 |
+        grep -E "$DATES" "$SRC_FILE" -A 5 | head -"$((LIMIT * 6))" || echo "（无匹配）"
+    elif [ -n "$KEYWORD" ]; then
+        grep -i "$KEYWORD" "$SRC_FILE" -B 1 -A 3 | head -"$((LIMIT * 5))" || echo "（无匹配）"
+    else
+        # 默认显示最后 N 段
+        tail -"$((LIMIT * 5))" "$SRC_FILE"
+    fi
+    exit 0
+fi
+
+# ── 全文搜索（index.json + notes/） ──
+echo -e "${BOLD}═══ KB 搜索 ═══${RESET}"
+[ -n "$KEYWORD" ] && echo -e "关键词: ${CYAN}$KEYWORD${RESET}"
+[ -n "$TAG_FILTER" ] && echo -e "标签: ${CYAN}$TAG_FILTER${RESET}"
+[ -n "$DAYS_FILTER" ] && echo -e "时间: ${CYAN}最近 $DAYS_FILTER 天${RESET}"
+echo ""
+
+# 先从 index.json 搜索（快速）
+RESULTS=$(python3 - "$INDEX" "$KEYWORD" "$TAG_FILTER" "$DAYS_FILTER" "$LIMIT" << 'PYEOF'
+import json, sys
+from datetime import datetime, timedelta
+
+index_path, keyword, tag_filter, days_str, limit_str = sys.argv[1:6]
+limit = int(limit_str)
+
+try:
+    with open(index_path) as f:
+        entries = json.load(f).get('entries', [])
+except (OSError, json.JSONDecodeError):
+    entries = []
+
+# 日期过滤
+if days_str:
+    cutoff = (datetime.now() - timedelta(days=int(days_str))).strftime('%Y%m%d')
+    entries = [e for e in entries if e.get('date', '') >= cutoff]
+
+# 标签过滤
+if tag_filter:
+    tag_lower = tag_filter.lower()
+    entries = [e for e in entries
+               if any(tag_lower in t.lower() for t in e.get('tags', []))]
+
+# 关键词过滤（匹配 summary）
+if keyword:
+    kw_lower = keyword.lower()
+    entries = [e for e in entries if kw_lower in e.get('summary', '').lower()]
+
+# 输出
+count = 0
+for e in entries[:limit]:
+    date = e.get('date', '?')
+    tags = ', '.join(e.get('tags', []))
+    summary = e.get('summary', '')[:80]
+    fpath = e.get('file', '')
+    print(f"DATE:{date}|TAGS:{tags}|SUMMARY:{summary}|FILE:{fpath}")
+    count += 1
+
+if count == 0 and not keyword:
+    print("NO_RESULTS")
+PYEOF
+)
+
+INDEX_COUNT=0
+if [ -n "$RESULTS" ] && [ "$RESULTS" != "NO_RESULTS" ]; then
+    while IFS= read -r line; do
+        DATE=$(echo "$line" | sed 's/DATE:\([^|]*\).*/\1/')
+        TAGS=$(echo "$line" | sed 's/.*TAGS:\([^|]*\).*/\1/')
+        SUMMARY=$(echo "$line" | sed 's/.*SUMMARY:\([^|]*\).*/\1/')
+        FILE=$(echo "$line" | sed 's/.*FILE:\(.*\)/\1/')
+        echo -e "${DIM}$DATE${RESET} ${YELLOW}[$TAGS]${RESET} $SUMMARY"
+        echo -e "  ${DIM}→ $FILE${RESET}"
+        INDEX_COUNT=$((INDEX_COUNT + 1))
+    done <<< "$RESULTS"
+fi
+
+# 如果有关键词，也搜索 notes 文件内容（深度搜索）
+if [ -n "$KEYWORD" ]; then
+    echo -e "\n${BOLD}── 笔记全文匹配 ──${RESET}"
+    FILE_LIST=""
+    if [ -n "$DAYS_FILTER" ]; then
+        for i in $(seq 0 $((DAYS_FILTER - 1))); do
+            D=$(date -v-${i}d +%Y%m%d 2>/dev/null || date -d "-${i} days" +%Y%m%d 2>/dev/null)
+            FILE_LIST="$FILE_LIST $(ls "$KB_DIR/notes/${D}"*.md 2>/dev/null || true)"
+        done
+    else
+        FILE_LIST=$(ls -t "$KB_DIR/notes/"*.md 2>/dev/null | head -200)
+    fi
+
+    GREP_COUNT=0
+    if [ -n "$FILE_LIST" ]; then
+        for f in $FILE_LIST; do
+            if grep -qli "$KEYWORD" "$f" 2>/dev/null; then
+                MATCH=$(grep -i "$KEYWORD" "$f" | head -1 | cut -c1-100)
+                echo -e "${GREEN}$(basename "$f")${RESET}: $MATCH"
+                GREP_COUNT=$((GREP_COUNT + 1))
+                [ "$GREP_COUNT" -ge "$LIMIT" ] && break
+            fi
+        done
+    fi
+
+    # 搜索 sources 归档
+    echo -e "\n${BOLD}── 来源归档匹配 ──${RESET}"
+    for src in "$KB_DIR/sources/"*.md; do
+        [ -f "$src" ] || continue
+        MATCH_COUNT=$(grep -ci "$KEYWORD" "$src" 2>/dev/null || echo 0)
+        if [ "$MATCH_COUNT" -gt 0 ]; then
+            echo -e "${GREEN}$(basename "$src")${RESET}: ${MATCH_COUNT} 处匹配"
+            grep -i "$KEYWORD" "$src" -m 3 | while IFS= read -r line; do
+                echo -e "  ${DIM}${line:0:120}${RESET}"
+            done
+        fi
+    done
+
+    TOTAL=$((INDEX_COUNT + GREP_COUNT))
+    echo -e "\n${BOLD}共找到 $TOTAL 条相关结果${RESET}"
+else
+    echo -e "\n${BOLD}共 $INDEX_COUNT 条结果${RESET}"
+fi


### PR DESCRIPTION
方案3: kb_search.sh — 按需查询工具
  - 全文搜索（关键词/标签/天数/来源，可组合）
  - --summary 统计概览（条目数、来源大小、热门标签、7天活跃度）
  - --source 搜索来源归档（arxiv/hn/freight/openclaw）

方案2: kb_review.sh 升级为 LLM 深度分析
  - 收集最近N天的 notes + sources 完整内容
  - 直接 curl proxy:5002 调 LLM 跨领域分析
  - 输出：本期亮点、跨领域关联、行动建议、知识空白
  - 分析结果推送 WhatsApp + 写入 KB review 文件
  - LLM 失败时 graceful fallback 到基础统计

方案1: kb_inject.sh — 每日 KB 摘要生成
  - 每天 07:00 生成 ~/.kb/daily_digest.md
  - 提取最近3天 notes 精华 + sources 归档关键段落
  - LLM 对话时可通过 read 工具查阅，实现知识库可查
  - Python 一次性处理，高效生成

配套变更:
  - jobs_registry.yaml: 新增 kb_inject 任务，kb_review 改为 system cron
  - auto_deploy.sh: FILE_MAP 新增 kb_search.sh + kb_inject.sh

https://claude.ai/code/session_015MvcCjuMLMFrndBMf4HnXQ