### PR TITLE
feat: inject operational knowledge into WhatsApp PA session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@
 │  GitHub (main) ──→ auto_deploy.sh (每2min轮询)                                      │
 │                     ├─ git fetch + pull                                              │
 │                     ├─ 单测验证（proxy_filters变更时）                                 │
-│                     ├─ 文件同步（仓库→运行时，23个文件映射）                            │
+│                     ├─ 文件同步（仓库→运行时，31个文件映射）                            │
 │                     ├─ 每小时漂移检测（md5全量比对）                                   │
 │                     ├─ 按需restart（核心服务文件变更时）                                │
 │                     └─ preflight_check.sh --full（部署后自动体检 11项）                │
@@ -103,7 +103,7 @@
 | `kb_write.sh` | KB写入脚本（含目录锁+原子写） |
 | `kb_review.sh` | **V29升级** KB跨笔记回顾（LLM深度分析+WhatsApp推送） |
 | `kb_search.sh` | **V29新增** KB按需查询工具（关键词/标签/来源/统计概览） |
-| `kb_inject.sh` | **V29新增** 每日KB摘要生成（~/.kb/daily_digest.md，供LLM对话查阅） |
+| `kb_inject.sh` | **V29新增→V29.4升级** 每日KB摘要+运维知识精华注入workspace CLAUDE.md；文档按需查阅路径 `~/.kb/docs/` |
 | `mm_index.py` | **V29.1新增** Multimodal Memory 索引器（Gemini Embedding 2，支持图片/音频/视频/PDF） |
 | `mm_search.py` | **V29.1新增** Multimodal Memory 语义搜索（文本查询→cosine similarity→匹配媒体） |
 | `mm_index_cron.sh` | **V29.1新增** MM 索引定时任务包装脚本（每2小时） |
@@ -194,6 +194,7 @@
 3. **Proxy 图片注入**：`proxy_filters.py` 新增 `inject_media_into_messages()` — 检测 `<media:image>` 标记 → 查找最近5分钟内的图片 → base64 编码（10MB上限）→ 转为 OpenAI 多模态消息格式；支持图片和文字分开发送的场景
 4. **restart.sh 修复**：`#48703 hotfix` 中的 grep 管道在无匹配时返回非零退出码，被 `set -e` 捕获导致脚本在 Gateway 启动前中断
 5. **openclaw.json 更新**：模型声明 `input` 从 `["text"]` 改为 `["text", "image"]`；research agent 工具白名单新增 `image`
+6. **WhatsApp PA 运维知识注入**：`kb_inject.sh` 升级 — workspace CLAUDE.md 新增系统架构简版、9条核心运维原则、常用运维命令、深度文档按需查阅路径（`~/.kb/docs/`）；`auto_deploy.sh` FILE_MAP 新增 3 个文档文件（GUIDE.md/config.md/CLAUDE.md → `~/.kb/docs/`），PA 遇架构/故障问题时可用 read 工具查阅完整文档
 
 ## V29.3 变更摘要（2026-03-24）
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ python3 mm_index.py && python3 mm_search.py "cat photos"
 | File | Description |
 |------|-------------|
 | `restart.sh` | One-command restart all services (with PATH fix for cron) |
-| `auto_deploy.sh` | Auto-deployment — git pull + file sync (23 files) + drift detection + smart restart + post-deploy preflight |
+| `auto_deploy.sh` | Auto-deployment — git pull + file sync (31 files) + drift detection + smart restart + post-deploy preflight |
 | `preflight_check.sh` | Pre-flight check — 11 automated checks (tests, registry, syntax, deploy consistency, env vars, connectivity, security scan) |
 | `health_check.sh` | Weekly health report + JSON output |
 | `openclaw_backup.sh` | **V29.1** Daily Gateway state backup to external SSD (7-day retention) |
@@ -238,12 +238,12 @@ python3 mm_search.py --stats           # Index stats
 ```
 Claude Code → claude/branch → PR → main → auto_deploy (2 min) → Mac Mini
                                                 ↓
-                               git pull → test → file sync (23 files) → smart restart
+                               git pull → test → file sync (31 files) → smart restart
                                                 ↓
                                preflight_check.sh --full (11 checks)
 ```
 
-The `auto_deploy.sh` script maps 23 repo files to runtime locations and only restarts services when core files change. Hourly drift detection via md5 checksums with WhatsApp alerts.
+The `auto_deploy.sh` script maps 31 repo files to runtime locations and only restarts services when core files change. Hourly drift detection via md5 checksums with WhatsApp alerts.
 
 ## Testing
 

--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -121,6 +121,11 @@ declare -a FILE_MAP=(
 
     # 自部署（bootstrapping）
     "auto_deploy.sh|$HOME/openclaw-model-bridge/auto_deploy.sh"
+
+    # 文档同步到 KB（供 WhatsApp PA 按需查阅）
+    "docs/GUIDE.md|$HOME/.kb/docs/GUIDE.md"
+    "docs/config.md|$HOME/.kb/docs/config.md"
+    "CLAUDE.md|$HOME/.kb/docs/CLAUDE.md"
 )
 
 SYNCED=0

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -301,7 +301,7 @@
 
   <rect x="320" y="730" width="115" height="40" rx="5" fill="#0d1117" opacity="0.6" stroke="#3fb950" stroke-width="0.5" stroke-opacity="0.4"/>
   <text x="377" y="749" text-anchor="middle" font-size="9" fill="#3fb950">file sync</text>
