### PR TITLE
feat: KB security hardening — status refresh + integrity check + atom…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,9 @@
 | `cron_doctor.sh` | **V30新增** 定时任务全面诊断工具（7项检查：crontab/锁文件/心跳/服务/环境/时效/系统） |
 | `cron_canary.sh` | **V30新增** Cron 心跳金丝雀（每10分钟，零依赖，原子写入） |
 | `crontab_safe.sh` | **V30新增** 安全 crontab 操作（自动备份+条目数验证+回滚保护） |
-| `test_cron_health.py` | **V30新增** 定时任务健康检测单测（72个用例：锁/心跳/告警/原子写入/损坏恢复/daemon检测） |
+| `test_cron_health.py` | **V30新增** 定时任务健康检测单测（94个用例：锁/心跳/告警/原子写入/损坏恢复/daemon检测/完整性/状态刷新） |
+| `kb_status_refresh.sh` | **V30.1新增** 每小时刷新 status.json 系统健康字段（三层服务/模型ID/KB统计/过期job），补齐三方宪法实时同步 |
+| `kb_integrity.py` | **V30.1新增** KB 文件完整性校验器（SHA256 指纹比对、目录文件数监控、权限检查、status.json 结构验证） |
 
 ## V30 变更摘要（2026-03-26）
 
@@ -183,6 +185,18 @@
 - **任何 `exit 0` 的代码路径都应有日志** — 静默成功和静默失败外观相同
 - **共享状态文件必须原子写入** — 被多进程读写的文件（stats/meta/status）一律 `tmp + replace`
 - **监控不能依赖被监控对象** — 告警通道必须有独立于被告警服务的回退
+
+## V30.1 变更摘要（2026-03-26）
+
+> 三方宪法安全加固：status.json 实时刷新 + KB 完整性校验 + 原子写入全覆盖
+
+1. **status.json 每小时自动刷新**：`kb_status_refresh.sh` — 聚合三层服务状态、模型ID、KB统计、过期job，写入 `status.json`；PA/Claude Code 读到的不再是几小时前的快照
+2. **KB 完整性校验器**：`kb_integrity.py` — SHA256 指纹比对关键文件（index.json/status.json/daily_digest.md）、目录文件数骤降检测、权限检查（other 不可读）、status.json 结构完整性验证；支持 `--init`/`--update`/`--json`
+3. **kb_inject.sh 原子写入**：daily_digest.md 和 workspace CLAUDE.md 均改为 `tmp + replace/mv`，防 crash 损坏
+4. **KB 目录权限收紧**：`~/.kb/` 设为 750、关键文件设为 640，阻止 other 用户读取
+5. **status.json 独立备份**：`openclaw_backup.sh` 新增 status_history/ 目录，每日独立备份，保留 30 天历史；备份后自动刷新完整性指纹
+6. **status_update.py 字段扩展**：新增 `kb_stats`、`stale_jobs`、`last_refresh` 字段，供三方实时消费
+7. **单测扩展至 179 个**：新增 22 个测试（状态刷新/完整性校验/原子写入/备份/字段完整性）
 
 ## V27 变更摘要
 

