### PR TITLE
docs: V29 收工文档同步 — KB三件套变更记录

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — openclaw-model-bridge 项目背景
 
-> 每次新会话开始时自动读取。当前版本：v28.3（2026-03-13）
+> 每次新会话开始时自动读取。当前版本：v29（2026-03-13）
 
 ---
 
@@ -36,7 +36,8 @@
 │  每天    OpenClaw Releases ──→ LLM富摘要 + KB写入 + WhatsApp推送                     │
 │  每小时  Issues监控 ──→ KB写入 + WhatsApp推送                                        │
 │  每天    KB晚间整理                                                                  │
-│  每周    KB跨笔记回顾                                                                │
+│  每天    KB每日摘要 ──→ ~/.kb/daily_digest.md（LLM对话时可查）                          │
+│  每周    KB跨笔记回顾 ──→ LLM深度分析 + WhatsApp推送                                   │
 │  每周    健康周报 ──→ WhatsApp推送                                                    │
 └─────────────────────────────────────────────────────────────────────────────────────┘
                                        │
@@ -55,7 +56,7 @@
 │  GitHub (main) ──→ auto_deploy.sh (每2min轮询)                                      │
 │                     ├─ git fetch + pull                                              │
 │                     ├─ 单测验证（proxy_filters变更时）                                 │
-│                     ├─ 文件同步（仓库→运行时，17个文件映射）                            │
+│                     ├─ 文件同步（仓库→运行时，19个文件映射）                            │
 │                     ├─ 每小时漂移检测（md5全量比对）                                   │
 │                     ├─ 按需restart（核心服务文件变更时）                                │
 │                     └─ preflight_check.sh --full（部署后自动体检 11项）                │
@@ -96,7 +97,9 @@
 | `restart.sh` | 一键重启 Proxy + Adapter + Gateway（含 PATH 修复，可在 cron 环境使用） |
 | `health_check.sh` | 每周健康周报脚本（V27: +JSON输出） |
 | `kb_write.sh` | KB写入脚本（含目录锁+原子写） |
-| `kb_review.sh` | KB跨笔记回顾脚本 |
+| `kb_review.sh` | **V29升级** KB跨笔记回顾（LLM深度分析+WhatsApp推送） |
+| `kb_search.sh` | **V29新增** KB按需查询工具（关键词/标签/来源/统计概览） |
+| `kb_inject.sh` | **V29新增** 每日KB摘要生成（~/.kb/daily_digest.md，供LLM对话查阅） |
 | `kb_save_arxiv.sh` | ArXiv监控结果写入KB + rsync备份 |
 | `auto_deploy.sh` | **V27.1新增** 仓库→部署自动同步 + 漂移检测（md5全量比对+WhatsApp告警） |
 | `test_tool_proxy.py` | proxy_filters 单测（43个用例） |
@@ -165,6 +168,15 @@
 2. **每次必查原则扩展至 7 条**：新增第 1 条"开工刷新 OpenClaw 架构"，原 1-6 顺延为 2-7
 3. **每日文档刷新范围扩展**：`docs/openclaw_architecture.md` 加入开工/收工强制 read→write 循环
 
