### PR TITLE
docs: update architecture for V29.4 multimodal image understanding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # CLAUDE.md — openclaw-model-bridge 项目背景
 
-> 每次新会话开始时自动读取。当前版本：v29.2（2026-03-23）
+> 每次新会话开始时自动读取。当前版本：v29.4（2026-03-25）
 
 ---
 
 ## 项目简介
 
-将任意大模型（当前：Qwen3-235B）接入 OpenClaw（WhatsApp AI助手框架）的双层中间件。
+将任意大模型（当前：Qwen3-235B + Qwen2.5-VL-72B）接入 OpenClaw（WhatsApp AI助手框架）的双层中间件，支持多模态（图片理解）。
 运行于 Mac Mini (macOS)，用户：bisdom。
 
 ## 系统架构总览
@@ -17,15 +17,17 @@
 └────────────────────────────┬────────────────────────────────────────┘
                              │
 ┌────────────────────────────▼────────────────────────────────────────┐
-│  ① 核心数据通路（实时对话）                                          │
+│  ① 核心数据通路（实时对话 + 多模态）                                  │
 │                                                                     │
-│  WhatsApp ←→ Gateway (:18789) ←→ Tool Proxy (:5002) ←→ Adapter (:5001) ←→ 远程GPU  │
-│              [launchd管理]        [策略过滤+监控]       [认证+Fallback]  [Qwen3-235B] │
-│                                                         [Qwen3→Gemini]              │
-│                  │                    │                    │                        │
-│                  │               /health ──→ /health       │                        │
-│                  │               /stats (token监控)        │                        │
-│                  │                    │                    │                        │
+│  WhatsApp ←→ Gateway (:18789) ←→ Tool Proxy (:5002) ←→ Adapter (:5001) ←→ 远程GPU        │
+│              [launchd管理]        [策略过滤+监控]       [认证+VL路由]     [Qwen3-235B]      │
+│              [媒体存储]           [图片base64注入]      [Fallback降级]    [Qwen2.5-VL-72B]  │
+│                  │                    │                    │                               │
+│                  │               /health ──→ /health       │                               │
+│                  │               /stats (token监控)        │                               │
+│                                                                     │
+│  图片流程：Gateway存储jpg → Proxy检测<media:image> → base64注入       │
+│           → Adapter检测image_url → 路由到Qwen2.5-VL → 图片理解回复    │
 └──────────────────┼────────────────────┼────────────────────┼────────────────────────┘
                    │                    │                    │
 ┌──────────────────▼────────────────────▼────────────────────▼────────────────────────┐
@@ -79,10 +81,10 @@
 
 | 组件 | 端口 | 文件 | 功能 | 进程管理 |
 |------|------|------|------|----------|
-| OpenClaw Gateway | 18789 | npm全局安装 | WhatsApp接入、工具执行、会话管理 | launchd (KeepAlive) |
-| Tool Proxy | 5002 | `tool_proxy.py` + `proxy_filters.py` | 工具过滤(24→12)、Schema简化、SSE转换、截断、token监控 | launchd plist |
-| Adapter | 5001 | `adapter.py` | 多Provider转发(Qwen/OpenAI/Gemini/Claude)、认证、Fallback降级、/health端点 | launchd plist |
-| 远程GPU | — | hkagentx.hkopenlab.com | Qwen3-235B推理 (262K context) | 外部服务 |
+| OpenClaw Gateway | 18789 | npm全局安装 | WhatsApp接入、**媒体存储**、工具执行、会话管理 | launchd (KeepAlive) |
+| Tool Proxy | 5002 | `tool_proxy.py` + `proxy_filters.py` | 工具过滤(24→12)、**图片base64注入**、Schema简化、SSE转换、截断、token监控 | launchd plist |
+| Adapter | 5001 | `adapter.py` | 多Provider转发、认证、**多模态路由**（文本→Qwen3，图片→Qwen2.5-VL）、Fallback降级 | launchd plist |
+| 远程GPU | — | hkagentx.hkopenlab.com | **Qwen3-235B**（文本, 262K context）+ **Qwen2.5-VL-72B**（视觉理解） | 外部服务 |
 
 ## 关键文件（本仓库）
 