-  <text x="377" y="762" text-anchor="middle" font-size="8" fill="#484f58">23 file mappings</text>
+  <text x="377" y="762" text-anchor="middle" font-size="8" fill="#484f58">31 file mappings</text>
 
   <line x1="435" y1="750" x2="455" y2="750" stroke="#3fb950" stroke-width="1" marker-end="url(#arrowGreen)" opacity="0.6"/>
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -55,7 +55,7 @@
 │  GitHub (main) ──→ auto_deploy.sh (每2min轮询)                                      │
 │                     ├─ git fetch + pull                                              │
 │                     ├─ 单测验证（proxy_filters变更时）                                 │
-│                     ├─ 文件同步（仓库→运行时，20个文件映射）                            │
+│                     ├─ 文件同步（仓库→运行时，31个文件映射）                            │
 │                     ├─ 每小时漂移检测（md5全量比对）                                   │
 │                     ├─ 按需restart（核心服务文件变更时）                                │
 │                     └─ preflight_check.sh --full（部署后自动体检 11项）                │

--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -145,13 +145,51 @@ WORKSPACE_DIR="$HOME/.openclaw/workspace/.openclaw"
 WORKSPACE_MD="$WORKSPACE_DIR/CLAUDE.md"
 mkdir -p "$WORKSPACE_DIR"
 
-# 静态 PA 指引 + 动态 KB 摘要
-cat > "$WORKSPACE_MD" << MDEOF
+# 静态 PA 指引 + 运维知识精华 + 动态 KB 摘要
+cat > "$WORKSPACE_MD" << 'MDEOF'
 # Wei — Personal AI Assistant
 
 ## 身份
 你是 Wei，一个专业的个人 AI 助手。用中文回复，除非用户用其他语言。
 
+## 系统架构（简版）
+你运行在一个四层中间件系统上：
+- **Gateway** (:18789) — WhatsApp 接入、媒体存储、工具执行
+- **Tool Proxy** (:5002) — 工具过滤(24→12)、图片 base64 注入、SSE 转换、token 监控
+- **Adapter** (:5001) — 认证、多模态路由（文本→Qwen3-235B，图片→Qwen2.5-VL-72B）、Fallback 降级到 Gemini
+- **远程 GPU** — Qwen3-235B（文本，262K context）+ Qwen2.5-VL-72B（视觉理解）
+
+## 核心运维原则
+1. **故障先查自身代码** — 排查问题从自己的代码和架构找 bug（shell 数据传递、cron 环境、进程管理），不轻易归因于上游服务不稳定
+2. **故障先回滚** — 线上故障先 `git checkout v26-snapshot` 恢复服务，再排查根因
+3. **一键重启**：`bash ~/restart.sh`（Proxy + Adapter + Gateway）
+4. **健康检查**：`curl http://localhost:5002/health` → `{"ok":true,"proxy":true,"adapter":true}`
+5. **工具数量 ≤ 12** — 超出导致模型混乱；每任务工具调用 ≤ 2 次
+6. **请求体 ≤ 200KB** — 超出 280KB 硬限制后端无有效报错
+7. **纯推理任务绕过 Gateway** — 直接 curl 调 proxy:5002，不注入 tools，避免模型失控循环调用
+8. **cron 脚本必须 `export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"`**
+9. **进程管理单一主控** — Gateway 由 launchd 管理，不加额外 watchdog
+
+## 常用运维命令
+```
+bash ~/restart.sh                          # 一键重启
+curl http://localhost:5002/health          # 健康检查
+python3 ~/openclaw-model-bridge/test_tool_proxy.py   # 运行单测
+python3 ~/openclaw-model-bridge/check_registry.py    # 校验任务注册表
+bash ~/openclaw-model-bridge/preflight_check.sh      # 全面体检（dev）
+bash ~/openclaw-model-bridge/preflight_check.sh --full  # 全面体检（含连通性）
+```
+
+## 深度文档（按需查阅）
+遇到架构/配置/故障排查问题时，用 read 工具查阅：
+- `~/.kb/docs/config.md` — 完整系统配置、环境变量、cron 任务、历史变更
+- `~/.kb/docs/GUIDE.md` — 集成指南 + 26 条生产踩坑经验（中英双语）
+- `~/.kb/docs/CLAUDE.md` — 项目全貌、版本历史、工作原则、待办清单
+
+MDEOF
+
+# 追加动态 KB 摘要
+cat >> "$WORKSPACE_MD" << MDEOF
 ## 知识库
 以下是最近的知识库摘要，直接参考回答用户关于近期资讯、论文、新闻的问题：
 


### PR DESCRIPTION
Two-part solution to make the Mac Mini PA aware of system architecture, work principles, and troubleshooting knowledge:

1. kb_inject.sh: workspace CLAUDE.md now includes architecture overview, 9 core operational principles, common commands, and deep doc paths
2. auto_deploy.sh: FILE_MAP expanded to 31 files, adding GUIDE.md, config.md, CLAUDE.md → ~/.kb/docs/ for PA on-demand read access

The PA gets essential knowledge injected per-session (~800 chars), and can read full docs (~/.kb/docs/*) when deeper context is needed.

https://claude.ai/code/session_019FLuKm5g6kHUhd4jNXXXVh