### PR TITLE
feat: feedback loop + prediction backtest for trend reports

### DIFF
--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -124,6 +124,33 @@ for filename, (label, max_chars) in sources_map.items():
         text = '\n'.join(relevant)[:max_chars]
         sections.append(f"## {label}\n{text}")
 
+# ── 用户反馈（闭环进化的关键数据） ──
+feedback_items = []
+for f in sorted(glob.glob(os.path.join(notes_dir, '*.md')), reverse=True):
+    basename = os.path.basename(f)
+    file_date = basename[:8]
+    if file_date < cutoff:
+        break
+    try:
+        with open(f) as fh:
+            content = fh.read()
+        # 识别 feedback 类型的笔记
+        if 'type: feedback' in content[:200] or 'tags: [feedback]' in content[:200]:
+            # 提取正文
+            body = content
+            if body.startswith('---'):
+                parts = body.split('---', 2)
+                if len(parts) >= 3:
+                    body = parts[2].strip()
+            lines = [l.strip() for l in body.split('\n') if l.strip() and not l.startswith('#') and not l.startswith('20')]
+            if lines:
+                feedback_items.append(f"- [{file_date}] {lines[0][:150]}")
+    except OSError:
+        continue
+
+if feedback_items:
+    sections.append("## 用户反馈\n以下是用户最近的反馈，Claude Code 开工时请参考并采取行动：\n" + '\n'.join(feedback_items[:10]))
+
 # ── 使用提示 ──
 sections.append("""---
 > 此文件由 kb_inject.sh 每日自动生成。
@@ -179,6 +206,19 @@ python3 ~/openclaw-model-bridge/check_registry.py    # 校验任务注册表
 bash ~/openclaw-model-bridge/preflight_check.sh      # 全面体检（dev）
 bash ~/openclaw-model-bridge/preflight_check.sh --full  # 全面体检（含连通性）
 ```
+
+## 反馈捕获（重要！）
+当用户对推送内容（趋势报告、ArXiv、HN、周报等）给出反馈时，**必须**用 exec 工具保存到 KB：
+```
+bash ~/kb_write.sh "用户的反馈内容" "feedback" "feedback"
+```
+反馈示例：
+- "趋势报告里 npm 是噪音" → `bash ~/kb_write.sh "趋势报告噪音词：npm，应加入停用词" "feedback" "feedback"`
+- "这篇论文很有用" → `bash ~/kb_write.sh "用户认为有价值：[论文标题]" "feedback" "feedback"`
+- "以后少推货代的" → `bash ~/kb_write.sh "用户偏好：减少货代动态推送频率" "feedback" "feedback"`
+
+判断规则：用户回复中包含评价（好/不好/没用/太多/太少/噪音/有用/关注/不关注）时触发保存。
+不确定时宁可多存，反馈数据是系统进化的燃料。
 
 ## 深度文档（按需查阅）
 遇到架构/配置/故障排查问题时，用 read 工具查阅：

--- a/kb_trend.py
+++ b/kb_trend.py
@@ -375,6 +375,163 @@ def push_whatsapp(report_text, rising, emerging):
 
 
 # ---------------------------------------------------------------------------
+# 预测回测：上周预测 vs 本周实际
+# ---------------------------------------------------------------------------
+
+def backtest(report_dir, this_kw, emerging):
+    """从上周报告中提取预测关键词，与本周实际数据对比。"""
+    # 找到最近的历史报告（不含今天）
+    today_str = datetime.now().strftime("%Y%m%d")
+    reports = sorted(glob.glob(os.path.join(report_dir, "trend_*.md")), reverse=True)
+
+    prev_report = None
+    for r in reports:
+        rdate = os.path.basename(r).replace("trend_", "").replace(".md", "")
+        if rdate < today_str:
+            prev_report = r
+            break
+
+    if not prev_report:
+        return None
+
+    try:
+        with open(prev_report) as f:
+            prev_content = f.read()
+    except OSError:
+        return None
+
+    prev_date = os.path.basename(prev_report).replace("trend_", "").replace(".md", "")
+
+    # 提取上周的"新出现热词"和"上升趋势"
+    prev_rising = set()
+    prev_emerging = set()
+    section = None
+    for line in prev_content.split("\n"):
+        if "上升趋势" in line:
+            section = "rising"
+        elif "新出现热词" in line:
+            section = "emerging"
+        elif "消退话题" in line or "高频词" in line or "LLM" in line:
+            section = None
+        elif section == "rising" and "|" in line and "关键词" not in line and "---" not in line:
+            parts = line.split("|")
+            if len(parts) >= 2:
+                word = parts[1].strip()
+                if word:
+                    prev_rising.add(word)
+        elif section == "emerging" and line.strip().startswith("- **"):
+            word = line.split("**")[1] if "**" in line else ""
+            if word:
+                prev_emerging.add(word)
+
+    if not prev_rising and not prev_emerging:
+        return None
+
+    # 本周实际数据
+    this_dict = dict(this_kw)
+    this_emerging_set = {w for w, _ in emerging}
+
+    # 对比
+    results = {
+        "prev_date": prev_date,
+        "continued_rising": [],    # 上周上升，本周仍在 top 100
+        "faded_rising": [],        # 上周上升，本周消失
+        "confirmed_emerging": [],  # 上周新出现，本周仍活跃
+        "flash_emerging": [],      # 上周新出现，本周已消退
+    }
+
+    for w in prev_rising:
+        if w in this_dict:
+            results["continued_rising"].append((w, this_dict[w]))
+        else:
+            results["faded_rising"].append(w)
+
+    for w in prev_emerging:
+        if w in this_dict:
+            results["confirmed_emerging"].append((w, this_dict[w]))
+        else:
+            results["flash_emerging"].append(w)
+
+    total_predictions = len(prev_rising) + len(prev_emerging)
+    hits = len(results["continued_rising"]) + len(results["confirmed_emerging"])
+    accuracy = hits / total_predictions * 100 if total_predictions > 0 else 0
+    results["accuracy"] = round(accuracy, 1)
+    results["total"] = total_predictions
+    results["hits"] = hits
+
+    return results
+
+
+def format_backtest(bt):
+    """格式化回测结果为 Markdown。"""
+    lines = [
+        f"## 🔄 预测回测（上期 {bt['prev_date']} → 本期）",
+        f"> 命中率：**{bt['accuracy']}%**（{bt['hits']}/{bt['total']}）",
+    ]
+    if bt["continued_rising"]:
+        items = ", ".join(f"{w}({c}次)" for w, c in bt["continued_rising"][:8])
+        lines.append(f"\n**持续上升** ✅：{items}")
+    if bt["confirmed_emerging"]:
+        items = ", ".join(f"{w}({c}次)" for w, c in bt["confirmed_emerging"][:8])
+        lines.append(f"**确认热词** ✅：{items}")
+    if bt["faded_rising"]:
+        items = ", ".join(bt["faded_rising"][:8])
+        lines.append(f"**昙花一现** ❌：{items}")
+    if bt["flash_emerging"]:
+        items = ", ".join(bt["flash_emerging"][:8])
+        lines.append(f"**一周即退** ❌：{items}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 用户反馈集成
+# ---------------------------------------------------------------------------
+
+def load_feedback(kb_dir, days=14):
+    """从 KB 中读取用户反馈，提取对趋势报告的优化建议。"""
+    notes_dir = os.path.join(kb_dir, "notes")
+    cutoff = (datetime.now() - timedelta(days=days)).strftime("%Y%m%d")
+    feedback = []
+    for f in sorted(glob.glob(os.path.join(notes_dir, "*.md")), reverse=True):
+        basename = os.path.basename(f)
+        file_date = basename[:8]
+        if file_date < cutoff:
+            break
+        try:
+            with open(f) as fh:
+                content = fh.read()
+            if "type: feedback" in content[:200] or "tags: [feedback]" in content[:200]:
+                body = content
+                if body.startswith("---"):
+                    parts = body.split("---", 2)
+                    if len(parts) >= 3:
+                        body = parts[2].strip()
+                lines = [l.strip() for l in body.split("\n")
+                         if l.strip() and not l.startswith("#") and not l.startswith("20")]
+                if lines:
+                    feedback.append(lines[0][:200])
+        except OSError:
+            continue
+    return feedback
+
+
+def apply_feedback_stopwords(feedback_items):
+    """从反馈中提取应该加入停用词的词。返回额外停用词集合。"""
+    extra_stops = set()
+    noise_patterns = re.compile(r"噪音[词：:]\s*(.+)|noise\s*(?:word)?[：:]\s*(.+)|停用词[：:]\s*(.+)", re.I)
+    for fb in feedback_items:
+        m = noise_patterns.search(fb)
+        if m:
+            words_str = m.group(1) or m.group(2) or m.group(3)
+            # 支持逗号、顿号、空格分隔
+            for w in re.split(r"[,，、\s]+", words_str):
+                w = w.strip().lower()
+                if w and len(w) > 1:
+                    extra_stops.add(w)
+    return extra_stops
+
+
+# ---------------------------------------------------------------------------
 # 主流程
 # ---------------------------------------------------------------------------
 
@@ -403,6 +560,15 @@ def main():
     log(f"本周: {this_start.strftime('%m/%d')}-{this_end.strftime('%m/%d')} | "
         f"上周: {last_start.strftime('%m/%d')}-{last_end.strftime('%m/%d')}")
 
+    # 读取用户反馈，动态扩充停用词
+    feedback = load_feedback(KB_DIR)
+    if feedback:
+        extra_stops = apply_feedback_stopwords(feedback)
+        if extra_stops:
+            STOP_WORDS.update(extra_stops)
+            log(f"从反馈中加载 {len(extra_stops)} 个额外停用词: {extra_stops}")
+        log(f"读取到 {len(feedback)} 条用户反馈")
+
     # 提取文本
     this_text = extract_period_text(KB_DIR, this_start, this_end)
     last_text = extract_period_text(KB_DIR, last_start, last_end)
@@ -424,6 +590,11 @@ def main():
 
     log(f"上升: {len(rising)} | 新出现: {len(emerging)} | 消退: {len(fading)}")
 
+    # 预测回测（所有模式共用）
+    bt = backtest(REPORT_DIR, this_kw, emerging)
+    if bt:
+        log(f"预测回测: 命中率 {bt['accuracy']}% ({bt['hits']}/{bt['total']})")
+
     # JSON 输出模式
     if args.json:
         result = {
@@ -436,6 +607,10 @@ def main():
             "fading": [{"word": w, "last_count": c} for w, c in fading],
             "top_keywords": [{"word": w, "count": c} for w, c in this_kw[:30]],
         }
+        if bt:
+            result["backtest"] = bt
+        if feedback:
+            result["feedback_count"] = len(feedback)
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return
 
@@ -452,6 +627,10 @@ def main():
         rising, emerging, fading, llm_result,
         this_kw, last_kw, len(this_text), len(last_text), args.weeks
     )
+    # 插入回测结果（在 LLM 分析之前）
+    if bt:
+        bt_section = format_backtest(bt)
+        report = report.replace("## 🤖 LLM 趋势分析", f"{bt_section}\n\n## 🤖 LLM 趋势分析")
 
     # 写入文件
     os.makedirs(REPORT_DIR, exist_ok=True)
@@ -481,6 +660,11 @@ def main():
             print(f"\n📉 消退:")
             for w, c in fading[:5]:
                 print(f"   {w} (上周{c}次)")
+        if bt:
+            print(f"\n🔄 预测回测 (上期 {bt['prev_date']}):")
+            print(f"   命中率: {bt['accuracy']}% ({bt['hits']}/{bt['total']})")
+        if feedback:
+            print(f"\n💬 用户反馈: {len(feedback)} 条已应用")
         print(f"\n📄 完整报告: {report_file}")
 
 


### PR DESCRIPTION
Three-part feedback loop implementation:

1. PA feedback capture: workspace CLAUDE.md instructs the WhatsApp PA to auto-save user feedback (noise words, preferences, ratings) to KB via `kb_write.sh` with type=feedback tag

2. Feedback surfacing: kb_inject.sh extracts recent feedback notes and includes them in daily_digest.md, visible to both PA and Claude Code on next session start

3. Prediction backtest: kb_trend.py reads previous week's report, extracts predicted rising/emerging keywords, compares with this week's actual data, and reports accuracy percentage. Also reads KB feedback to dynamically add stop words (e.g., user says "npm is noise" → auto-filtered next run)

Data flow:
  User feedback (WhatsApp) → PA saves to KB → kb_inject extracts →
  daily_digest.md → Claude Code reads → implements improvements →
  kb_trend reads feedback → auto-adjusts → better report next week

https://claude.ai/code/session_019FLuKm5g6kHUhd4jNXXXVh