+## V29 变更摘要（2026-03-13）
+
+1. **KB 搜索工具**：`kb_search.sh` 支持全文搜索（关键词/标签/天数/来源组合）、`--summary` 统计概览（条目数/来源大小/热门标签/7天活跃度）、`--source` 来源归档搜索
+2. **KB 回顾升级为 LLM 深度分析**：`kb_review.sh` 收集最近N天的 notes + sources 完整内容 → curl proxy:5002 调 LLM 跨领域分析（亮点/关联/行动建议/知识空白） → 推送 WhatsApp + 写入 review 文件；LLM 失败时 graceful fallback
+3. **KB 每日摘要**：`kb_inject.sh` 每天 07:00 生成 `~/.kb/daily_digest.md`（notes 精华 + sources 关键段），LLM 对话时通过 read 工具查阅
+4. **WhatsApp LLM 自动查 KB**：workspace CLAUDE.md 添加知识库查询指引，用户问"最近有什么新论文"等问题时 LLM 自动读取 daily_digest.md 回答
+5. **kb_review.sh 从 openclaw cron 改为 system cron**：直接 curl 调 LLM 分析，不再依赖 openclaw agent
+6. **auto_deploy.sh FILE_MAP 扩展至 19 个文件**：新增 kb_search.sh + kb_inject.sh
+
 ## 常用命令
 
 ```bash
@@ -192,6 +204,12 @@ bash smoke_test.sh
 bash preflight_check.sh
 # 收工前全面体检（Mac Mini，含部署一致性+环境变量+连通性）
 bash preflight_check.sh --full
+
+# KB 搜索 / 摘要
+bash kb_search.sh "关键词"         # 全文搜索
+bash kb_search.sh --summary        # 统计概览
+bash kb_search.sh --source arxiv   # 搜索来源归档
+bash kb_inject.sh                  # 手动生成每日摘要
 
 # 生成任务文档 / 检测文档漂移
 python3 gen_jobs_doc.py           # 输出 markdown 表格
@@ -289,6 +307,7 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 | ✅ | Blog中文标题升级为LLM动态生成 |
 | ✅ | WhatsApp target号码统一为 OPENCLAW_PHONE |
 | 低 | 探索Claude/GPT-4o替换Qwen3 |
+| ✅ | KB三件套：搜索/LLM深度回顾/每日摘要注入（V29） |
 
 ## 远程连接（本机）
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,7 +1,7 @@
 # OpenClaw 完整配置文档
 > 最后更新：2026-03-12 (HKT)
 > 系统：Mac Mini (macOS) | 用户：bisdom
-> 版本：v28.3（V28基础上：健康端点修复、全面体检系统、自动部署后体检、架构重构、OpenClaw架构文档、开工流程扩展）
+> 版本：v29（V28基础上：健康端点修复、全面体检系统、自动部署后体检、架构重构、OpenClaw架构文档、KB三件套）
 > OpenClaw Gateway：2026.3.7（2026-03-08升级）
 ---
 ## 一、系统架构（V28.1 四层架构）
@@ -31,7 +31,8 @@
 │  每天    OpenClaw Releases ──→ LLM富摘要 + KB写入 + WhatsApp推送                     │
 │  每小时  Issues监控 ──→ KB写入 + WhatsApp推送                                        │
 │  每天    KB晚间整理                                                                  │
-│  每周    KB跨笔记回顾                                                                │
+│  每天    KB每日摘要 ──→ ~/.kb/daily_digest.md（LLM对话时可查）                          │
+│  每周    KB跨笔记回顾 ──→ LLM深度分析 + WhatsApp推送                                   │
 │  每周    健康周报 ──→ WhatsApp推送                                                    │
 └─────────────────────────────────────────────────────────────────────────────────────┘
                                        │
@@ -106,7 +107,9 @@
 | 注册表校验器 | ~/openclaw-model-bridge/check_registry.py | **V27新增** 校验ID唯一/路径存在/字段完整 |
 | 回滚指南 | ~/openclaw-model-bridge/ROLLBACK.md | **V27新增** 30秒恢复到V26 |
 | KB写入脚本 | ~/kb_write.sh | KB记录执行脚本（v18已加目录锁+原子写） |
-| KB回顾脚本 | ~/kb_review.sh | KB跨笔记回顾脚本 |
+| KB回顾脚本 | ~/kb_review.sh | **V29升级：LLM深度分析+WhatsApp推送** |
+| **KB搜索工具** | **~/kb_search.sh** | **V29新增：按需查询（关键词/标签/来源/统计概览）** |
+| **KB每日摘要** | **~/kb_inject.sh** | **V29新增：每日07:00生成~/.kb/daily_digest.md，供LLM对话查阅** |
 | ~~ArXiv KB归档脚本~~ | ~~~/kb_save_arxiv.sh~~ | ~~已废弃（V28: 功能合并到 arxiv_monitor）~~ |
 | **ArXiv AI论文监控** | **~/.openclaw/jobs/arxiv_monitor/run_arxiv.sh** | **V28新增：ArXiv论文监控 + KB写入 + rsync备份（合并原 monitor-arxiv-ai-models + kb-save-arxiv）** |
 | **每周健康检查脚本** | **~/health_check.sh** | **系统健康周报脚本（v16新增）** |
@@ -241,6 +244,7 @@ export OPENCLAW_PHONE="+85200000000"
 | kb-evening | 每天22:00 | `kb_evening.sh` | `~/kb_evening.log` | ✅ 晚间 KB 整理 |
 | session-cleanup | 每6小时 04/10/16/22:00 | 直接rm命令（无脚本） | `~/.openclaw/logs/session_cleanup.log` | ✅ v24变更：从每天1次→每6小时1次 |
 | wa-keepalive | 每30分钟 | `~/wa_keepalive.sh` | `~/wa_keepalive.log` | ✅ V28.1新增：真实发送零宽字符验证WhatsApp通道 |
+| kb-inject | 每天07:00 | `~/kb_inject.sh` | `~/kb_inject.log` | ✅ V29新增：每日KB摘要生成，供LLM对话查阅 |
 | auto-deploy | 每2分钟 | `~/openclaw-model-bridge/auto_deploy.sh` | `~/.openclaw/logs/auto_deploy.log` | ✅ V27.1新增+V28.1：部署后自动体检 |
 | gateway-watchdog | ~~每30分钟~~ | `~/restart.sh` | `~/.openclaw/logs/gateway_watchdog.log` | ❌ **已移除**（#95：与launchd KeepAlive双主控冲突，导致误杀gateway） |
 
@@ -255,6 +259,7 @@ export OPENCLAW_PHONE="+85200000000"
 0 */3 * * * mkdir -p $HOME/.openclaw/logs/jobs; bash -lc '$HOME/.openclaw/jobs/arxiv_monitor/run_arxiv.sh >> $HOME/.openclaw/logs/jobs/arxiv_monitor.log 2>&1'
 30 * * * * bash -lc '$HOME/openclaw-model-bridge/job_watchdog.sh >> $HOME/job_watchdog.log 2>&1'
 */30 * * * * bash -lc '$HOME/wa_keepalive.sh >> $HOME/wa_keepalive.log 2>&1'
+0 7 * * * bash ~/kb_inject.sh >> ~/kb_inject.log 2>&1
 */2 * * * * bash -lc 'bash $HOME/openclaw-model-bridge/auto_deploy.sh >> $HOME/.openclaw/logs/auto_deploy.log 2>&1'
 ```
 > 💡 **架构说明**：系统crontab用`bash -lc`加载完整登录环境（含`$HOME`、`$PATH`等环境变量），避免cron空环境导致命令找不到。创建日志目录前置在`mkdir -p`确保首次运行不失败。
