### PR TITLE
fix: security hardening + version pinning + doc drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ python3 mm_index.py && python3 mm_search.py "cat photos"
 | `upgrade_openclaw.sh` | Gateway upgrade SOP (must run via SSH, never via WhatsApp) |
 | `smoke_test.sh` | End-to-end smoke test (unit tests + registry + doc drift + connectivity) |
 
-### Scheduled Jobs (20 active)
+### Scheduled Jobs (21 registered, 19 active)
 
 All jobs registered in `jobs_registry.yaml`. Validate: `python3 check_registry.py`
 
@@ -186,12 +186,13 @@ All jobs registered in `jobs_registry.yaml`. Validate: `python3 check_registry.p
 | `auto_deploy.sh` | Every 2 min | Git → runtime auto-sync |
 | `job_watchdog.sh` | Hourly:30 | Job health monitoring |
 | `wa_keepalive.sh` | Every 30 min | WhatsApp session probe |
+| `kb_trend.py` | Sat 09:00 | Weekly AI trend report (keyword trends + LLM analysis) |
 
 ### Configuration & Testing
 
 | File | Description |
 |------|-------------|
-| `jobs_registry.yaml` | Unified job registry — 20 jobs, system cron |
+| `jobs_registry.yaml` | Unified job registry — 21 jobs (19 active, 2 disabled), system cron |
 | `check_registry.py` | Registry validator — ID uniqueness, paths, fields |
 | `gen_jobs_doc.py` | Auto-generate job docs from registry + drift detection |
 | `test_tool_proxy.py` | Unit tests for proxy_filters (43 cases) |
@@ -266,7 +267,7 @@ python3 test_tool_proxy.py              # 43 proxy_filters tests
 python3 test_check_registry.py          # 18 registry tests
 
 # Registry validation
-python3 check_registry.py               # Validate all 20 jobs
+python3 check_registry.py               # Validate all 21 jobs
 
 # Doc drift detection
 python3 gen_jobs_doc.py --check          # Compare registry vs docs

--- a/adapter.py
+++ b/adapter.py
@@ -346,11 +346,12 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
 fb_info = f" (fallback: {FALLBACK['name']}/{FALLBACK['model_id']})" if FALLBACK else " (no fallback)"
 vl_info = f" (VL: {VL_MODEL_ID})" if VL_MODEL_ID else ""
 fast_info = f" (fast: {FAST_ROUTE['name']}/{FAST_ROUTE['model_id']})" if FAST_ROUTE else ""
-log(f"Starting on :{PORT} -> {TARGET_BASE} (model: {REAL_MODEL_ID}){vl_info}{fb_info}{fast_info}")
+BIND_ADDR = os.environ.get("BIND_ADDR", "127.0.0.1")
+log(f"Starting on {BIND_ADDR}:{PORT} -> {TARGET_BASE} (model: {REAL_MODEL_ID}){vl_info}{fb_info}{fast_info}")
 sys.stdout.flush()
 class ThreadedServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     daemon_threads = True
     allow_reuse_address = True
 
-with ThreadedServer(("", PORT), ProxyHandler) as httpd:
+with ThreadedServer((BIND_ADDR, PORT), ProxyHandler) as httpd:
     httpd.serve_forever()

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -19,7 +19,7 @@
 - [Knowledge Base System / 知识库系统](#knowledge-base-system--知识库系统v29)
 - [Local AI / 本地 AI](#local-ai--本地-aiv293)
 - [Monitoring / 监控](#monitoring--监控)
-- [26 Hard-Won Lessons / 26条踩坑经验](#26-hard-won-lessons--26条踩坑经验)
+- [27 Hard-Won Lessons / 27条踩坑经验](#26-hard-won-lessons--26条踩坑经验)
 
 ---
 
@@ -470,7 +470,7 @@ curl http://localhost:18789/health  # Gateway
 
 ---
 
-## 26 Hard-Won Lessons / 26条踩坑经验
+## 27 Hard-Won Lessons / 27条踩坑经验
 
 Lessons learned from production operation. Read these before debugging.
 

--- a/requirements-mm.txt
+++ b/requirements-mm.txt
@@ -1,4 +1,5 @@
 # Multimodal Memory 依赖 (mm_index.py, mm_search.py)
 # Install: pip3 install -r requirements-mm.txt
-google-genai>=0.3.0
-numpy>=1.24.0
+# Pin versions for reproducibility (update periodically via pip-compile or manual review)
+google-genai==0.8.3
+numpy==1.26.4

--- a/requirements-rag.txt
+++ b/requirements-rag.txt
@@ -1,3 +1,4 @@
 # KB RAG 语义搜索依赖 (kb_embed.py, kb_rag.py, local_embed.py)
 # Install: pip3 install -r requirements-rag.txt
-sentence-transformers>=2.2.0
+# Pin versions for reproducibility (update periodically via pip-compile or manual review)
+sentence-transformers==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
 # Core services (tool_proxy.py, proxy_filters.py, adapter.py)
 # 核心服务仅使用 Python 标准库，无第三方依赖
 
-# --- Optional: KB RAG (kb_embed.py, kb_rag.py, local_embed.py) ---
-# pip3 install -r requirements-rag.txt
-# sentence-transformers>=2.2.0
+# --- Optional modules (install as needed) ---
+# KB RAG (kb_embed.py, kb_rag.py, local_embed.py):
+#   pip3 install -r requirements-rag.txt
+#
+# Multimodal Memory (mm_index.py, mm_search.py):
+#   pip3 install -r requirements-mm.txt
+#
+# Freight Watcher (importyeti_scraper.py):
+#   pip3 install playwright && python3 -m playwright install chromium
 
-# --- Optional: Multimodal Memory (mm_index.py, mm_search.py) ---
-# pip3 install -r requirements-mm.txt
-# google-genai>=0.3.0
-# numpy>=1.24.0
+# Version policy: pin exact versions in requirements-*.txt for reproducibility.
+# Review and update quarterly or when upstream releases critical fixes.

--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -212,12 +212,13 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(err)
 
 
-log(f"Starting on :{PORT} -> {BACKEND}")
+BIND_ADDR = os.environ.get("BIND_ADDR", "127.0.0.1")
+log(f"Starting on {BIND_ADDR}:{PORT} -> {BACKEND}")
 log(f"Allowed: {ALLOWED_TOOLS} + prefix: {ALLOWED_PREFIXES}")
 sys.stdout.flush()
 class ThreadedServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     daemon_threads = True
     allow_reuse_address = True
 
-with ThreadedServer(("", PORT), ProxyHandler) as httpd:
+with ThreadedServer((BIND_ADDR, PORT), ProxyHandler) as httpd:
     httpd.serve_forever()


### PR DESCRIPTION
Based on external engineering review feedback:

1. Security: Bind adapter.py and tool_proxy.py to 127.0.0.1 instead of 0.0.0.0. Services are localhost-only by design (Gateway on same machine). Override via BIND_ADDR env var if needed.

2. Version pinning: Pin exact versions in requirements-rag.txt (sentence-transformers==2.7.0) and requirements-mm.txt (google-genai==0.8.3, numpy==1.26.4). Prevents silent upstream breakage on pip install.

3. Doc drift fixes: README job counts updated to match registry (21 registered, 19 active, 2 disabled). Added kb_trend.py to scheduled jobs table. GUIDE.md lessons updated to 27.

https://claude.ai/code/session_019FLuKm5g6kHUhd4jNXXXVh