### PR TITLE
fix: preflight #12 exits silently due to set -euo pipefail + grep no …

### DIFF
--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -418,7 +418,7 @@ if $FULL_MODE; then
     if [ -d "$OPENCLAW_DIST" ]; then
         # 只扫描顶层 chunks（避免 821 个文件全量 grep 卡住）
         UNPATCHED=$(grep -l 'const listeners = /\* @__PURE__ \*/ new Map()' \
-            "$OPENCLAW_DIST"/*.js "$OPENCLAW_DIST"/chunks/*.js 2>/dev/null | grep -v ".bak" | wc -l | tr -d ' ')
+            "$OPENCLAW_DIST"/*.js "$OPENCLAW_DIST"/chunks/*.js 2>/dev/null | grep -v ".bak" | wc -l | tr -d ' ' || echo "0")
         if [ "$UNPATCHED" -gt 0 ]; then
             fail "#48703 未修复: $UNPATCHED 个文件有 listeners Map 副本"
         else


### PR DESCRIPTION
…match

grep returns exit code 1 when no matches found, which propagates through pipefail and causes the script to exit at check #12. Added || echo "0" fallback to handle the no-match case gracefully.

https://claude.ai/code/session_01JJ4jzA5z7XF7fRQ6wZsRys