### PR TITLE
fix: ArXiv seen_ids timing + status.json git sync

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -130,6 +130,9 @@ declare -a FILE_MAP=(
     # 数据清洗工具
     "data_clean.py|$HOME/data_clean.py"
 
+    # 三方宪法状态锚点（repo → ~/.kb/，Claude Code 收工写入的变更同步到 PA）
+    "status.json|$HOME/.kb/status.json"
+
     # 自部署（bootstrapping）
     "auto_deploy.sh|$HOME/openclaw-model-bridge/auto_deploy.sh"
 

--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -47,7 +47,8 @@ echo "[arxiv] XML抓取完成"
 PAPERS_FILE="$CACHE/papers.jsonl"
 SEEN_FILE="$CACHE/seen_ids.txt"
 touch "$SEEN_FILE"
-if ! python3 - "$FEED_FILE" "$MAX_AGE_DAYS" "$MAX_PAPERS" "$SEEN_FILE" << 'PYEOF' > "$PAPERS_FILE"
+NEW_IDS_FILE="$CACHE/new_ids.txt"
+if ! python3 - "$FEED_FILE" "$MAX_AGE_DAYS" "$MAX_PAPERS" "$SEEN_FILE" "$NEW_IDS_FILE" << 'PYEOF' > "$PAPERS_FILE"
 import sys, json, re, xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 
@@ -55,6 +56,7 @@ feed_file = sys.argv[1]
 max_age = int(sys.argv[2])
 max_papers = int(sys.argv[3])
 seen_file = sys.argv[4]
+new_ids_file = sys.argv[5]
 cutoff = datetime.now(timezone.utc) - timedelta(days=max_age)
 
 # Load previously sent paper IDs
@@ -113,11 +115,10 @@ for entry in root.findall("a:entry", NS):
     if count >= max_papers:
         break
 
-# Append new IDs to seen file
-if new_ids:
-    with open(seen_file, 'a') as f:
-        for aid in new_ids:
-            f.write(aid + '\n')
+# Write new IDs to separate file (NOT seen_file — only mark seen after successful push)
+with open(new_ids_file, 'w') as f:
+    for aid in new_ids:
+        f.write(aid + '\n')
 
 print(f"[arxiv] 解析完成: {count} 篇新论文（跳过 {len(seen_ids)} 篇已发送）", file=sys.stderr)
 PYEOF
@@ -336,10 +337,16 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${PAPER_COUNT} 篇论文"
+    # 推送成功后才标记为已发送（防止推送失败后论文被跳过）
+    if [ -f "$NEW_IDS_FILE" ]; then
+        cat "$NEW_IDS_FILE" >> "$SEEN_FILE"
+        log "已标记 ${PAPER_COUNT} 篇为已发送"
+    fi
     printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$PAPER_COUNT" > "$STATUS_FILE"
 else
     log "ERROR: 推送失败（${PAPER_COUNT} 篇待发）: $(cat "$SEND_ERR" | head -3)"
     log "MSG_FILE size: $(wc -c < "$MSG_FILE") bytes"
+    log "NOTE: 未标记已发送，下次运行将重试这 ${PAPER_COUNT} 篇论文"
     printf '{"time":"%s","status":"send_failed","new":%d,"sent":false}\n' "$TS" "$PAPER_COUNT" > "$STATUS_FILE"
 fi
 

--- a/kb_status_refresh.sh
+++ b/kb_status_refresh.sh
@@ -95,3 +95,18 @@ python3 "$STATUS_UPDATE" --set health.stale_jobs "${STALE_JOBS:-unknown}" --by c
 python3 "$STATUS_UPDATE" --set health.last_refresh "$TS" --by cron 2>/dev/null || true
 
 echo "[$TS] kb_status_refresh: services=$SVC_STATUS stale_jobs=${STALE_JOBS:-unknown}"
+
+# ── 5. 同步 status.json 到 git 仓库（三方宪法跨环境锚点）─────────
+# Claude Code dev 通过 git 读取此文件，因此每次刷新后推送到仓库
+REPO_DIR="$HOME/openclaw-model-bridge"
+REPO_STATUS="$REPO_DIR/status.json"
+if [ -d "$REPO_DIR/.git" ] && [ -f "$HOME/.kb/status.json" ]; then
+    cp "$HOME/.kb/status.json" "$REPO_STATUS"
+    cd "$REPO_DIR"
+    # 仅在内容有变化时才提交（避免空commit噪音）
+    if ! git diff --quiet "$REPO_STATUS" 2>/dev/null; then
+        git add status.json
+        git commit -m "auto: sync status.json from kb_status_refresh" --no-gpg-sign 2>/dev/null || true
+        git push origin main 2>/dev/null || echo "[$TS] WARN: status.json push failed (will retry next hour)"
+    fi
+fi

--- a/status.json
+++ b/status.json
@@ -1,0 +1,37 @@
+{
+  "updated": "2026-03-28 19:00:01",
+  "updated_by": "cron",
+  "priorities": [
+    {
+      "task": "知识图谱",
+      "status": "backlog",
+      "note": "需6-12个月数据积累"
+    },
+    {
+      "task": "趋势报告优化",
+      "status": "active",
+      "note": "反馈闭环已上线"
+    },
+    {
+      "task": "模型智能路由",
+      "status": "active",
+      "note": "待启用FAST_PROVIDER"
+    }
+  ],
+  "recent_changes": [],
+  "feedback": [],
+  "health": {
+    "services": "ok",
+    "last_deploy": "ce83650",
+    "last_deploy_time": "2026-03-27 14:34",
+    "last_preflight": "pass",
+    "last_preflight_time": "2026-03-27 14:34",
+    "last_trend_report": "2026-03-28",
+    "model_id": "Qwen3-235B-A22B-Instruct-2507-W8A8",
+    "kb_stats": "142 notes, 5 today, 1095KB sources",
+    "stale_jobs": "all_ok",
+    "last_refresh": "2026-03-28 19:00"
+  },
+  "focus": "V29.5: 趋势报告+智能路由+三方状态共享",
+  "notes": ""
+}

--- a/status_update.py
+++ b/status_update.py
@@ -26,7 +26,12 @@ import os
 import sys
 import time
 
-STATUS_FILE = os.path.expanduser("~/.kb/status.json")
+# 状态文件路径解析：优先 ~/.kb/status.json（Mac Mini 生产环境），
+# 不存在则回退到仓库根目录 status.json（Claude Code dev 环境）。
+# 三方宪法要求此文件是唯一实时锚点，git 仓库作为跨环境同步通道。
+_KB_STATUS = os.path.expanduser("~/.kb/status.json")
+_REPO_STATUS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "status.json")
+STATUS_FILE = _KB_STATUS if os.path.exists(_KB_STATUS) else _REPO_STATUS
 
 # ---------------------------------------------------------------------------
 # 默认状态结构