--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -119,9 +119,11 @@ declare -a FILE_MAP=(
     "kb_dedup.py|$HOME/kb_dedup.py"
     "kb_autotag.py|$HOME/kb_autotag.py"
 
-    # KB 趋势报告 + 状态共享
+    # KB 趋势报告 + 状态共享 + 安全
     "kb_trend.py|$HOME/kb_trend.py"
     "status_update.py|$HOME/status_update.py"
+    "kb_status_refresh.sh|$HOME/kb_status_refresh.sh"
+    "kb_integrity.py|$HOME/kb_integrity.py"
 
     # 自部署（bootstrapping）
     "auto_deploy.sh|$HOME/openclaw-model-bridge/auto_deploy.sh"

--- a/docs/config.md
+++ b/docs/config.md
@@ -267,6 +267,7 @@ export GEMINI_API_KEY="AIzaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"   # V29.1新增
 | kb-embed | 每4小时:30分 | `~/kb_embed.py` | `~/kb_embed.log` | ✅ V29.3新增：KB文本向量索引（本地sentence-transformers，增量分块，供RAG搜索） |
 | kb-trend | 每周六09:00 | `~/kb_trend.py` | `~/kb_trend.log` | ✅ V29.5新增：KB周趋势报告（本周vs上周关键词+LLM分析+WhatsApp推送） |
 | cron-canary | 每10分钟 | `~/cron_canary.sh` | 无（写 `~/.cron_canary`） | ✅ V30新增：Cron心跳金丝雀（零依赖、零锁文件、原子写入），供watchdog/doctor检测cron daemon存活 |
+| kb-status-refresh | 每小时整点 | `~/kb_status_refresh.sh` | `~/kb_status_refresh.log` | ✅ V30.1新增：每小时刷新status.json系统健康字段（三层服务/模型ID/KB统计/过期job） |
 | auto-deploy | 每2分钟 | `~/openclaw-model-bridge/auto_deploy.sh` | `~/.openclaw/logs/auto_deploy.log` | ✅ V27.1新增+V28.1：部署后自动体检 |
 | weekly-health-check | 每周一09:00 | `~/health_check.sh` | `~/health_check.log` | ✅ V29.1：从openclaw cron迁移至系统crontab，直接执行不经LLM |
 | gateway-watchdog | ~~每30分钟~~ | `~/restart.sh` | `~/.openclaw/logs/gateway_watchdog.log` | ❌ **已移除**（#95：与launchd KeepAlive双主控冲突，导致误杀gateway） |
@@ -287,6 +288,7 @@ export GEMINI_API_KEY="AIzaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"   # V29.1新增
 0 3 * * * bash -lc "$HOME/openclaw_backup.sh >> $HOME/openclaw_backup.log 2>&1"
 0 9 * * 6 bash -lc '$HOME/kb_trend.py >> $HOME/kb_trend.log 2>&1'
 */10 * * * * bash -lc 'bash $HOME/cron_canary.sh'
+0 * * * * bash -lc 'bash $HOME/kb_status_refresh.sh >> $HOME/kb_status_refresh.log 2>&1'
 */2 * * * * bash -lc 'bash $HOME/openclaw-model-bridge/auto_deploy.sh >> $HOME/.openclaw/logs/auto_deploy.log 2>&1'
 ```
 > 💡 **架构说明**：系统crontab用`bash -lc`加载完整登录环境（含`$HOME`、`$PATH`等环境变量），避免cron空环境导致命令找不到。创建日志目录前置在`mkdir -p`确保首次运行不失败。

--- a/jobs_registry.yaml
+++ b/jobs_registry.yaml
@@ -209,3 +209,12 @@ jobs:
     needs_api_key: false
     enabled: true
     description: Cron 心跳金丝雀 — 写 epoch 到 ~/.cron_canary，供 watchdog/doctor 验证 cron daemon 存活
+
+  - id: kb_status_refresh
+    scheduler: system
+    entry: kb_status_refresh.sh
+    interval: "0 * * * *"           # 每小时整点
+    log: ~/kb_status_refresh.log
+    needs_api_key: false
+    enabled: true
+    description: 每小时刷新 status.json 系统健康字段（三层服务/模型ID/KB统计/过期job），补齐三方宪法实时同步需求

--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -157,10 +157,12 @@ sections.append("""---
 > 用户询问最近资讯/论文/新闻时，请参考以上内容回答。
 > 需要更详细信息，可用 read 工具读取 ~/.kb/sources/ 下的完整归档。""")
 
-# ── 写入 ──
+# ── 原子写入（tmp + replace，防 crash 损坏）──
 output = '\n\n'.join(sections) + '\n'
-with open(digest_file, 'w') as f:
+tmp = digest_file + '.tmp'
+with open(tmp, 'w') as f:
     f.write(output)
+import os; os.replace(tmp, digest_file)
 
 print(f"OK: {digest_file} ({len(output)} chars, {len(note_items)} notes)")
 PYEOF
@@ -172,8 +174,9 @@ WORKSPACE_DIR="$HOME/.openclaw/workspace/.openclaw"
 WORKSPACE_MD="$WORKSPACE_DIR/CLAUDE.md"
 mkdir -p "$WORKSPACE_DIR"
 
-# 静态 PA 指引 + 运维知识精华 + 动态 KB 摘要
-cat > "$WORKSPACE_MD" << 'MDEOF'
+# 静态 PA 指引 + 运维知识精华 + 动态 KB 摘要（原子写入）
+WORKSPACE_TMP="$WORKSPACE_MD.tmp"
+cat > "$WORKSPACE_TMP" << 'MDEOF'
 # Wei — Personal AI Assistant
 
 ## 身份
@@ -241,7 +244,7 @@ bash ~/kb_write.sh "用户的反馈内容" "feedback" "feedback"
 MDEOF
 
 # 追加动态 KB 摘要
-cat >> "$WORKSPACE_MD" << MDEOF
+cat >> "$WORKSPACE_TMP" << MDEOF
 ## 知识库
 以下是最近的知识库摘要，直接参考回答用户关于近期资讯、论文、新闻的问题：
 
@@ -272,7 +275,13 @@ $(cat "$DIGEST_FILE" 2>/dev/null || echo '（摘要暂未生成）')
 查看索引统计：\`python3 ~/mm_search.py --stats\`
 MDEOF
 
+mv "$WORKSPACE_TMP" "$WORKSPACE_MD"
 log "workspace CLAUDE.md 已同步 ($(wc -c < "$WORKSPACE_MD" | tr -d ' ') bytes)"
+
+# ── 权限收紧（防止 other 用户读取 KB 数据）──
+chmod 750 "$KB_DIR" 2>/dev/null || true
+chmod 640 "$KB_DIR/status.json" 2>/dev/null || true
+chmod 640 "$KB_DIR/index.json" 2>/dev/null || true
 
 # ── rsync 备份 ──
 rsync -a --quiet "$KB_DIR/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true

--- a/kb_integrity.py
+++ b/kb_integrity.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""kb_integrity.py — KB 文件完整性校验器（V30.1 新增）
+
+每日运行，为 ~/.kb/ 关键文件生成 SHA256 指纹并比对上次记录。
+检测意外篡改、损坏、异常删除。
+
+用法：
+  python3 kb_integrity.py              # 校验（对比上次指纹）
+  python3 kb_integrity.py --init       # 首次初始化指纹库
+  python3 kb_integrity.py --update     # 更新指纹库（确认变更后）
+  python3 kb_integrity.py --json       # JSON 输出（供脚本调用）
+
+指纹库：~/.kb/.integrity/checksums.json
+"""
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+KB_DIR = os.path.expanduser("~/.kb")
+INTEGRITY_DIR = os.path.join(KB_DIR, ".integrity")
+CHECKSUMS_FILE = os.path.join(INTEGRITY_DIR, "checksums.json")
+
+# 关键文件——篡改/损坏会导致系统行为异常
+CRITICAL_FILES = [
+    "index.json",
+    "status.json",
+    "daily_digest.md",
+]
+
+# 关键目录——文件数量骤降可能表示意外删除
+CRITICAL_DIRS = {
+    "notes": 0,      # 动态阈值，初始化时记录
+    "sources": 0,
+    "text_index": 0,
+    "mm_index": 0,
+}
+
+# 不校验的路径模式
+SKIP_PATTERNS = {".integrity", ".write.lockdir", "__pycache__", ".tmp"}
+
+
+def sha256_file(path):
+    """计算文件 SHA256"""
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def scan_critical_files():
+    """扫描关键文件，返回 {rel_path: sha256}"""
+    checksums = {}
+    for name in CRITICAL_FILES:
+        path = os.path.join(KB_DIR, name)
+        if os.path.isfile(path):
+            checksums[name] = sha256_file(path)
+    return checksums
+
+
+def scan_dir_counts():
+    """统计关键目录文件数"""
+    counts = {}
+    for dirname in CRITICAL_DIRS:
+        dirpath = os.path.join(KB_DIR, dirname)
+        if os.path.isdir(dirpath):
+            count = sum(1 for f in os.listdir(dirpath)
+                        if os.path.isfile(os.path.join(dirpath, f))
+                        and not f.startswith("."))
+            counts[dirname] = count
+        else:
+            counts[dirname] = 0
+    return counts
+
+
+def scan_permissions():
+    """检查 ~/.kb/ 目录权限"""
+    issues = []
+    try:
+        st = os.stat(KB_DIR)
+        mode = oct(st.st_mode)[-3:]
+        # 目录应该是 700 或 750（不允许 other 读写）
+        if int(mode[2]) > 0:
+            issues.append(f"~/.kb/ 权限 {mode}：other 有访问权限（应为 700 或 750）")
+    except OSError:
+        issues.append("~/.kb/ 不存在或无法访问")
+
+    # 检查 status.json 权限
+    status_path = os.path.join(KB_DIR, "status.json")
+    if os.path.isfile(status_path):
+        st = os.stat(status_path)
+        mode = oct(st.st_mode)[-3:]
+        if int(mode[2]) > 0:
+            issues.append(f"status.json 权限 {mode}：other 有访问权限")
+
+    return issues
+
+
+def load_checksums():
+    """加载上次的指纹记录"""
+    if not os.path.isfile(CHECKSUMS_FILE):
+        return None
+    try:
+        with open(CHECKSUMS_FILE) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def save_checksums(data):
+    """原子保存指纹"""
+    os.makedirs(INTEGRITY_DIR, exist_ok=True)
+    data["updated"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    tmp = CHECKSUMS_FILE + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, CHECKSUMS_FILE)
+
+
+def verify(json_output=False):
+    """校验当前状态 vs 上次记录"""
+    prev = load_checksums()
+    if prev is None:
+        msg = "指纹库不存在，请先运行 python3 kb_integrity.py --init"
+        if json_output:
+            print(json.dumps({"status": "no_baseline", "message": msg}))
+        else:
+            print(f"⚠️  {msg}")
+        return 1
+
+    alerts = []
+    info = []
+
+    # 1. 关键文件指纹比对
+    current_checksums = scan_critical_files()
+    prev_checksums = prev.get("checksums", {})
+
+    for name in CRITICAL_FILES:
+        prev_hash = prev_checksums.get(name)
+        curr_hash = current_checksums.get(name)
+
+        if prev_hash and not curr_hash:
+            alerts.append(f"❌ {name} 已消失（上次存在）")
+        elif prev_hash and curr_hash and prev_hash != curr_hash:
+            info.append(f"📝 {name} 已变更（正常更新或需确认）")
+        elif not prev_hash and curr_hash:
+            info.append(f"✨ {name} 新增")
+
+    # 2. 目录文件数变化
+    current_counts = scan_dir_counts()
+    prev_counts = prev.get("dir_counts", {})
+
+    for dirname, curr_count in current_counts.items():
+        prev_count = prev_counts.get(dirname, 0)
+        if prev_count > 0 and curr_count == 0:
+            alerts.append(f"❌ {dirname}/ 目录已清空（{prev_count} → 0）")
+        elif prev_count > 10 and curr_count < prev_count * 0.5:
+            alerts.append(f"⚠️  {dirname}/ 文件数骤降（{prev_count} → {curr_count}）")
+        elif curr_count > prev_count:
+            info.append(f"📈 {dirname}/: {prev_count} → {curr_count} 文件")
+
+    # 3. 权限检查
+    perm_issues = scan_permissions()
+    for issue in perm_issues:
+        alerts.append(f"🔒 {issue}")
+
+    # 4. status.json 结构完整性
+    status_path = os.path.join(KB_DIR, "status.json")
+    if os.path.isfile(status_path):
+        try:
+            with open(status_path) as f:
+                status = json.load(f)
+            required_keys = {"priorities", "recent_changes", "feedback", "health", "focus"}
+            missing = required_keys - set(status.keys())
+            if missing:
+                alerts.append(f"⚠️  status.json 缺少字段: {missing}")
+        except json.JSONDecodeError:
+            alerts.append("❌ status.json JSON 格式损坏")
+
+    # 输出
+    if json_output:
+        result = {
+            "status": "alert" if alerts else "ok",
+            "alerts": alerts,
+            "info": info,
+            "checksums": current_checksums,
+            "dir_counts": current_counts,
+            "baseline_time": prev.get("updated", "unknown"),
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print(f"🔍 KB 完整性校验 ({ts})")
+        print(f"   基线时间: {prev.get('updated', 'unknown')}")
+        print()
+
+        if alerts:
+            print("🚨 告警:")
+            for a in alerts:
+                print(f"  {a}")
+            print()
+
+        if info:
+            print("ℹ️  变更:")
+            for i in info:
+                print(f"  {i}")
+            print()
+
+        if not alerts and not info:
+            print("✅ 所有关键文件完好，无异常变更")
+
+        # 目录统计
+        print(f"\n📊 目录统计:")
+        for dirname, count in current_counts.items():
+            prev_count = prev_counts.get(dirname, "?")
+            print(f"  {dirname}/: {count} 文件 (上次: {prev_count})")
+
+    return 1 if alerts else 0
+
+
+def init_or_update():
+    """初始化或更新指纹库"""
+    checksums = scan_critical_files()
+    dir_counts = scan_dir_counts()
+
+    data = {
+        "checksums": checksums,
+        "dir_counts": dir_counts,
+    }
+    save_checksums(data)
+
+    print(f"✅ 指纹库已{'更新' if os.path.isfile(CHECKSUMS_FILE) else '初始化'}")
+    print(f"   关键文件: {len(checksums)} 个")
+    for name, h in checksums.items():
+        print(f"     {name}: {h[:16]}...")
+    print(f"   目录统计:")
+    for dirname, count in dir_counts.items():
+        print(f"     {dirname}/: {count} 文件")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="KB 文件完整性校验")
+    parser.add_argument("--init", action="store_true", help="初始化指纹库")
+    parser.add_argument("--update", action="store_true", help="更新指纹库")
+    parser.add_argument("--json", action="store_true", help="JSON 输出")
+    args = parser.parse_args()
+
+    if args.init or args.update:
+        init_or_update()
+    else:
+        sys.exit(verify(json_output=args.json))
+
+
+if __name__ == "__main__":
+    main()

--- a/kb_status_refresh.sh
+++ b/kb_status_refresh.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# kb_status_refresh.sh — 每小时自动刷新 status.json 系统健康字段
+# 三方宪法要求实时同步，但 status.json 之前仅在 Claude Code 开/收工 + 部署时更新
+# 本脚本补齐"自动感知"能力：每小时聚合系统状态写入 status.json
+# cron: 0 * * * *（每小时整点）
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+
+STATUS_UPDATE="${STATUS_UPDATE:-$HOME/status_update.py}"
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M')"
+
+# ── 1. 三层服务连通性 ─────────────────────────────────────────────
+GW=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:18789/health 2>/dev/null)
+PX=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:5002/health 2>/dev/null)
+AD=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:5001/health 2>/dev/null)
+
+if [ "$GW" = "200" ] && [ "$PX" = "200" ] && [ "$AD" = "200" ]; then
+    SVC_STATUS="ok"
+else
+    SVC_STATUS="degraded (GW:${GW} PX:${PX} AD:${AD})"
+fi
+
+python3 "$STATUS_UPDATE" --set health.services "$SVC_STATUS" --by cron 2>/dev/null || true
+
+# ── 2. 模型 ID（从 adapter /health 获取）─────────────────────────
+MODEL_ID=$(curl -s --max-time 5 http://localhost:5001/health 2>/dev/null | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('model_id', d.get('model', '')))
+except Exception:
+    print('')
+" 2>/dev/null)
+
+if [ -n "$MODEL_ID" ]; then
+    python3 "$STATUS_UPDATE" --set health.model_id "$MODEL_ID" --by cron 2>/dev/null || true
+fi
+
+# ── 3. KB 统计快照 ────────────────────────────────────────────────
+KB_DIR="$HOME/.kb"
+if [ -d "$KB_DIR" ]; then
+    KB_STATS=$(python3 -c "
+import json, os, glob
+from datetime import datetime, timedelta
+kb = os.path.expanduser('~/.kb')
+idx = os.path.join(kb, 'index.json')
+total = 0
+today = 0
+try:
+    with open(idx) as f:
+        entries = json.load(f).get('entries', [])
+    total = len(entries)
+    cutoff = (datetime.now() - timedelta(days=1)).strftime('%Y%m%d')
+    today = sum(1 for e in entries if e.get('date', '') >= cutoff)
+except Exception:
+    pass
+# sources 文件大小
+src_size = 0
+for f in glob.glob(os.path.join(kb, 'sources', '*.md')):
+    src_size += os.path.getsize(f)
+print(f'{total} notes, {today} today, {src_size // 1024}KB sources')
+" 2>/dev/null)
+    if [ -n "$KB_STATS" ]; then
+        python3 "$STATUS_UPDATE" --set health.kb_stats "$KB_STATS" --by cron 2>/dev/null || true
+    fi
+fi
+
+# ── 4. 最近 job 执行状态汇总 ──────────────────────────────────────
+STALE_JOBS=$(python3 -c "
+import json, os, time
+jobs = {
+    'arxiv': os.path.expanduser('~/.openclaw/jobs/arxiv_monitor/cache/last_run.json'),
+    'hn': os.path.expanduser('~/.openclaw/jobs/hn_watcher/cache/last_run.json'),
+    'freight': os.path.expanduser('~/.openclaw/jobs/freight_watcher/cache/last_run.json'),
+    'discussions': os.path.expanduser('~/.openclaw/jobs/openclaw_official/cache/last_run_discussions.json'),
+}
+stale = []
+now = time.time()
+for name, path in jobs.items():
+    try:
+        with open(path) as f:
+            d = json.load(f)
+        t = d.get('time', '')
+        from datetime import datetime, timedelta, timezone
+        dt = datetime.strptime(t, '%Y-%m-%d %H:%M:%S')
+        dt_utc = dt - timedelta(hours=8)
+        epoch = int(dt_utc.replace(tzinfo=timezone.utc).timestamp())
+        if now - epoch > 25200:  # 7h
+            stale.append(name)
+    except Exception:
+        stale.append(name)
+print(','.join(stale) if stale else 'all_ok')
+" 2>/dev/null)
+
+python3 "$STATUS_UPDATE" --set health.stale_jobs "${STALE_JOBS:-unknown}" --by cron 2>/dev/null || true
+python3 "$STATUS_UPDATE" --set health.last_refresh "$TS" --by cron 2>/dev/null || true
+
+echo "[$TS] kb_status_refresh: services=$SVC_STATUS stale_jobs=${STALE_JOBS:-unknown}"

--- a/openclaw_backup.sh
+++ b/openclaw_backup.sh
@@ -52,4 +52,20 @@ if [ "$DELETED" -gt 0 ]; then
     echo "[$TIMESTAMP] Cleaned $DELETED old backup(s)" >> "$LOG"
 fi
 
+# ── status.json 独立版本备份（三方共享状态是核心，单独保留 30 天历史）──
+STATUS_SRC="$HOME/.kb/status.json"
+STATUS_BACKUP_DIR="$BACKUP_DIR/status_history"
+if [ -f "$STATUS_SRC" ]; then
+    mkdir -p "$STATUS_BACKUP_DIR"
+    cp "$STATUS_SRC" "$STATUS_BACKUP_DIR/status_${DATE}.json"
+    # 清理超过 30 天的历史
+    find "$STATUS_BACKUP_DIR" -name "status_*.json" -mtime +30 -delete 2>/dev/null || true
+    echo "[$TIMESTAMP] status.json backed up to $STATUS_BACKUP_DIR/" >> "$LOG"
+fi
+
+# ── KB 完整性指纹更新（每日备份后自动刷新基线）──
+if [ -f "$HOME/kb_integrity.py" ]; then
+    python3 "$HOME/kb_integrity.py" --update >> "$LOG" 2>&1 || true
+fi
+
 echo "[$TIMESTAMP] === Backup done ===" >> "$LOG"

--- a/status_update.py
+++ b/status_update.py
@@ -53,6 +53,9 @@ DEFAULT_STATUS = {
         "last_preflight_time": "",
         "last_trend_report": "",
         "model_id": "",
+        "kb_stats": "",
+        "stale_jobs": "",
+        "last_refresh": "",
     },
 
     # 本周焦点（开工时 Claude Code 设置，PA 可引用）

--- a/test_cron_health.py
+++ b/test_cron_health.py
@@ -832,5 +832,210 @@ class TestUndeliveredAlertScanning(unittest.TestCase):
         shutil.rmtree(tmp_dir)
 
 
+class TestKbStatusRefresh(unittest.TestCase):
+    """测试 kb_status_refresh.sh"""
+
+    def test_script_syntax(self):
+        """kb_status_refresh.sh bash 语法正确"""
+        result = subprocess.run(
+            ["bash", "-n", "kb_status_refresh.sh"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, f"Syntax error: {result.stderr}")
+
+    def test_calls_status_update(self):
+        """kb_status_refresh.sh 调用 status_update.py"""
+        with open("kb_status_refresh.sh") as f:
+            content = f.read()
+        self.assertIn("status_update.py", content)
+        self.assertIn("health.services", content)
+        self.assertIn("health.last_refresh", content)
+
+    def test_checks_three_services(self):
+        """kb_status_refresh.sh 检查三层服务"""
+        with open("kb_status_refresh.sh") as f:
+            content = f.read()
+        self.assertIn("18789", content)  # Gateway
+        self.assertIn("5002", content)   # Proxy
+        self.assertIn("5001", content)   # Adapter
+
+    def test_checks_stale_jobs(self):
+        """kb_status_refresh.sh 检查过期 job"""
+        with open("kb_status_refresh.sh") as f:
+            content = f.read()
+        self.assertIn("stale_jobs", content)
+
+    def test_checks_kb_stats(self):
+        """kb_status_refresh.sh 聚合 KB 统计"""
+        with open("kb_status_refresh.sh") as f:
+            content = f.read()
+        self.assertIn("kb_stats", content)
+        self.assertIn("index.json", content)
+
+
+class TestKbIntegrity(unittest.TestCase):
+    """测试 kb_integrity.py"""
+
+    def test_python_syntax(self):
+        """kb_integrity.py Python 语法正确"""
+        result = subprocess.run(
+            ["python3", "-c", "import ast; ast.parse(open('kb_integrity.py').read())"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, f"Syntax error: {result.stderr}")
+
+    def test_sha256_function(self):
+        """SHA256 哈希计算正确"""
+        tmp_dir = tempfile.mkdtemp()
+        test_file = os.path.join(tmp_dir, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("hello world")
+        import hashlib
+        expected = hashlib.sha256(b"hello world").hexdigest()
+        # 验证我们的实现
+        h = hashlib.sha256()
+        with open(test_file, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+        self.assertEqual(h.hexdigest(), expected)
+        shutil.rmtree(tmp_dir)
+
+    def test_checks_critical_files(self):
+        """kb_integrity.py 校验关键文件"""
+        with open("kb_integrity.py") as f:
+            content = f.read()
+        self.assertIn("index.json", content)
+        self.assertIn("status.json", content)
+        self.assertIn("daily_digest.md", content)
+
+    def test_checks_permissions(self):
+        """kb_integrity.py 检查目录权限"""
+        with open("kb_integrity.py") as f:
+            content = f.read()
+        self.assertIn("scan_permissions", content)
+        self.assertIn("700", content)
+
+    def test_uses_atomic_save(self):
+        """kb_integrity.py 指纹库使用原子写入"""
+        with open("kb_integrity.py") as f:
+            content = f.read()
+        self.assertIn("os.replace(tmp,", content)
+
+    def test_detects_file_disappearance(self):
+        """kb_integrity.py 检测文件消失"""
+        with open("kb_integrity.py") as f:
+            content = f.read()
+        self.assertIn("已消失", content)
+
+    def test_detects_dir_count_drop(self):
+        """kb_integrity.py 检测目录文件数骤降"""
+        with open("kb_integrity.py") as f:
+            content = f.read()
+        self.assertIn("骤降", content)
+        self.assertIn("已清空", content)
+
+    def test_integrity_init_and_verify(self):
+        """模拟 kb_integrity 初始化 → 校验流程"""
+        tmp_dir = tempfile.mkdtemp()
+        # 创建模拟 KB 结构
+        os.makedirs(os.path.join(tmp_dir, "notes"))
+        os.makedirs(os.path.join(tmp_dir, ".integrity"))
+        for i in range(3):
+            with open(os.path.join(tmp_dir, "notes", f"note_{i}.md"), "w") as f:
+                f.write(f"note {i}")
+        status = os.path.join(tmp_dir, "status.json")
+        with open(status, "w") as f:
+            json.dump({"test": True}, f)
+
+        # 模拟初始化
+        checksums = {}
+        if os.path.isfile(status):
+            import hashlib
+            h = hashlib.sha256()
+            with open(status, "rb") as f:
+                h.update(f.read())
+            checksums["status.json"] = h.hexdigest()
+
+        note_count = len(os.listdir(os.path.join(tmp_dir, "notes")))
+        self.assertEqual(note_count, 3)
+        self.assertIn("status.json", checksums)
+
+        # 模拟文件被删除
+        os.remove(status)
+        self.assertFalse(os.path.exists(status))
+        shutil.rmtree(tmp_dir)
+
+
+class TestKbInjectAtomicWrite(unittest.TestCase):
+    """测试 kb_inject.sh 原子写入"""
+
+    def test_digest_uses_atomic_write(self):
+        """kb_inject.sh 使用 tmp + replace 写 daily_digest.md"""
+        with open("kb_inject.sh") as f:
+            content = f.read()
+        self.assertIn("digest_file + '.tmp'", content)
+        self.assertIn("os.replace(tmp, digest_file)", content)
+
+    def test_workspace_uses_atomic_write(self):
+        """kb_inject.sh 使用 tmp + mv 写 workspace CLAUDE.md"""
+        with open("kb_inject.sh") as f:
+            content = f.read()
+        self.assertIn("WORKSPACE_TMP", content)
+        self.assertIn('mv "$WORKSPACE_TMP" "$WORKSPACE_MD"', content)
+
+    def test_permissions_hardened(self):
+        """kb_inject.sh 收紧 KB 目录权限"""
+        with open("kb_inject.sh") as f:
+            content = f.read()
+        self.assertIn("chmod 750", content)
+        self.assertIn("chmod 640", content)
+
+
+class TestStatusJsonBackup(unittest.TestCase):
+    """测试 status.json 备份机制"""
+
+    def test_backup_includes_status(self):
+        """openclaw_backup.sh 备份 status.json"""
+        with open("openclaw_backup.sh") as f:
+            content = f.read()
+        self.assertIn("status.json", content)
+        self.assertIn("status_history", content)
+
+    def test_backup_keeps_30_days(self):
+        """status.json 保留 30 天历史"""
+        with open("openclaw_backup.sh") as f:
+            content = f.read()
+        self.assertIn("-mtime +30", content)
+
+    def test_backup_updates_integrity(self):
+        """备份后自动刷新完整性指纹"""
+        with open("openclaw_backup.sh") as f:
+            content = f.read()
+        self.assertIn("kb_integrity.py", content)
+        self.assertIn("--update", content)
+
+
+class TestStatusUpdateNewFields(unittest.TestCase):
+    """测试 status_update.py 新增字段"""
+
+    def test_has_kb_stats_field(self):
+        """status_update.py 包含 kb_stats 字段"""
+        with open("status_update.py") as f:
+            content = f.read()
+        self.assertIn('"kb_stats"', content)
+
+    def test_has_stale_jobs_field(self):
+        """status_update.py 包含 stale_jobs 字段"""
+        with open("status_update.py") as f:
+            content = f.read()
+        self.assertIn('"stale_jobs"', content)
+
+    def test_has_last_refresh_field(self):
+        """status_update.py 包含 last_refresh 字段"""
+        with open("status_update.py") as f:
+            content = f.read()
+        self.assertIn('"last_refresh"', content)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…ic writes

V30.1: Three-party constitution security upgrade

- kb_status_refresh.sh: hourly auto-refresh status.json (services/model/KB stats/stale jobs)
- kb_integrity.py: SHA256 file integrity checker (critical files + dir counts + permissions)
- kb_inject.sh: atomic writes for daily_digest.md and workspace CLAUDE.md (tmp+replace/mv)
- kb_inject.sh: harden ~/.kb/ permissions (750 dir, 640 critical files)
- openclaw_backup.sh: status.json independent backup (30-day history) + auto integrity refresh
- status_update.py: new fields (kb_stats, stale_jobs, last_refresh)
- auto_deploy.sh: FILE_MAP +2 (kb_status_refresh.sh, kb_integrity.py)
- tests: 94 cron_health tests (was 72), 179 total

https://claude.ai/code/session_01GxwHNNWy1cXnnvhrZJ7nxF