@@ -184,6 +186,14 @@
 4. **WhatsApp LLM 自动查 KB**：workspace CLAUDE.md 添加知识库查询指引，用户问"最近有什么新论文"等问题时 LLM 自动读取 daily_digest.md 回答
 5. **kb_review.sh 从 openclaw cron 改为 system cron**：直接 curl 调 LLM 分析，不再依赖 openclaw agent
 6. **auto_deploy.sh FILE_MAP 扩展至 19 个文件**：新增 kb_search.sh + kb_inject.sh
+
+## V29.4 变更摘要（2026-03-25）
+
+1. **多模态图片理解**：WhatsApp 发送图片 → Gateway 存储到 `~/.openclaw/media/inbound/` → Proxy 检测 `<media:image>` 标记并读取图片 base64 编码注入 `image_url` → Adapter 检测多模态内容自动路由到 Qwen2.5-VL-72B-Instruct → 返回图片描述/理解
+2. **Adapter VL 模型路由**：`adapter.py` 新增 `vl_model_id` 配置，检测 `image_url`/`image`/`audio`/`video` content 类型时自动切换模型，纯文本继续用 Qwen3-235B；`/health` 端点暴露 VL 模型信息
+3. **Proxy 图片注入**：`proxy_filters.py` 新增 `inject_media_into_messages()` — 检测 `<media:image>` 标记 → 查找最近5分钟内的图片 → base64 编码（10MB上限）→ 转为 OpenAI 多模态消息格式；支持图片和文字分开发送的场景
+4. **restart.sh 修复**：`#48703 hotfix` 中的 grep 管道在无匹配时返回非零退出码，被 `set -e` 捕获导致脚本在 Gateway 启动前中断
+5. **openclaw.json 更新**：模型声明 `input` 从 `["text"]` 改为 `["text", "image"]`；research agent 工具白名单新增 `image`
 
 ## V29.3 变更摘要（2026-03-24）
 
@@ -355,6 +365,9 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 | 优先级 | 任务 |
 |--------|------|
 | 低 | 货代Watcher V3：Bing News API替代GoogleNews |
+| 低 | 语音消息支持：WhatsApp语音→STT→LLM回复 |
+| 低 | MM搜索接入对话：mm_search.py 注册为 OpenClaw tool |
+| ✅ | **多模态图片理解：Qwen2.5-VL-72B 自动路由（V29.4）** |
 | ✅ | Multimodal Memory：Gemini Embedding 2 索引图片/音频/视频/PDF（V29.1） |
 | ✅ | Model Fallback 降级链（V29.1） |
 | ✅ | 每日自动备份（V29.1） |

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # openclaw-model-bridge
 
