### PR TITLE
feat: add image tool to proxy allowlist for WhatsApp photo analysis

### DIFF
--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -19,6 +19,7 @@ ALLOWED_TOOLS = {
     "exec",
     "memory_search", "memory_get",
     "cron", "message", "tts",
+    "image",
 }
 
 # 前缀匹配的工具（browser_navigate, browser_click 等）


### PR DESCRIPTION
Gateway sends <media:image> placeholder when receiving WhatsApp photos, expecting LLM to call the built-in image tool. The tool was filtered out by proxy, so LLM could never analyze images. Now 12/12 tools allowed.

https://claude.ai/code/session_019FLuKm5g6kHUhd4jNXXXVh