### PR TITLE
feat: add token usage report and KB smart dedup

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -113,8 +113,10 @@ declare -a FILE_MAP=(
     "mm_search.py|$HOME/openclaw-model-bridge/mm_search.py"
     "mm_index_cron.sh|$HOME/openclaw-model-bridge/mm_index_cron.sh"
 
-    # 对话质量监控
+    # 监控 & 维护
     "conv_quality.py|$HOME/conv_quality.py"
+    "token_report.py|$HOME/token_report.py"
+    "kb_dedup.py|$HOME/kb_dedup.py"
 
     # 自部署（bootstrapping）
     "auto_deploy.sh|$HOME/openclaw-model-bridge/auto_deploy.sh"

--- a/jobs_registry.yaml
+++ b/jobs_registry.yaml
@@ -164,3 +164,21 @@ jobs:
     needs_api_key: false
     enabled: true
     description: 对话质量日报 — 解析 proxy/adapter 日志，生成响应时间/成功率/工具分布/Token用量报告
+
+  - id: token_report
+    scheduler: system
+    entry: token_report.py
+    interval: "20 8 * * *"          # 每天 08:20（conv_quality 之后5分钟）
+    log: ~/token_report.log
+    needs_api_key: false
+    enabled: true
+    description: Token 用量日报 — 每日消耗总量/逐小时分布/上下文压力/多日趋势
+
+  - id: kb_dedup
+    scheduler: system
+    entry: kb_dedup.py
+    interval: "0 23 * * *"          # 每天 23:00（晚间整理后）
+    log: ~/kb_dedup.log
+    needs_api_key: false
+    enabled: true
+    description: KB 智能去重 — Notes 精确/模糊去重 + Sources 行去重（dry-run 模式，仅报告）

--- a/kb_dedup.py
+++ b/kb_dedup.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""
+kb_dedup.py — KB 智能去重
+扫描 ~/.kb/notes/ 和 ~/.kb/sources/ 中的重复内容，合并或标记。
+
+策略（无外部依赖，纯 Python）：
+  1. Notes 精确去重：index.json 中 summary 完全相同 → 保留最新，删除旧的
+  2. Notes 模糊去重：内容前 200 字相同 → 标记为疑似重复
+  3. Sources 行去重：同一 source 文件中完全重复的行 → 去除
+  4. 统计报告 + WhatsApp 推送
+
+用法：
+  python3 kb_dedup.py              # dry-run（只报告，不删除）
+  python3 kb_dedup.py --apply      # 执行去重（删除重复 notes，去除重复 source 行）
+  python3 kb_dedup.py --stats      # 仅输出统计
+"""
+import os, json, sys, subprocess, hashlib
+from datetime import datetime
+from collections import defaultdict
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+KB_BASE = os.environ.get("KB_BASE", os.path.expanduser("~/.kb"))
+NOTES_DIR = os.path.join(KB_BASE, "notes")
+SOURCES_DIR = os.path.join(KB_BASE, "sources")
+INDEX_FILE = os.path.join(KB_BASE, "index.json")
+REPORT_JSON = os.path.expanduser("~/kb_dedup.json")
+PHONE = os.environ.get("OPENCLAW_PHONE", "+85200000000")
+OPENCLAW = os.environ.get("OPENCLAW", "/opt/homebrew/bin/openclaw")
+
+
+def load_index():
+    """Load KB index.json."""
+    if not os.path.exists(INDEX_FILE):
+        return {"entries": []}
+    try:
+        with open(INDEX_FILE, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {"entries": []}
+
+
+def save_index(data):
+    """Write KB index.json atomically."""
+    tmp = INDEX_FILE + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, INDEX_FILE)
+
+
+def read_note_content(filepath):
+    """Read note file content, skip YAML frontmatter."""
+    full_path = os.path.join(KB_BASE, filepath) if not os.path.isabs(filepath) else filepath
+    if not os.path.exists(full_path):
+        return ""
+    try:
+        with open(full_path, "r", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return ""
+    # Strip YAML frontmatter (between --- markers)
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            text = text[end + 3:].strip()
+    return text
+
+
+def content_hash(text, length=200):
+    """Hash first N chars of content for fuzzy matching."""
+    normalized = " ".join(text[:length].split()).lower()
+    return hashlib.md5(normalized.encode()).hexdigest()
+
+
+def find_duplicate_notes(index):
+    """Find duplicate notes in index.
+    Returns:
+      exact_dupes: list of (kept_entry, removed_entries) — same summary
+      fuzzy_dupes: list of (entry_a, entry_b) — similar content
+    """
+    entries = index.get("entries", [])
+
+    # --- Exact duplicates by summary ---
+    summary_groups = defaultdict(list)
+    for entry in entries:
+        summary = entry.get("summary", "").strip()
+        if summary:
+            summary_groups[summary].append(entry)
+
+    exact_dupes = []
+    for summary, group in summary_groups.items():
+        if len(group) > 1:
+            # Keep the newest (first in index, since index is newest-first)
+            kept = group[0]
+            removed = group[1:]
+            exact_dupes.append((kept, removed))
+
+    # --- Fuzzy duplicates by content hash ---
+    hash_groups = defaultdict(list)
+    for entry in entries:
+        filepath = entry.get("file", "")
+        if not filepath:
+            continue
+        text = read_note_content(filepath)
+        if len(text) < 20:
+            continue
+        h = content_hash(text)
+        hash_groups[h].append((entry, filepath))
+
+    fuzzy_dupes = []
+    for h, group in hash_groups.items():
+        if len(group) > 1:
+            # Check they aren't already in exact_dupes
+            files = {g[1] for g in group}
+            exact_files = set()
+            for kept, removed_list in exact_dupes:
+                for r in removed_list:
+                    exact_files.add(r.get("file", ""))
+            new_files = files - exact_files
+            if len(new_files) > 1:
+                fuzzy_dupes.append([(e, fp) for e, fp in group if fp in new_files])
+
+    return exact_dupes, fuzzy_dupes
+
+
+def find_duplicate_source_lines(sources_dir):
+    """Find duplicate lines within each source file.
+    Returns: dict of {filename: (original_lines, deduped_lines, removed_count)}
+    """
+    results = {}
+    if not os.path.isdir(sources_dir):
+        return results
+
+    for fname in os.listdir(sources_dir):
+        if not fname.endswith(".md"):
+            continue
+        fpath = os.path.join(sources_dir, fname)
+        try:
+            with open(fpath, "r", errors="replace") as f:
+                lines = f.readlines()
+        except OSError:
+            continue
+
+        # Dedup content lines (preserve headers "## YYYY-MM-DD" and empty lines)
+        seen = set()
+        deduped = []
+        removed = 0
+        for line in lines:
+            stripped = line.strip()
+            # Always keep headers, empty lines, and metadata
+            if not stripped or stripped.startswith("##") or stripped.startswith("#"):
+                deduped.append(line)
+                continue
+            if stripped in seen:
+                removed += 1
+                continue
+            seen.add(stripped)
+            deduped.append(line)
+
+        if removed > 0:
+            results[fname] = (lines, deduped, removed)
+
+    return results
+
+
+def apply_note_dedup(exact_dupes, index):
+    """Remove duplicate notes: delete files + remove from index."""
+    removed_files = set()
+    for kept, removed_list in exact_dupes:
+        for entry in removed_list:
+            filepath = entry.get("file", "")
+            full_path = os.path.join(KB_BASE, filepath)
+            if os.path.exists(full_path):
+                os.remove(full_path)
+                removed_files.add(filepath)
+
+    # Rebuild index without removed entries
+    entries = index.get("entries", [])
+    index["entries"] = [e for e in entries if e.get("file", "") not in removed_files]
+    save_index(index)
+    return len(removed_files)
+
+
+def apply_source_dedup(source_results, sources_dir):
+    """Write deduped source files."""
+    for fname, (orig, deduped, count) in source_results.items():
+        fpath = os.path.join(sources_dir, fname)
+        with open(fpath, "w") as f:
+            f.writelines(deduped)
+    return sum(r[2] for r in source_results.values())
+
+
+def generate_stats():
+    """Quick KB stats without dedup analysis."""
+    note_count = 0
+    if os.path.isdir(NOTES_DIR):
+        note_count = len([f for f in os.listdir(NOTES_DIR) if f.endswith(".md")])
+    source_count = 0
+    source_size = 0
+    if os.path.isdir(SOURCES_DIR):
+        for f in os.listdir(SOURCES_DIR):
+            if f.endswith(".md"):
+                source_count += 1
+                source_size += os.path.getsize(os.path.join(SOURCES_DIR, f))
+    index = load_index()
+    index_entries = len(index.get("entries", []))
+    return {
+        "note_files": note_count,
+        "source_files": source_count,
+        "source_size_kb": round(source_size / 1024, 1),
+        "index_entries": index_entries,
+    }
+
+
+def format_report(stats, exact_dupes, fuzzy_dupes, source_results, applied):
+    """Format dedup report for WhatsApp."""
+    lines = [f"🧹 KB 去重报告 {datetime.now().strftime('%Y-%m-%d')}"]
+    lines.append("")
+
+    # Stats
+    lines.append(f"📊 KB 概览：")
+    lines.append(f"   Notes: {stats['note_files']} 个文件 / Index: {stats['index_entries']} 条")
+    lines.append(f"   Sources: {stats['source_files']} 个文件 ({stats['source_size_kb']} KB)")
+
+    # Exact duplicates
+    exact_count = sum(len(r) for _, r in exact_dupes)
+    if exact_count:
+        lines.append("")
+        lines.append(f"🔴 精确重复 Notes: {exact_count} 个")
+        for kept, removed in exact_dupes[:5]:
+            lines.append(f"   [{kept.get('summary', '?')[:40]}] × {len(removed) + 1}")
+        if len(exact_dupes) > 5:
+            lines.append(f"   ... 还有 {len(exact_dupes) - 5} 组")
+
+    # Fuzzy duplicates
+    fuzzy_count = sum(len(g) - 1 for g in fuzzy_dupes) if fuzzy_dupes else 0
+    if fuzzy_count:
+        lines.append("")
+        lines.append(f"🟡 疑似重复 Notes: {fuzzy_count} 个")
+        for group in fuzzy_dupes[:3]:
+            summaries = [e.get("summary", "?")[:30] for e, _ in group]
+            lines.append(f"   [{' ≈ '.join(summaries[:2])}]")
+
+    # Source line dedup
+    source_total = sum(r[2] for r in source_results.values())
+    if source_total:
+        lines.append("")
+        lines.append(f"📄 Sources 重复行: {source_total} 行")
+        for fname, (_, _, count) in sorted(source_results.items(), key=lambda x: -x[1][2])[:5]:
+            lines.append(f"   {fname}: {count} 行重复")
+
+    # Action taken
+    if exact_count == 0 and source_total == 0:
+        lines.append("")
+        lines.append("✅ 无重复，KB 健康")
+    elif applied:
+        lines.append("")
+        lines.append(f"✅ 已清理：{exact_count} 个重复 notes + {source_total} 行重复 source")
+    else:
+        lines.append("")
+        lines.append("💡 运行 `python3 kb_dedup.py --apply` 执行清理")
+
+    return "\n".join(lines)
+
+
+def send_whatsapp(report):
+    """Push report to WhatsApp."""
+    try:
+        result = subprocess.run(
+            [OPENCLAW, "message", "send", "--target", PHONE, "--message", report, "--json"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            print("[kb_dedup] WhatsApp 推送成功")
+        else:
+            print(f"[kb_dedup] ERROR: WhatsApp 推送失败 (exit {result.returncode})")
+    except (OSError, subprocess.TimeoutExpired) as e:
+        print(f"[kb_dedup] ERROR: WhatsApp 推送异常: {e}")
+
+
+def write_json(stats, exact_dupes, fuzzy_dupes, source_results, applied):
+    """Write machine-readable report."""
+    output = {
+        "date": datetime.now().strftime("%Y-%m-%d"),
+        "stats": stats,
+        "exact_duplicates": len(exact_dupes),
+        "exact_duplicate_notes": sum(len(r) for _, r in exact_dupes),
+        "fuzzy_duplicates": len(fuzzy_dupes),
+        "source_duplicate_lines": sum(r[2] for r in source_results.values()),
+        "applied": applied,
+        "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    }
+    try:
+        with open(REPORT_JSON, "w") as f:
+            json.dump(output, f, indent=2, ensure_ascii=False)
+        print(f"[kb_dedup] JSON written to {REPORT_JSON}")
+    except OSError as e:
+        print(f"[kb_dedup] WARN: Failed to write JSON: {e}")
+
+
+def main():
+    apply_mode = "--apply" in sys.argv
+    stats_only = "--stats" in sys.argv
+
+    stats = generate_stats()
+
+    if stats_only:
+        print(json.dumps(stats, indent=2, ensure_ascii=False))
+        return
+
+    print(f"[kb_dedup] Scanning KB at {KB_BASE}")
+    print(f"[kb_dedup] Mode: {'APPLY' if apply_mode else 'DRY-RUN'}")
+
+    index = load_index()
+    exact_dupes, fuzzy_dupes = find_duplicate_notes(index)
+    source_results = find_duplicate_source_lines(SOURCES_DIR)
+
+    applied = False
+    if apply_mode and (exact_dupes or source_results):
+        if exact_dupes:
+            n = apply_note_dedup(exact_dupes, index)
+            print(f"[kb_dedup] Removed {n} duplicate note files")
+        if source_results:
+            n = apply_source_dedup(source_results, SOURCES_DIR)
+            print(f"[kb_dedup] Removed {n} duplicate source lines")
+        applied = True
+
+    report = format_report(stats, exact_dupes, fuzzy_dupes, source_results, applied)
+    print(report)
+
+    write_json(stats, exact_dupes, fuzzy_dupes, source_results, applied)
+
+    total_dupes = sum(len(r) for _, r in exact_dupes) + sum(r[2] for r in source_results.values())
+    if total_dupes > 0:
+        send_whatsapp(report)
+    else:
+        print("[kb_dedup] No duplicates, skipping WhatsApp push")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_kb_dedup.py
+++ b/test_kb_dedup.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""test_kb_dedup.py — kb_dedup.py 单测"""
+import unittest, tempfile, os, json, shutil
+
+_tmpdir = tempfile.mkdtemp()
+_kb_base = os.path.join(_tmpdir, "kb")
+_notes_dir = os.path.join(_kb_base, "notes")
+_sources_dir = os.path.join(_kb_base, "sources")
+_index_file = os.path.join(_kb_base, "index.json")
+
+import kb_dedup
+kb_dedup.KB_BASE = _kb_base
+kb_dedup.NOTES_DIR = _notes_dir
+kb_dedup.SOURCES_DIR = _sources_dir
+kb_dedup.INDEX_FILE = _index_file
+kb_dedup.REPORT_JSON = os.path.join(_tmpdir, "kb_dedup.json")
+
+
+def setup_kb():
+    """Create fresh KB structure."""
+    for d in (_notes_dir, _sources_dir):
+        os.makedirs(d, exist_ok=True)
+
+
+def write_note(filename, content, frontmatter="---\ndate: 20260324\ntags: [test]\n---\n"):
+    """Write a note file."""
+    with open(os.path.join(_notes_dir, filename), "w") as f:
+        f.write(frontmatter + content)
+
+
+def write_index(entries):
+    """Write index.json."""
+    with open(_index_file, "w") as f:
+        json.dump({"entries": entries}, f)
+
+
+def write_source(filename, content):
+    """Write a source file."""
+    with open(os.path.join(_sources_dir, filename), "w") as f:
+        f.write(content)
+
+
+class TestExactDedup(unittest.TestCase):
+
+    def setUp(self):
+        if os.path.exists(_kb_base):
+            shutil.rmtree(_kb_base)
+        setup_kb()
+
+    def test_no_duplicates(self):
+        write_note("20260324100000.md", "# Unique note A")
+        write_note("20260324110000.md", "# Unique note B")
+        write_index([
+            {"date": "20260324", "file": "notes/20260324100000.md", "summary": "Unique note A", "tags": ["test"]},
+            {"date": "20260324", "file": "notes/20260324110000.md", "summary": "Unique note B", "tags": ["test"]},
+        ])
+        index = kb_dedup.load_index()
+        exact, fuzzy = kb_dedup.find_duplicate_notes(index)
+        self.assertEqual(len(exact), 0)
+
+    def test_exact_summary_duplicate(self):
+        write_note("20260324100000.md", "# Same content here")
+        write_note("20260324110000.md", "# Same content here")
+        write_index([
+            {"date": "20260324", "file": "notes/20260324100000.md", "summary": "Same content here", "tags": ["test"]},
+            {"date": "20260324", "file": "notes/20260324110000.md", "summary": "Same content here", "tags": ["test"]},
+        ])
+        index = kb_dedup.load_index()
+        exact, _ = kb_dedup.find_duplicate_notes(index)
+        self.assertEqual(len(exact), 1)
+        kept, removed = exact[0]
+        self.assertEqual(len(removed), 1)
+
+    def test_triple_duplicate(self):
+        for i in range(3):
+            write_note(f"2026032410000{i}.md", "# Triple")
+        write_index([
+            {"date": "20260324", "file": f"notes/2026032410000{i}.md", "summary": "Triple", "tags": ["test"]}
+            for i in range(3)
+        ])
+        index = kb_dedup.load_index()
+        exact, _ = kb_dedup.find_duplicate_notes(index)
+        self.assertEqual(len(exact), 1)
+        self.assertEqual(len(exact[0][1]), 2)  # 2 removed, 1 kept
+
+    def test_apply_removes_files(self):
+        write_note("20260324100000.md", "# Dup A")
+        write_note("20260324110000.md", "# Dup A slightly different body")
+        write_index([
+            {"date": "20260324", "file": "notes/20260324100000.md", "summary": "Dup A", "tags": ["test"]},
+            {"date": "20260324", "file": "notes/20260324110000.md", "summary": "Dup A", "tags": ["test"]},
+        ])
+        index = kb_dedup.load_index()
+        exact, _ = kb_dedup.find_duplicate_notes(index)
+        n = kb_dedup.apply_note_dedup(exact, index)
+        self.assertEqual(n, 1)
+        # First entry kept, second removed
+        self.assertTrue(os.path.exists(os.path.join(_notes_dir, "20260324100000.md")))
+        self.assertFalse(os.path.exists(os.path.join(_notes_dir, "20260324110000.md")))
+        # Index updated
+        updated = kb_dedup.load_index()
+        self.assertEqual(len(updated["entries"]), 1)
+
+
+class TestFuzzyDedup(unittest.TestCase):
+
+    def setUp(self):
+        if os.path.exists(_kb_base):
+            shutil.rmtree(_kb_base)
+        setup_kb()
+
+    def test_similar_content(self):
+        """Notes with same first 200 chars flagged as fuzzy duplicate."""
+        long_text = "This is a long note about AI research " * 10  # >200 chars
+        write_note("20260324100000.md", long_text)
+        write_note("20260324110000.md", long_text + " with extra ending")
+        write_index([
+            {"date": "20260324", "file": "notes/20260324100000.md", "summary": "Note A", "tags": ["test"]},
+            {"date": "20260324", "file": "notes/20260324110000.md", "summary": "Note B", "tags": ["test"]},
+        ])
+        index = kb_dedup.load_index()
+        _, fuzzy = kb_dedup.find_duplicate_notes(index)
+        self.assertGreaterEqual(len(fuzzy), 1)
+
+    def test_different_content(self):
+        write_note("20260324100000.md", "Completely different note about cats " * 10)
+        write_note("20260324110000.md", "Totally unrelated note about dogs " * 10)
+        write_index([
+            {"date": "20260324", "file": "notes/20260324100000.md", "summary": "Cats", "tags": ["test"]},
+            {"date": "20260324", "file": "notes/20260324110000.md", "summary": "Dogs", "tags": ["test"]},
+        ])
+        index = kb_dedup.load_index()
+        _, fuzzy = kb_dedup.find_duplicate_notes(index)
+        self.assertEqual(len(fuzzy), 0)
+
+
+class TestSourceDedup(unittest.TestCase):
+
+    def setUp(self):
+        if os.path.exists(_kb_base):
+            shutil.rmtree(_kb_base)
+        setup_kb()
+
+    def test_no_duplicates(self):
+        write_source("arxiv_daily.md", "## 2026-03-24\n- Paper A\n- Paper B\n")
+        results = kb_dedup.find_duplicate_source_lines(_sources_dir)
+        self.assertEqual(len(results), 0)
+
+    def test_duplicate_lines(self):
+        write_source("arxiv_daily.md",
+            "## 2026-03-24\n- Paper A: description\n- Paper B: desc\n"
+            "## 2026-03-23\n- Paper A: description\n- Paper C: different\n"
+        )
+        results = kb_dedup.find_duplicate_source_lines(_sources_dir)
+        self.assertIn("arxiv_daily.md", results)
+        _, deduped, removed = results["arxiv_daily.md"]
+        self.assertEqual(removed, 1)  # "- Paper A: description" duplicated
+
+    def test_headers_preserved(self):
+        """Date headers and empty lines are never removed."""
+        write_source("test.md",
+            "## 2026-03-24\n\n- Item\n## 2026-03-24\n\n- Item\n"
+        )
+        results = kb_dedup.find_duplicate_source_lines(_sources_dir)
+        if "test.md" in results:
+            _, deduped, removed = results["test.md"]
+            # Headers "## 2026-03-24" should be kept even if repeated
+            header_count = sum(1 for l in deduped if l.strip().startswith("##"))
+            self.assertEqual(header_count, 2)
+
+    def test_apply_source_dedup(self):
+        write_source("hn_daily.md",
+            "## 2026-03-24\n- Post A\n- Post B\n## 2026-03-23\n- Post A\n- Post C\n"
+        )
+        results = kb_dedup.find_duplicate_source_lines(_sources_dir)
+        n = kb_dedup.apply_source_dedup(results, _sources_dir)
+        self.assertEqual(n, 1)
+        # Verify file was rewritten
+        with open(os.path.join(_sources_dir, "hn_daily.md")) as f:
+            content = f.read()
+        self.assertEqual(content.count("- Post A"), 1)  # deduped to 1
+
+
+class TestStats(unittest.TestCase):
+
+    def setUp(self):
+        if os.path.exists(_kb_base):
+            shutil.rmtree(_kb_base)
+        setup_kb()
+
+    def test_empty_kb(self):
+        write_index([])
+        stats = kb_dedup.generate_stats()
+        self.assertEqual(stats["note_files"], 0)
+        self.assertEqual(stats["index_entries"], 0)
+
+    def test_with_data(self):
+        write_note("20260324100000.md", "# Note")
+        write_source("arxiv_daily.md", "data")
+        write_index([{"date": "20260324", "file": "notes/20260324100000.md", "summary": "Note", "tags": []}])
+        stats = kb_dedup.generate_stats()
+        self.assertEqual(stats["note_files"], 1)
+        self.assertEqual(stats["source_files"], 1)
+        self.assertEqual(stats["index_entries"], 1)
+
+
+class TestFormatReport(unittest.TestCase):
+
+    def test_clean_report(self):
+        stats = {"note_files": 10, "source_files": 3, "source_size_kb": 50.0, "index_entries": 10}
+        report = kb_dedup.format_report(stats, [], [], {}, False)
+        self.assertIn("无重复", report)
+        self.assertIn("KB 健康", report)
+
+    def test_report_with_dupes(self):
+        stats = {"note_files": 10, "source_files": 3, "source_size_kb": 50.0, "index_entries": 10}
+        exact = [
+            ({"summary": "Test note"}, [{"summary": "Test note", "file": "notes/old.md"}])
+        ]
+        report = kb_dedup.format_report(stats, exact, [], {}, False)
+        self.assertIn("精确重复", report)
+        self.assertIn("--apply", report)
+
+
+class TestWriteJson(unittest.TestCase):
+
+    def test_json_output(self):
+        if os.path.exists(_kb_base):
+            shutil.rmtree(_kb_base)
+        setup_kb()
+        stats = kb_dedup.generate_stats()
+        kb_dedup.write_json(stats, [], [], {}, False)
+        self.assertTrue(os.path.exists(kb_dedup.REPORT_JSON))
+        with open(kb_dedup.REPORT_JSON) as f:
+            data = json.load(f)
+        self.assertIn("generated_at", data)
+        self.assertEqual(data["exact_duplicates"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_token_report.py
+++ b/test_token_report.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""test_token_report.py — token_report.py 单测"""
+import unittest, tempfile, os, json
+
+_tmpdir = tempfile.mkdtemp()
+_proxy_log = os.path.join(_tmpdir, "tool_proxy.log")
+_history_file = os.path.join(_tmpdir, "token_history.json")
+_report_json = os.path.join(_tmpdir, "token_report.json")
+
+import token_report
+token_report.PROXY_LOG = _proxy_log
+token_report.HISTORY_FILE = _history_file
+token_report.REPORT_JSON = _report_json
+
+DATE = "2026-03-24"
+
+
+def write_log(lines):
+    with open(_proxy_log, "w") as f:
+        for line in lines:
+            f.write(line + "\n")
+
+
+def reset():
+    for p in (_proxy_log, _history_file, _report_json):
+        if os.path.exists(p):
+            os.remove(p)
+
+
+class TestParseTokens(unittest.TestCase):
+
+    def setUp(self):
+        reset()
+
+    def test_no_log(self):
+        self.assertIsNone(token_report.parse_tokens(DATE))
+
+    def test_single_request(self):
+        write_log([
+            f"[proxy] {DATE} 10:05:30 [abc12345] Backend: 200 1500b 350ms stream=True",
+            f"[proxy] {DATE} 10:05:30 [abc12345] TOKENS: prompt=50,000 total=52,000 (19% of 260K)",
+        ])
+        data = token_report.parse_tokens(DATE)
+        self.assertEqual(data["request_count"], 1)
+        self.assertEqual(data["total_prompt_tokens"], 50000)
+        self.assertEqual(data["total_completion_tokens"], 2000)
+        self.assertEqual(data["total_tokens"], 52000)
+        self.assertEqual(data["avg_prompt"], 50000)
+        self.assertEqual(data["peak_hour"], 10)
+
+    def test_multiple_hours(self):
+        write_log([
+            f"[proxy] {DATE} 08:00:00 [r0000001] Backend: 200 1000b 300ms stream=False",
+            f"[proxy] {DATE} 08:00:00 [r0000001] TOKENS: prompt=10,000 total=11,000 (3% of 260K)",
+            f"[proxy] {DATE} 08:30:00 [r0000002] Backend: 200 1000b 300ms stream=False",
+            f"[proxy] {DATE} 08:30:00 [r0000002] TOKENS: prompt=20,000 total=22,000 (7% of 260K)",
+            f"[proxy] {DATE} 14:00:00 [r0000003] Backend: 200 1000b 300ms stream=False",
+            f"[proxy] {DATE} 14:00:00 [r0000003] TOKENS: prompt=5,000 total=6,000 (1% of 260K)",
+        ])
+        data = token_report.parse_tokens(DATE)
+        self.assertEqual(data["request_count"], 3)
+        self.assertEqual(data["total_prompt_tokens"], 35000)
+        # Peak hour: 08 has 33000 total tokens, 14 has 6000
+        self.assertEqual(data["peak_hour"], 8)
+        self.assertEqual(len(data["hourly"]), 2)  # hours 8 and 14
+
+    def test_distribution_buckets(self):
+        write_log([
+            f"[proxy] {DATE} 10:00:00 [r001] Backend: 200 100b 100ms stream=False",
+            f"[proxy] {DATE} 10:00:00 [r001] TOKENS: prompt=5,000 total=6,000 (1% of 260K)",
+            f"[proxy] {DATE} 10:01:00 [r002] Backend: 200 100b 100ms stream=False",
+            f"[proxy] {DATE} 10:01:00 [r002] TOKENS: prompt=30,000 total=31,000 (11% of 260K)",
+            f"[proxy] {DATE} 10:02:00 [r003] Backend: 200 100b 100ms stream=False",
+            f"[proxy] {DATE} 10:02:00 [r003] TOKENS: prompt=80,000 total=82,000 (30% of 260K)",
+            f"[proxy] {DATE} 10:03:00 [r004] Backend: 200 100b 100ms stream=False",
+            f"[proxy] {DATE} 10:03:00 [r004] TOKENS: prompt=150,000 total=155,000 (57% of 260K)",
+        ])
+        data = token_report.parse_tokens(DATE)
+        self.assertEqual(data["distribution"]["<10K"], 1)
+        self.assertEqual(data["distribution"]["10-50K"], 1)
+        self.assertEqual(data["distribution"]["50-100K"], 1)
+        self.assertEqual(data["distribution"]["100K+"], 1)
+
+    def test_context_pressure(self):
+        write_log([
+            f"[proxy] {DATE} 10:00:00 [r001] Backend: 200 100b 100ms stream=False",
+            f"[proxy] {DATE} 10:00:00 [r001] TOKENS: prompt=200,000 total=201,000 (76% of 260K)",
+            f"[proxy] {DATE} 10:01:00 [r002] Backend: 200 100b 100ms stream=False",
+            f"[proxy] {DATE} 10:01:00 [r002] TOKENS: prompt=240,000 total=241,000 (92% of 260K)",
+        ])
+        data = token_report.parse_tokens(DATE)
+        self.assertEqual(data["context_pressure"]["warn_75pct"], 2)  # both >= 195K
+        self.assertEqual(data["context_pressure"]["critical_90pct"], 1)  # only 240K >= 234K
+
+    def test_date_filter(self):
+        write_log([
+            f"[proxy] 2026-03-23 10:00:00 [old001] Backend: 200 100b 100ms stream=False",
+            f"[proxy] 2026-03-23 10:00:00 [old001] TOKENS: prompt=99,999 total=100,000 (38% of 260K)",
+            f"[proxy] {DATE} 10:00:00 [new001] Backend: 200 100b 100ms stream=False",
+            f"[proxy] {DATE} 10:00:00 [new001] TOKENS: prompt=5,000 total=6,000 (1% of 260K)",
+        ])
+        data = token_report.parse_tokens(DATE)
+        self.assertEqual(data["request_count"], 1)
+        self.assertEqual(data["total_prompt_tokens"], 5000)
+
+
+class TestHistory(unittest.TestCase):
+
+    def setUp(self):
+        reset()
+
+    def test_append_creates_file(self):
+        data = {"date": DATE, "request_count": 5, "total_tokens": 100000,
+                "total_prompt_tokens": 80000, "total_completion_tokens": 20000,
+                "avg_prompt": 16000, "max_prompt": 30000, "peak_hour": 10}
+        days = token_report.append_history(data)
+        self.assertEqual(len(days), 1)
+        self.assertTrue(os.path.exists(_history_file))
+
+    def test_idempotent_rerun(self):
+        data = {"date": DATE, "request_count": 5, "total_tokens": 100000,
+                "total_prompt_tokens": 80000, "total_completion_tokens": 20000,
+                "avg_prompt": 16000, "max_prompt": 30000, "peak_hour": 10}
+        token_report.append_history(data)
+        token_report.append_history(data)  # re-run same date
+        history = token_report.load_history()
+        self.assertEqual(len(history["days"]), 1)  # not duplicated
+
+    def test_multi_day(self):
+        for i in range(3):
+            d = f"2026-03-{22+i:02d}"
+            data = {"date": d, "request_count": i+1, "total_tokens": (i+1)*10000,
+                    "total_prompt_tokens": (i+1)*8000, "total_completion_tokens": (i+1)*2000,
+                    "avg_prompt": 8000, "max_prompt": 12000, "peak_hour": 10}
+            token_report.append_history(data)
+        history = token_report.load_history()
+        self.assertEqual(len(history["days"]), 3)
+        # Sorted by date
+        dates = [d["date"] for d in history["days"]]
+        self.assertEqual(dates, sorted(dates))
+
+
+class TestFormatReport(unittest.TestCase):
+
+    def test_basic_report(self):
+        write_log([
+            f"[proxy] {DATE} 10:00:00 [r001] Backend: 200 100b 300ms stream=False",
+            f"[proxy] {DATE} 10:00:00 [r001] TOKENS: prompt=50,000 total=52,000 (19% of 260K)",
+        ])
+        data = token_report.parse_tokens(DATE)
+        report = token_report.format_report(data, None)
+        self.assertIn("52,000 tokens", report)
+        self.assertIn("Prompt: 50,000", report)
+        self.assertIn("Token 日报完毕", report)
+
+    def test_day_over_day(self):
+        write_log([
+            f"[proxy] {DATE} 10:00:00 [r001] Backend: 200 100b 300ms stream=False",
+            f"[proxy] {DATE} 10:00:00 [r001] TOKENS: prompt=50,000 total=52,000 (19% of 260K)",
+        ])
+        data = token_report.parse_tokens(DATE)
+        prev = {"total_tokens": 40000}
+        report = token_report.format_report(data, prev)
+        self.assertIn("+30.0%", report)
+        self.assertIn("昨日 40,000", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/token_report.py
+++ b/token_report.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+token_report.py — Token 用量日报
+解析 tool_proxy.log，生成每日 token 消耗报告 + 追加历史趋势文件。
+
+指标：
+  - 当日 prompt/completion/total tokens 总消耗
+  - 逐小时 token 分布（发现高峰时段）
+  - 单请求 token 分布（<10K / 10-50K / 50-100K / 100K+ 四档）
+  - 上下文压力事件（>75% / >90% 次数）
+  - 与前一天对比（日环比）
+  - 追加到 ~/token_history.json 供趋势分析
+"""
+import os, re, json, sys, subprocess, statistics
+from datetime import datetime, timedelta
+from collections import defaultdict
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+PROXY_LOG = os.path.expanduser("~/tool_proxy.log")
+HISTORY_FILE = os.path.expanduser("~/token_history.json")
+REPORT_JSON = os.path.expanduser("~/token_report.json")
+PHONE = os.environ.get("OPENCLAW_PHONE", "+85200000000")
+OPENCLAW = os.environ.get("OPENCLAW", "/opt/homebrew/bin/openclaw")
+CONTEXT_LIMIT = 260000
+
+# ---------------------------------------------------------------------------
+# Log patterns
+# ---------------------------------------------------------------------------
+# [proxy] 2026-03-24 10:05:30 [abc12345] TOKENS: prompt=12,345 total=13,456 (5% of 260K)
+RE_TOKENS = re.compile(
+    r"\[proxy\] (\d{4}-\d{2}-\d{2}) (\d{2}):\d{2}:\d{2} \[(\w+)\] "
+    r"TOKENS: prompt=([\d,]+) total=([\d,]+)"
+)
+# [proxy] 2026-03-24 10:05:30 [abc12345] Backend: 200 1500b 350ms
+RE_BACKEND = re.compile(
+    r"\[proxy\] (\d{4}-\d{2}-\d{2}) \S+ \[(\w+)\] Backend: 200"
+)
+
+
+def parse_int(s):
+    return int(s.replace(",", ""))
+
+
+def parse_tokens(target_date):
+    """Parse token usage from proxy log for a given date."""
+    hourly_prompt = defaultdict(int)     # hour -> total prompt tokens
+    hourly_total = defaultdict(int)      # hour -> total tokens
+    hourly_requests = defaultdict(int)   # hour -> request count
+    prompt_list = []                     # all prompt_tokens values
+    total_list = []                      # all total_tokens values
+    request_count = 0
+
+    if not os.path.exists(PROXY_LOG):
+        return None
+
+    # Count total successful requests for the date
+    success_rids = set()
+    with open(PROXY_LOG, "r", errors="replace") as f:
+        for line in f:
+            m = RE_BACKEND.search(line)
+            if m and m.group(1) == target_date:
+                success_rids.add(m.group(2))
+
+    with open(PROXY_LOG, "r", errors="replace") as f:
+        for line in f:
+            m = RE_TOKENS.search(line)
+            if not m or m.group(1) != target_date:
+                continue
+
+            hour = int(m.group(2))
+            pt = parse_int(m.group(4))
+            tt = parse_int(m.group(5))
+            completion = tt - pt
+
+            hourly_prompt[hour] += pt
+            hourly_total[hour] += tt
+            hourly_requests[hour] += 1
+            prompt_list.append(pt)
+            total_list.append(tt)
+            request_count += 1
+
+    if request_count == 0:
+        return None
+
+    # Token distribution buckets
+    buckets = {"<10K": 0, "10-50K": 0, "50-100K": 0, "100K+": 0}
+    for pt in prompt_list:
+        if pt < 10000:
+            buckets["<10K"] += 1
+        elif pt < 50000:
+            buckets["10-50K"] += 1
+        elif pt < 100000:
+            buckets["50-100K"] += 1
+        else:
+            buckets["100K+"] += 1
+
+    # Context pressure
+    warn_count = sum(1 for pt in prompt_list if pt >= int(CONTEXT_LIMIT * 0.75))
+    critical_count = sum(1 for pt in prompt_list if pt >= int(CONTEXT_LIMIT * 0.90))
+
+    # Peak hour
+    peak_hour = max(hourly_total, key=hourly_total.get) if hourly_total else 0
+    total_prompt = sum(prompt_list)
+    total_all = sum(total_list)
+    total_completion = total_all - total_prompt
+
+    return {
+        "date": target_date,
+        "request_count": request_count,
+        "total_prompt_tokens": total_prompt,
+        "total_completion_tokens": total_completion,
+        "total_tokens": total_all,
+        "avg_prompt": int(statistics.mean(prompt_list)),
+        "max_prompt": max(prompt_list),
+        "median_prompt": int(statistics.median(prompt_list)),
+        "distribution": buckets,
+        "context_pressure": {"warn_75pct": warn_count, "critical_90pct": critical_count},
+        "peak_hour": peak_hour,
+        "peak_hour_tokens": hourly_total.get(peak_hour, 0),
+        "hourly": {str(h): {"prompt": hourly_prompt[h], "total": hourly_total[h], "requests": hourly_requests[h]}
+                   for h in sorted(hourly_prompt.keys())},
+    }
+
+
+def load_history():
+    """Load historical daily token data."""
+    if os.path.exists(HISTORY_FILE):
+        try:
+            with open(HISTORY_FILE, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"days": []}
+
+
+def save_history(history):
+    """Persist history file."""
+    try:
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(history, f, indent=2, ensure_ascii=False)
+    except OSError as e:
+        print(f"[token_report] WARN: Failed to write history: {e}")
+
+
+def append_history(data):
+    """Append today's summary to history, dedup by date."""
+    history = load_history()
+    days = history["days"]
+
+    # Remove existing entry for same date (idempotent re-run)
+    days = [d for d in days if d.get("date") != data["date"]]
+
+    days.append({
+        "date": data["date"],
+        "requests": data["request_count"],
+        "total_tokens": data["total_tokens"],
+        "total_prompt": data["total_prompt_tokens"],
+        "total_completion": data["total_completion_tokens"],
+        "avg_prompt": data["avg_prompt"],
+        "max_prompt": data["max_prompt"],
+        "peak_hour": data["peak_hour"],
+    })
+
+    # Keep last 90 days
+    days.sort(key=lambda d: d["date"])
+    if len(days) > 90:
+        days = days[-90:]
+
+    history["days"] = days
+    history["updated"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    save_history(history)
+    return days
+
+
+def format_report(data, prev_day):
+    """Format token report for WhatsApp."""
+    lines = [f"🔢 Token 用量日报 {data['date']}"]
+    lines.append("")
+
+    # Totals
+    tp = data["total_prompt_tokens"]
+    tc = data["total_completion_tokens"]
+    tt = data["total_tokens"]
+    lines.append(f"📊 总消耗：{tt:,} tokens（{data['request_count']} 次请求）")
+    lines.append(f"   Prompt: {tp:,}  Completion: {tc:,}")
+
+    # Day-over-day comparison
+    if prev_day:
+        prev_tt = prev_day.get("total_tokens", 0)
+        if prev_tt > 0:
+            change_pct = round((tt - prev_tt) / prev_tt * 100, 1)
+            arrow = "📈" if change_pct > 0 else "📉" if change_pct < 0 else "➡️"
+            lines.append(f"   {arrow} 日环比：{change_pct:+.1f}%（昨日 {prev_tt:,}）")
+
+    # Per-request stats
+    lines.append("")
+    lines.append(f"📋 单请求统计：")
+    lines.append(f"   avg={data['avg_prompt']:,}  median={data['median_prompt']:,}  max={data['max_prompt']:,}")
+
+    # Distribution
+    dist = data["distribution"]
+    lines.append(f"   分布：{dist['<10K']}×<10K  {dist['10-50K']}×10-50K  {dist['50-100K']}×50-100K  {dist['100K+']}×100K+")
+
+    # Peak hour
+    lines.append("")
+    lines.append(f"⏰ 高峰时段：{data['peak_hour']:02d}:00（{data['peak_hour_tokens']:,} tokens）")
+
+    # Context pressure
+    cp = data["context_pressure"]
+    if cp["warn_75pct"] or cp["critical_90pct"]:
+        lines.append("")
+        lines.append(f"⚠️ 上下文压力：")
+        if cp["warn_75pct"]:
+            lines.append(f"   >75% (195K): {cp['warn_75pct']} 次")
+        if cp["critical_90pct"]:
+            lines.append(f"   >90% (234K): {cp['critical_90pct']} 次")
+
+    # Hourly breakdown (compact)
+    hourly = data["hourly"]
+    if len(hourly) > 1:
+        lines.append("")
+        lines.append(f"📊 逐小时（请求数/tokens）：")
+        for h in sorted(hourly.keys(), key=int):
+            hd = hourly[h]
+            bar = "█" * max(1, hd["total"] // (data["total_tokens"] // len(hourly) or 1))
+            lines.append(f"   {int(h):02d}h: {hd['requests']}次 {hd['total']:,}t {bar}")
+
+    lines.append("")
+    lines.append("✅ Token 日报完毕")
+    return "\n".join(lines)
+
+
+def write_json(data):
+    """Write machine-readable report."""
+    output = dict(data)
+    output["generated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        with open(REPORT_JSON, "w") as f:
+            json.dump(output, f, indent=2, ensure_ascii=False)
+        print(f"[token_report] JSON written to {REPORT_JSON}")
+    except OSError as e:
+        print(f"[token_report] WARN: Failed to write JSON: {e}")
+
+
+def send_whatsapp(report):
+    """Push report to WhatsApp."""
+    try:
+        result = subprocess.run(
+            [OPENCLAW, "message", "send", "--target", PHONE, "--message", report, "--json"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            print("[token_report] WhatsApp 推送成功")
+        else:
+            print(f"[token_report] ERROR: WhatsApp 推送失败 (exit {result.returncode})")
+    except (OSError, subprocess.TimeoutExpired) as e:
+        print(f"[token_report] ERROR: WhatsApp 推送异常: {e}")
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--today":
+        target_date = datetime.now().strftime("%Y-%m-%d")
+    elif len(sys.argv) > 1 and re.match(r"\d{4}-\d{2}-\d{2}", sys.argv[1]):
+        target_date = sys.argv[1]
+    else:
+        target_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+
+    print(f"[token_report] Analyzing tokens for {target_date}")
+
+    data = parse_tokens(target_date)
+    if data is None:
+        print("[token_report] No token data found, skipping")
+        return
+
+    # Append to history and get previous day for comparison
+    days = append_history(data)
+    prev_day = None
+    for i, d in enumerate(days):
+        if d["date"] == target_date and i > 0:
+            prev_day = days[i - 1]
+            break
+
+    report = format_report(data, prev_day)
+    print(report)
+    write_json(data)
+    send_whatsapp(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
token_report.py — Daily token consumption report:
- Total prompt/completion/total tokens per day
- Hourly distribution with peak hour detection
- Token bucket distribution (<10K/10-50K/50-100K/100K+)
- Context pressure tracking (>75%/>90% events)
- Day-over-day comparison with historical trend file (90 days)
- 11 unit tests

kb_dedup.py — KB intelligent deduplication:
- Exact dedup: identical summary in index.json → keep newest
- Fuzzy dedup: same first 200 chars content hash → flag as suspect
- Source line dedup: remove duplicate lines within source files
- Dry-run by default (--apply to execute, --stats for quick overview)
- 15 unit tests

Registry: token_report@08:20 daily, kb_dedup@23:00 daily (dry-run mode)
FILE_MAP: +3 files (token_report.py, kb_dedup.py, conv_quality.py)

https://claude.ai/code/session_01H9hsWJKhNBMEME3q3PEhJt