-> Connect any LLM to [OpenClaw](https://github.com/openclaw/openclaw) — production-tested middleware for Qwen3-235B on Mac Mini.
-> 将任意大模型接入 OpenClaw — 基于 Qwen3-235B 生产验证的中间件，运行于 Mac Mini。
+> Connect any LLM to [OpenClaw](https://github.com/openclaw/openclaw) — production-tested middleware with multimodal support on Mac Mini.
+> 将任意大模型接入 OpenClaw — 支持多模态（图片理解）的生产中间件，运行于 Mac Mini。
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://img.shields.io/badge/tests-61%20passed-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-58%20passed-brightgreen.svg)]()
 [![Jobs](https://img.shields.io/badge/cron%20jobs-20-blue.svg)]()
 
 ## Architecture / 系统架构
@@ -18,14 +18,20 @@
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                     用户层 (WhatsApp)                            │
+│                 文本 / 图片 / 语音消息                            │
 └────────────────────────┬────────────────────────────────────────┘
                          │
 ┌────────────────────────▼────────────────────────────────────────┐
-│  ① 核心数据通路（实时对话）                                       │
+│  ① 核心数据通路（实时对话 + 多模态）                               │
 │                                                                  │
-│  WhatsApp ←→ Gateway (:18789) ←→ Proxy (:5002) ←→ Adapter (:5001) ←→ Remote GPU  │
-│              [launchd]           [策略过滤+监控]    [认证+Fallback]    [Qwen3-235B] │
-│                                                    [→Gemini降级]                   │
+│  WhatsApp ←→ Gateway (:18789) ←→ Proxy (:5002) ←→ Adapter (:5001) ←→ Remote GPU       │
+│              [launchd]           [策略过滤+监控]    [认证+Fallback]    [Qwen3-235B]      │
+│              [媒体存储]          [图片base64注入]   [VL模型路由]       [Qwen2.5-VL-72B]  │
+│                                                    [→Gemini降级]                        │
+│                                                                  │
+│  图片流程：Gateway存储jpg → Proxy检测<media:image>                │
+│           → 读取图片base64编码 → 注入image_url                    │
+│           → Adapter检测多模态 → 路由到Qwen2.5-VL → 图片理解回复    │
 └──────────────────┬──────────────────┬───────────────────────────┘
                    │                  │
 ┌──────────────────▼──────────────────▼───────────────────────────┐
@@ -72,11 +78,11 @@
 
 | Component | Port | Files | Role |
 |-----------|------|-------|------|
-| OpenClaw Gateway | 18789 | npm global | WhatsApp integration, tool execution, session management |
-| Tool Proxy | 5002 | `tool_proxy.py` + `proxy_filters.py` | Tool filtering (24→12), schema simplification, SSE conversion, truncation, token monitoring |
-| Adapter | 5001 | `adapter.py` | Multi-provider forwarding (Qwen/Gemini), auth, fallback degradation, /health |
+| OpenClaw Gateway | 18789 | npm global | WhatsApp integration, media storage, tool execution, session management |
+| Tool Proxy | 5002 | `tool_proxy.py` + `proxy_filters.py` | Tool filtering (24→12), schema simplification, **image base64 injection**, SSE conversion, truncation, token monitoring |
+| Adapter | 5001 | `adapter.py` | Multi-provider forwarding, auth, **multimodal routing** (text→Qwen3, image→Qwen2.5-VL), fallback degradation |
 | Local Embedding | — | `local_embed.py` | sentence-transformers (384-dim, 50+ languages), zero API calls |
-| Remote GPU | — | hkagentx.hkopenlab.com | Qwen3-235B inference (262K context) |
+| Remote GPU | — | hkagentx.hkopenlab.com | Qwen3-235B (text, 262K context) + **Qwen2.5-VL-72B** (vision) |
 
 ## Quick Start
 
@@ -103,9 +109,9 @@ python3 mm_index.py && python3 mm_search.py "cat photos"
 
 | File | Description |
 |------|-------------|
-| `tool_proxy.py` | HTTP layer — request/response routing, logging, health cascade |
-| `proxy_filters.py` | Policy layer — tool filtering, param fixing, truncation, SSE conversion (pure functions) |
-| `adapter.py` | API adapter — multi-provider (Qwen/Gemini) forwarding, auth, fallback degradation |
+| `tool_proxy.py` | HTTP layer — request/response routing, **media injection**, logging, health cascade |
+| `proxy_filters.py` | Policy layer — tool filtering, **image base64 injection** (`<media:image>` → `image_url`), param fixing, truncation, SSE conversion |
+| `adapter.py` | API adapter — multi-provider forwarding, auth, **multimodal routing** (text→Qwen3, image→Qwen2.5-VL), fallback degradation |
 
 ### Knowledge Base & Local AI
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,7 +1,7 @@
 # OpenClaw 完整配置文档
-> 最后更新：2026-03-24 (HKT)
+> 最后更新：2026-03-25 (HKT)
 > 系统：Mac Mini (macOS) | 用户：bisdom
-> 版本：v29.2（V29.1基础上：OpenClaw架构文档同步至v2026.3.22）
+> 版本：v29.4（V29.3基础上：多模态图片理解 — Qwen2.5-VL-72B 自动路由）
 > OpenClaw Gateway：2026.3.13-1（当前部署，暂不升级）| 上游最新：v2026.3.23（WhatsApp plugin 仅 0.0.5-Alpha + ClawHub 429，等稳定版再升级）
 ---
 ## 一、系统架构（V28.1 四层架构）
@@ -13,13 +13,17 @@
 └────────────────────────────┬────────────────────────────────────────┘
                              │
 ┌────────────────────────────▼────────────────────────────────────────┐
-│  ① 核心数据通路（实时对话）                                          │
+│  ① 核心数据通路（实时对话 + 多模态）                                  │
 │                                                                     │
-│  WhatsApp ←→ Gateway (:18789) ←→ Tool Proxy (:5002) ←→ Adapter (:5001) ←→ 远程GPU  │
-│              [launchd管理]        [策略过滤+监控]       [认证+转发]     [Qwen3-235B] │
-│                  │                    │                    │                        │
-│                  │               /health ──→ /health       │                        │
-│                  │               /stats (token监控)        │                        │
+│  WhatsApp ←→ Gateway (:18789) ←→ Tool Proxy (:5002) ←→ Adapter (:5001) ←→ 远程GPU        │
+│              [launchd管理]        [策略过滤+监控]       [认证+VL路由]     [Qwen3-235B]      │
+│              [媒体存储]           [图片base64注入]      [Fallback降级]    [Qwen2.5-VL-72B]  │
+│                  │                    │                    │                               │
+│                  │               /health ──→ /health       │                               │
+│                  │               /stats (token监控)        │                               │
+│                                                                     │
+│  图片流程：Gateway存储jpg → Proxy检测<media:image> → base64注入       │
+│           → Adapter检测image_url → 路由到Qwen2.5-VL → 图片理解回复    │
 └──────────────────┼────────────────────┼────────────────────┼────────────────────────┘
                    │                    │                    │
 ┌──────────────────▼────────────────────▼────────────────────▼────────────────────────┐
@@ -90,10 +94,10 @@
 ### 1.3 核心组件详情
 | 组件 | 端口 | 文件位置 | 功能 | 进程管理 |
 |------|------|----------|------|----------|
-| OpenClaw Gateway | 18789 | 全局安装 (npm) | WhatsApp接入、工具执行、会话管理 | launchd (KeepAlive) |
-| Tool Proxy | 5002 | ~/tool_proxy.py + ~/proxy_filters.py | HTTP层 + 策略层：工具过滤、Schema简化、参数修复、SSE转换、截断、token监控、/health级联检查 | launchd plist |
-| Adapter | 5001 | ~/adapter.py | 多Provider转发(Qwen/OpenAI/Gemini/Claude)、认证、/health端点、**Fallback降级** | launchd plist |
-| 远程GPU | - | hkagentx.hkopenlab.com | Qwen3-235B推理 + 原生tool calling (262K context) | 外部服务 |
+| OpenClaw Gateway | 18789 | 全局安装 (npm) | WhatsApp接入、**媒体存储**、工具执行、会话管理 | launchd (KeepAlive) |
+| Tool Proxy | 5002 | ~/tool_proxy.py + ~/proxy_filters.py | HTTP层 + 策略层：工具过滤、**图片base64注入**、Schema简化、参数修复、SSE转换、截断、token监控 | launchd plist |
+| Adapter | 5001 | ~/adapter.py | 多Provider转发、认证、**多模态路由**（文本→Qwen3，图片→Qwen2.5-VL）、Fallback降级 | launchd plist |
+| 远程GPU | - | hkagentx.hkopenlab.com | **Qwen3-235B**（文本，262K context）+ **Qwen2.5-VL-72B**（视觉理解） | 外部服务 |
 ---
 ## 二、关键文件清单
 | 文件 | 路径 | 用途 |
@@ -149,10 +153,10 @@
 |------|------|
 | Endpoint | https://hkagentx.hkopenlab.com/v1/chat/completions |
 | API Key | 通过环境变量 `$REMOTE_API_KEY` 读取（~/.zshrc） |
-| Model ID | Qwen3-235B-A22B-Instruct-2507-W8A8 |
-| 参数量 | 235B (W8A8量化) |
-| 上下文窗口 | 262K tokens |
+| 文本模型 | Qwen3-235B-A22B-Instruct-2507-W8A8（235B, W8A8量化, 262K context） |
+| **视觉模型** | **Qwen2.5-VL-72B-Instruct（72B, 同endpoint同API Key，V29.4新增）** |
 | 请求体限制 | ~280KB |
+| **多模态路由** | **Adapter自动检测image_url内容 → 切换到VL模型；纯文本 → 继续用Qwen3** |
 ### ⚠️ 模型ID使用规则
 | 文件 | 使用哪种ID |
 |------|-----------|


### PR DESCRIPTION
All architecture diagrams (CLAUDE.md, README.md, docs/config.md) updated to reflect the new multimodal pipeline:
- WhatsApp photo → Gateway stores jpg → Proxy base64 injection → Adapter VL model routing → Qwen2.5-VL-72B → image understanding response
- Component tables updated with new capabilities
- V29.4 changelog added
- Todo list updated (image understanding marked done, voice/MM search added)

https://claude.ai/code/session_019FLuKm5g6kHUhd4jNXXXVh