### PR TITLE
fix: restart.sh grep exit code breaks set -e, skipping Gateway restart

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -29,7 +29,7 @@ sleep 1
 OPENCLAW_DIST="/opt/homebrew/lib/node_modules/openclaw/dist"
 if [ -d "$OPENCLAW_DIST" ]; then
     UNPATCHED=$(grep -rl 'const listeners = /\* @__PURE__ \*/ new Map()' \
-        "$OPENCLAW_DIST" --include="*.js" 2>/dev/null | grep -v ".bak" | wc -l | tr -d ' ')
+        "$OPENCLAW_DIST" --include="*.js" 2>/dev/null | grep -v ".bak" | wc -l | tr -d ' ' || echo 0)
     if [ "$UNPATCHED" -gt 0 ]; then
         echo "[restart] Applying #48703 hotfix ($UNPATCHED files)..."
         sudo sed -i.bak \


### PR DESCRIPTION
The #48703 hotfix grep pipeline returns non-zero when no matches found, causing the script to exit before reaching the Gateway launchd bootstrap. Add || echo 0 fallback to prevent early termination.

https://claude.ai/code/session_019FLuKm5g6kHUhd4jNXXXVh