### PR TITLE
fix: restart.sh #48703 grep pipe error under set -eo pipefail

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -29,7 +29,8 @@ sleep 1
 OPENCLAW_DIST="/opt/homebrew/lib/node_modules/openclaw/dist"
 if [ -d "$OPENCLAW_DIST" ]; then
     UNPATCHED=$(grep -rl 'const listeners = /\* @__PURE__ \*/ new Map()' \
-        "$OPENCLAW_DIST" --include="*.js" 2>/dev/null | grep -v ".bak" | wc -l | tr -d ' ' || echo 0)
+        "$OPENCLAW_DIST" --include="*.js" 2>/dev/null | grep -vc ".bak" || true)
+    UNPATCHED="${UNPATCHED:-0}"
     if [ "$UNPATCHED" -gt 0 ]; then
         echo "[restart] Applying #48703 hotfix ($UNPATCHED files)..."
         sudo sed -i.bak \


### PR DESCRIPTION
grep -rl with no matches returns non-zero, causing `|| echo 0` to append extra "0" line to wc -l output → "0\n0" breaks integer test. Use grep -vc with || true instead.

https://claude.ai/code/session_01GxwHNNWy1cXnnvhrZJ7nxF