### PR DESCRIPTION
## Summary

- **ArXiv seen_ids 修复**：将 `seen_ids.txt` 写入时机从 XML 解析阶段移到 WhatsApp 推送成功之后，防止推送失败时论文被跳过不再重试
- **三方宪法 status.json 同步**：`status.json` 纳入 git 仓库作为跨环境锚点，修复 Claude Code dev 环境始终读不到共享状态的问题

## 变更文件

| 文件 | 变更 |
|------|------|
| `jobs/arxiv_monitor/run_arxiv.sh` | seen_ids 延迟写入：推送成功后才标记已发送 |
| `status.json` | 新增：仓库根目录三方状态锚点 |
| `status_update.py` | 路径回退：`~/.kb/status.json` → 仓库根 `status.json` |
| `kb_status_refresh.sh` | 新增步骤5：刷新后复制到仓库并 git push |
| `auto_deploy.sh` | FILE_MAP 新增 `status.json → ~/.kb/status.json` |

## 数据流

```
Mac Mini cron → ~/.kb/status.json → repo (git push) → Claude Code dev
Claude Code dev → repo/status.json (git push) → auto_deploy → ~/.kb/ → PA
```

## Test plan

- [x] 单测 118 个通过（proxy 67 + registry 18 + status_update 33）
- [x] Shell 语法检查通过（kb_status_refresh.sh + auto_deploy.sh）
- [x] 安全扫描通过（无 API key 泄漏）
- [ ] Mac Mini 合并后验证：`bash kb_status_refresh.sh` 确认 git sync 步骤正常
- [ ] Mac Mini 验证：`python3 status_update.py --read --human` 确认字段完整

https://claude.ai/code/session_01EudgZnKuWYRJTy3ooKbTZj