@@ -536,6 +541,7 @@ GitHub SSH Key：`~/.ssh/id_ed25519`（2026-02-28添加到 github.com/settings/s
 │   ├── openclaw_official.md                               ← Releases+Blog永久归档
 │   ├── hn_daily.md                                        ← HN Watcher归档
 │   └── freight_daily.md                                   ← 货代Watcher归档（v26新增）
+├── daily_digest.md  每日KB摘要（V29新增）                   ← kb_inject.sh 每日07:00生成，LLM对话查阅
 ├── inbox.md     Watcher去重列表（v20新增，URL为唯一键）      ← Official Watcher写入
 └── index.json   主索引                                     ← kb_write.sh维护
 备份（外挂SSD，每次kb-save-arxiv执行后自动同步）：
@@ -757,6 +763,10 @@ nohup python3 ~/adapter.py > ~/adapter.log 2>&1 &
 | ✅ | V28.1 auto_deploy.sh 部署后自动体检 + WhatsApp告警 | 完成 |
 | ✅ | V28.1 环境变量同步到 ~/.bash_profile（cron环境修复） | 完成 |
 | ✅ | V28.1 四层架构图文档化 | 完成 |
+| ✅ | V29 KB搜索工具（kb_search.sh） | 完成 |
+| ✅ | V29 KB回顾升级为LLM深度分析（kb_review.sh） | 完成 |
+| ✅ | V29 KB每日摘要生成（kb_inject.sh） | 完成 |
+| ✅ | V29 WhatsApp LLM自动查KB（workspace CLAUDE.md指引） | 完成 |
 | 低 | 探索Claude/GPT-4o替换Qwen3 | ⏳ |
 ---
 ## 十九、工作原则（工作宪法）


### PR DESCRIPTION
CLAUDE.md:
  - 版本升至 v29
  - 新增 V29 变更摘要（6项）
  - 关键文件表新增 kb_search.sh、kb_inject.sh
  - 架构图更新：KB每日摘要 + KB回顾升级
  - FILE_MAP 17→19
  - 常用命令新增 KB 搜索/摘要
  - 待办新增 V29 完成项

docs/config.md:
  - 版本升至 v29
  - 文件清单新增 kb_search.sh、kb_inject.sh、kb_review.sh 升级说明
  - crontab 任务表新增 kb-inject
  - KB 目录结构新增 daily_digest.md
  - 待办新增 V29 四项完成记录

https://claude.ai/code/session_015MvcCjuMLMFrndBMf4HnXQ