### PR TITLE
feat: MM Search conversation integration + KB auto-tagging

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -117,6 +117,7 @@ declare -a FILE_MAP=(
     "conv_quality.py|$HOME/conv_quality.py"
     "token_report.py|$HOME/token_report.py"
     "kb_dedup.py|$HOME/kb_dedup.py"
+    "kb_autotag.py|$HOME/kb_autotag.py"
 
     # 自部署（bootstrapping）
     "auto_deploy.sh|$HOME/openclaw-model-bridge/auto_deploy.sh"

--- a/kb_autotag.py
+++ b/kb_autotag.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+kb_autotag.py — KB 标签自动化
+根据内容关键词自动推断标签，替代硬编码的 "技术/AI"。
+
+用法：
+  python3 kb_autotag.py "some content about machine learning"  # 输出标签
+  python3 kb_autotag.py --retag                                # 批量重新标记已有 notes
+  python3 kb_autotag.py --retag --apply                        # 批量重新标记并写入
+  python3 kb_autotag.py --stats                                # 当前标签分布统计
+"""
+import os, sys, json, re
+from collections import Counter
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+KB_BASE = os.environ.get("KB_BASE", os.path.expanduser("~/.kb"))
+INDEX_FILE = os.path.join(KB_BASE, "index.json")
+NOTES_DIR = os.path.join(KB_BASE, "notes")
+
+# ---------------------------------------------------------------------------
+# Tag rules: (tag, keywords_list, weight)
+# First match wins within a category; multiple categories can match.
+# Output format: "primary/secondary"
+# ---------------------------------------------------------------------------
+TAG_RULES = [
+    # AI & ML
+    ("技术/AI", [
+        "machine learning", "deep learning", "neural network", "transformer",
+        "llm", "gpt", "claude", "gemini", "qwen", "大模型", "大语言模型",
+        "ai", "artificial intelligence", "人工智能", "机器学习", "深度学习",
+        "embedding", "fine-tune", "finetune", "rag", "prompt", "token",
+        "diffusion", "stable diffusion", "midjourney", "dall-e",
+        "reinforcement learning", "强化学习", "自然语言处理", "nlp",
+        "computer vision", "cv", "计算机视觉",
+    ]),
+    # Academic / Papers
+    ("学术/论文", [
+        "arxiv", "paper", "论文", "研究", "research", "abstract",
+        "methodology", "experiment", "baseline", "benchmark", "sota",
+        "conference", "icml", "neurips", "iclr", "cvpr", "acl", "emnlp",
+    ]),
+    # Shipping / Freight
+    ("物流/货代", [
+        "freight", "shipping", "货代", "航运", "集装箱", "container",
+        "port", "vessel", "carrier", "运费", "海运", "空运", "物流",
+        "importyeti", "supplier", "供应商", "fob", "cif",
+        "tariff", "关税", "customs", "报关",
+    ]),
+    # OpenClaw / Infrastructure
+    ("技术/OpenClaw", [
+        "openclaw", "gateway", "whatsapp", "proxy", "adapter",
+        "plugin", "cron", "session", "launchd", "deploy", "部署",
+    ]),
+    # Programming / Dev
+    ("技术/编程", [
+        "python", "javascript", "typescript", "rust", "golang",
+        "api", "http", "rest", "graphql", "database", "sql",
+        "docker", "kubernetes", "k8s", "git", "github", "cicd",
+        "shell", "bash", "linux", "macos", "编程", "代码", "开发",
+    ]),
+    # Tech News
+    ("科技/新闻", [
+        "hackernews", "hacker news", "hn", "startup", "创业",
+        "funding", "ipo", "acquisition", "科技", "tech news",
+        "product hunt", "techcrunch",
+    ]),
+    # Finance / Crypto
+    ("财经/金融", [
+        "stock", "股票", "crypto", "bitcoin", "btc", "ethereum",
+        "投资", "finance", "金融", "央行", "利率", "通胀",
+    ]),
+    # Health
+    ("生活/健康", [
+        "health", "健康", "exercise", "运动", "diet", "饮食",
+        "sleep", "睡眠", "mental", "心理",
+    ]),
+]
+
+# Fallback tag when no rules match
+DEFAULT_TAG = "其他/未分类"
+
+
+def infer_tags(content, max_tags=2):
+    """Infer tags from content text. Returns list of tag strings.
+
+    Matches against TAG_RULES using keyword presence.
+    Returns up to max_tags, scored by keyword hit count.
+    """
+    if not content:
+        return [DEFAULT_TAG]
+
+    text_lower = content.lower()
+
+    scores = []
+    for tag, keywords in TAG_RULES:
+        hits = sum(1 for kw in keywords if kw.lower() in text_lower)
+        if hits > 0:
+            scores.append((tag, hits))
+
+    if not scores:
+        return [DEFAULT_TAG]
+
+    # Sort by hit count descending
+    scores.sort(key=lambda x: -x[1])
+    return [tag for tag, _ in scores[:max_tags]]
+
+
+def infer_tag_string(content):
+    """Return a single tag string for kb_write.sh compatibility.
+    If multiple tags, join with comma.
+    """
+    tags = infer_tags(content)
+    return ", ".join(tags)
+
+
+def read_note_content(filepath):
+    """Read note content, skip YAML frontmatter."""
+    if not os.path.exists(filepath):
+        return ""
+    try:
+        with open(filepath, "r", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return ""
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            text = text[end + 3:].strip()
+    return text
+
+
+def update_note_tags(filepath, new_tags_str):
+    """Update the tags field in a note's YAML frontmatter."""
+    try:
+        with open(filepath, "r", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return False
+
+    if not text.startswith("---"):
+        return False
+
+    end = text.find("---", 3)
+    if end == -1:
+        return False
+
+    frontmatter = text[3:end]
+    body = text[end:]
+
+    # Replace tags line
+    new_fm = re.sub(
+        r"tags:\s*\[.*?\]",
+        f"tags: [{new_tags_str}]",
+        frontmatter,
+    )
+
+    if new_fm == frontmatter:
+        return False
+
+    with open(filepath, "w") as f:
+        f.write("---" + new_fm + body)
+    return True
+
+
+def retag_all(apply=False):
+    """Re-tag all existing notes based on content."""
+    index = load_index()
+    entries = index.get("entries", [])
+
+    changes = []
+    for entry in entries:
+        filepath = os.path.join(KB_BASE, entry.get("file", ""))
+        content = read_note_content(filepath)
+        if not content:
+            continue
+
+        new_tags = infer_tags(content)
+        old_tags = entry.get("tags", [])
+        new_tags_str = ", ".join(new_tags)
+
+        if set(new_tags) != set(old_tags):
+            changes.append({
+                "file": entry.get("file", ""),
+                "old": old_tags,
+                "new": new_tags,
+                "summary": entry.get("summary", "")[:50],
+            })
+
+            if apply:
+                # Update note file frontmatter
+                update_note_tags(filepath, new_tags_str)
+                # Update index entry
+                entry["tags"] = new_tags
+
+    if apply and changes:
+        save_index(index)
+
+    return changes
+
+
+def load_index():
+    if not os.path.exists(INDEX_FILE):
+        return {"entries": []}
+    try:
+        with open(INDEX_FILE, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {"entries": []}
+
+
+def save_index(data):
+    tmp = INDEX_FILE + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, INDEX_FILE)
+
+
+def show_stats():
+    """Show current tag distribution."""
+    index = load_index()
+    entries = index.get("entries", [])
+    tag_counter = Counter()
+    for entry in entries:
+        for tag in entry.get("tags", []):
+            tag_counter[tag] += 1
+
+    print(f"📊 KB 标签统计（共 {len(entries)} 条 notes）")
+    if not tag_counter:
+        print("   无标签数据")
+        return
+
+    for tag, count in tag_counter.most_common():
+        pct = round(count / len(entries) * 100, 1)
+        bar = "█" * max(1, count * 20 // max(tag_counter.values()))
+        print(f"   {tag:20s} {count:4d} ({pct:5.1f}%) {bar}")
+
+
+def main():
+    if "--stats" in sys.argv:
+        show_stats()
+        return
+
+    if "--retag" in sys.argv:
+        apply = "--apply" in sys.argv
+        mode = "APPLY" if apply else "DRY-RUN"
+        print(f"[kb_autotag] 批量重新标记模式: {mode}")
+
+        changes = retag_all(apply=apply)
+        if not changes:
+            print("[kb_autotag] 所有 notes 标签已是最优，无需更改")
+            return
+
+        print(f"[kb_autotag] 发现 {len(changes)} 个标签变更：")
+        for c in changes[:20]:
+            print(f"   {c['file']}: {c['old']} → {c['new']}  ({c['summary']})")
+        if len(changes) > 20:
+            print(f"   ... 还有 {len(changes) - 20} 个")
+
+        if not apply:
+            print(f"\n运行 `python3 kb_autotag.py --retag --apply` 执行变更")
+        else:
+            print(f"[kb_autotag] 已更新 {len(changes)} 个 notes 的标签")
+        return
+
+    # Single content tagging (for kb_write.sh integration)
+    if len(sys.argv) > 1 and not sys.argv[1].startswith("--"):
+        content = " ".join(a for a in sys.argv[1:] if not a.startswith("--"))
+        tag = infer_tag_string(content)
+        print(tag)
+        return
+
+    print("用法:")
+    print("  python3 kb_autotag.py \"content text\"    # 输出推断的标签")
+    print("  python3 kb_autotag.py --retag            # 预览批量重新标记")
+    print("  python3 kb_autotag.py --retag --apply    # 执行批量重新标记")
+    print("  python3 kb_autotag.py --stats            # 标签分布统计")
+
+
+if __name__ == "__main__":
+    main()

--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -161,6 +161,16 @@ $(cat "$DIGEST_FILE" 2>/dev/null || echo '（摘要暂未生成）')
 - 完整归档：\`~/.kb/sources/\` 目录下各来源文件
 - 笔记详情：\`~/.kb/notes/\` 目录下按时间戳命名的 .md 文件
 - KB 搜索：\`bash ~/kb_search.sh "关键词"\`
+
+## 多媒体搜索
+当用户询问照片、图片、录音、视频等媒体文件时，使用 exec 工具执行：
+\`python3 ~/mm_search.py "用户描述的内容"\`
+支持自然语言查询，例如：
+- "找一下猫的照片" → \`python3 ~/mm_search.py "猫的照片"\`
+- "最近的会议录音" → \`python3 ~/mm_search.py "会议录音"\`
+- "上周的PDF文档" → \`python3 ~/mm_search.py "PDF文档"\`
+返回结果包含文件路径，可用 read 工具查看或告知用户路径。
+查看索引统计：\`python3 ~/mm_search.py --stats\`
 MDEOF
 
 log "workspace CLAUDE.md 已同步 ($(wc -c < "$WORKSPACE_MD" | tr -d ' ') bytes)"

--- a/kb_write.sh
+++ b/kb_write.sh
@@ -6,8 +6,15 @@ while ! mkdir "$LOCKDIR" 2>/dev/null; do sleep 0.1; done
 trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
 
 CONTENT="$1"
-TAGS="${2:-技术/AI}"
 TYPE="${3:-note}"
+
+# 标签自动推断：有显式传入则用传入值，否则调用 kb_autotag.py
+if [ -n "$2" ]; then
+    TAGS="$2"
+else
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    TAGS=$(python3 "$SCRIPT_DIR/kb_autotag.py" "$CONTENT" 2>/dev/null || echo "技术/AI")
+fi
 DATE=$(date +%Y%m%d)
 TS=$(date +%Y%m%d%H%M%S)
 

--- a/test_kb_autotag.py
+++ b/test_kb_autotag.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""test_kb_autotag.py — kb_autotag.py 单测"""
+import unittest, tempfile, os, json, shutil
+
+_tmpdir = tempfile.mkdtemp()
+_kb_base = os.path.join(_tmpdir, "kb")
+_notes_dir = os.path.join(_kb_base, "notes")
+_index_file = os.path.join(_kb_base, "index.json")
+
+import kb_autotag
+kb_autotag.KB_BASE = _kb_base
+kb_autotag.INDEX_FILE = _index_file
+kb_autotag.NOTES_DIR = _notes_dir
+
+
+def setup_kb():
+    os.makedirs(_notes_dir, exist_ok=True)
+
+
+def write_note(filename, content, tags="技术/AI"):
+    with open(os.path.join(_notes_dir, filename), "w") as f:
+        f.write(f"---\ndate: 20260324\ntags: [{tags}]\nsource: direct\ntype: note\n---\n\n{content}")
+
+
+def write_index(entries):
+    with open(_index_file, "w") as f:
+        json.dump({"entries": entries}, f)
+
+
+class TestInferTags(unittest.TestCase):
+    """Tag inference from content."""
+
+    def test_ai_content(self):
+        tags = kb_autotag.infer_tags("New paper on transformer architecture for LLM training")
+        self.assertIn("技术/AI", tags)
+
+    def test_ai_chinese(self):
+        tags = kb_autotag.infer_tags("最新的大语言模型研究进展")
+        self.assertIn("技术/AI", tags)
+
+    def test_freight_content(self):
+        tags = kb_autotag.infer_tags("Container shipping rates from Shanghai port increased")
+        self.assertIn("物流/货代", tags)
+
+    def test_freight_chinese(self):
+        tags = kb_autotag.infer_tags("货代报价：上海到洛杉矶集装箱海运费上涨")
+        self.assertIn("物流/货代", tags)
+
+    def test_openclaw_content(self):
+        tags = kb_autotag.infer_tags("OpenClaw gateway plugin update deployed to production")
+        self.assertIn("技术/OpenClaw", tags)
+
+    def test_arxiv_paper(self):
+        tags = kb_autotag.infer_tags("arxiv paper: Attention Is All You Need - transformer research")
+        self.assertIn("学术/论文", tags)
+        # Should also match AI
+        self.assertTrue(len(tags) >= 1)
+
+    def test_hn_news(self):
+        tags = kb_autotag.infer_tags("HackerNews top post: new startup raises funding")
+        self.assertIn("科技/新闻", tags)
+
+    def test_programming(self):
+        tags = kb_autotag.infer_tags("Python HTTP API endpoint using REST framework")
+        self.assertIn("技术/编程", tags)
+
+    def test_finance(self):
+        tags = kb_autotag.infer_tags("Bitcoin price surge and crypto market analysis")
+        self.assertIn("财经/金融", tags)
+
+    def test_health(self):
+        tags = kb_autotag.infer_tags("改善睡眠质量的运动方法")
+        self.assertIn("生活/健康", tags)
+
+    def test_empty_content(self):
+        tags = kb_autotag.infer_tags("")
+        self.assertEqual(tags, ["其他/未分类"])
+
+    def test_unknown_content(self):
+        tags = kb_autotag.infer_tags("random gibberish xyzzy plugh")
+        self.assertEqual(tags, ["其他/未分类"])
+
+    def test_max_tags(self):
+        """Content matching multiple categories returns at most max_tags."""
+        # Matches AI + academic + programming
+        content = "arxiv paper on deep learning using Python PyTorch benchmark"
+        tags = kb_autotag.infer_tags(content, max_tags=2)
+        self.assertLessEqual(len(tags), 2)
+
+    def test_single_tag_string(self):
+        result = kb_autotag.infer_tag_string("LLM transformer paper")
+        self.assertIn("技术/AI", result)
+
+
+class TestRetag(unittest.TestCase):
+
+    def setUp(self):
+        if os.path.exists(_kb_base):
+            shutil.rmtree(_kb_base)
+        setup_kb()
+
+    def test_retag_dry_run(self):
+        write_note("20260324100000.md", "New deep learning research on transformers")
+        write_index([{
+            "date": "20260324",
+            "file": "notes/20260324100000.md",
+            "tags": ["技术/AI"],  # already correct
+            "summary": "New deep learning research",
+        }])
+        changes = kb_autotag.retag_all(apply=False)
+        # Tags should already be correct, so no changes
+        # (or changes if autotag finds additional tags)
+        # Either way, files should not be modified in dry-run
+        with open(os.path.join(_notes_dir, "20260324100000.md")) as f:
+            content = f.read()
+        self.assertIn("tags: [技术/AI]", content)
+
+    def test_retag_apply(self):
+        write_note("20260324100000.md",
+                    "Shanghai port container shipping freight rates analysis",
+                    tags="技术/AI")  # wrong tag
+        write_index([{
+            "date": "20260324",
+            "file": "notes/20260324100000.md",
+            "tags": ["技术/AI"],
+            "summary": "Shanghai port container shipping",
+        }])
+        changes = kb_autotag.retag_all(apply=True)
+        self.assertTrue(len(changes) > 0)
+        # Check file was updated
+        with open(os.path.join(_notes_dir, "20260324100000.md")) as f:
+            content = f.read()
+        self.assertIn("物流/货代", content)
+        # Check index was updated
+        index = kb_autotag.load_index()
+        self.assertIn("物流/货代", index["entries"][0]["tags"])
+
+    def test_retag_no_changes(self):
+        write_note("20260324100000.md", "random text nothing special xyzzy")
+        write_index([{
+            "date": "20260324",
+            "file": "notes/20260324100000.md",
+            "tags": ["其他/未分类"],
+            "summary": "random text",
+        }])
+        changes = kb_autotag.retag_all(apply=False)
+        self.assertEqual(len(changes), 0)
+
+
+class TestUpdateNoteTags(unittest.TestCase):
+
+    def setUp(self):
+        if os.path.exists(_kb_base):
+            shutil.rmtree(_kb_base)
+        setup_kb()
+
+    def test_update_frontmatter(self):
+        write_note("20260324100000.md", "test content", tags="技术/AI")
+        filepath = os.path.join(_notes_dir, "20260324100000.md")
+        result = kb_autotag.update_note_tags(filepath, "物流/货代")
+        self.assertTrue(result)
+        with open(filepath) as f:
+            content = f.read()
+        self.assertIn("tags: [物流/货代]", content)
+        self.assertNotIn("技术/AI", content)
+
+    def test_no_frontmatter(self):
+        filepath = os.path.join(_notes_dir, "nofm.md")
+        with open(filepath, "w") as f:
+            f.write("No frontmatter here")
+        result = kb_autotag.update_note_tags(filepath, "test")
+        self.assertFalse(result)
+
+
+class TestStats(unittest.TestCase):
+
+    def setUp(self):
+        if os.path.exists(_kb_base):
+            shutil.rmtree(_kb_base)
+        setup_kb()
+
+    def test_empty_index(self):
+        write_index([])
+        # Should not crash
+        kb_autotag.show_stats()
+
+    def test_with_data(self):
+        write_index([
+            {"date": "20260324", "file": "a.md", "tags": ["技术/AI"], "summary": "a"},
+            {"date": "20260324", "file": "b.md", "tags": ["技术/AI"], "summary": "b"},
+            {"date": "20260324", "file": "c.md", "tags": ["物流/货代"], "summary": "c"},
+        ])
+        # Should not crash
+        kb_autotag.show_stats()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
MM Search integration:
- kb_inject.sh workspace CLAUDE.md now includes multimodal search instructions
- LLM can use exec tool to run mm_search.py when users ask about photos/media
- Natural language queries: "找猫的照片" → python3 ~/mm_search.py "猫的照片"

KB auto-tagging (kb_autotag.py):
- Keyword-based tag inference across 9 categories (AI, academic, freight, OpenClaw, programming, tech news, finance, health, uncategorized)
- Integrated into kb_write.sh: auto-infers tags when not explicitly provided
- Batch retag mode: --retag (dry-run) / --retag --apply
- Tag stats: --stats shows distribution
- 21 unit tests

FILE_MAP: +1 file (kb_autotag.py)

https://claude.ai/code/session_01H9hsWJKhNBMEME3q3PEhJt