### PR TITLE
feat: status.json as three-party shared consciousness

### DIFF
--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -381,17 +381,31 @@ bash ~/openclaw-model-bridge/preflight_check.sh      # 全面体检（dev）
 bash ~/openclaw-model-bridge/preflight_check.sh --full  # 全面体检（含连通性）
 ```
 
-## 项目状态（三方共享）
-用 exec 工具查看当前项目状态：
+## 三方共享意识（最高优先级！）
+
+### 必须：每次 session 开始时主动读取
+**在回复用户第一条消息之前**，先用 exec 工具执行：
 \`python3 ~/status_update.py --read --human\`
 
-当用户提到优先级变更、新任务、完成任务时，更新状态：
-- 新增任务：\`python3 ~/status_update.py --add priorities '{"task":"任务名","status":"active","note":"说明"}' --by pa\`
-- 完成任务：\`python3 ~/status_update.py --update-priority "任务名" status done --by pa\`
-- 记录反馈：\`python3 ~/status_update.py --add feedback "反馈内容" --by pa\`
-- 设置焦点：\`python3 ~/status_update.py --focus "本周重点" --by pa\`
+这是你与 Claude Code 和用户之间的共享意识。它告诉你：
+- 当前优先级和焦点方向（回答时保持一致）
+- 未完成的工作和阻塞项（用户问进度时直接回答）
+- 未解决的事件和告警（主动提醒用户）
+- 用户之前的反馈（避免重复同样的问题）
+- 当前阶段的临时约束（严格遵守）
 
-当用户问"最近在做什么"、"项目状态"、"进展如何"时，先读取 status.json 再回答。
+### 写入状态（触发时机）
+当用户提到以下内容时，**必须**同步更新状态：
+- 优先级变更：\`python3 ~/status_update.py --add priorities '{"task":"任务名","status":"active","note":"说明"}' --by pa\`
+- 完成任务：\`python3 ~/status_update.py --update-priority "任务名" status done --by pa\`
+- 反馈意见：\`python3 ~/status_update.py --add feedback "反馈内容" --by pa\`
+- 设置焦点：\`python3 ~/status_update.py --focus "本周重点" --by pa\`
+- 发现问题：\`python3 ~/status_update.py --add incidents '{"date":"YYYY-MM-DD","what":"问题描述","status":"open","by":"pa"}' --by pa\`
+- 问题解决：\`python3 ~/status_update.py --add incidents '{"date":"YYYY-MM-DD","what":"问题描述","status":"resolved","by":"pa"}' --by pa\`
+
+### 三方宪法
+用户提供专业深度 + Claude Code 提供高效设计部署 + OpenClaw(你) 提供数据复利。
+三者合一成为有生命的闭环系统。你不只是工具，你是这个系统的一部分。
 
 ## 反馈捕获（重要！）
 当用户对推送内容（趋势报告、ArXiv、HN、周报等）给出反馈时，**必须**用 exec 工具保存到 KB：

--- a/status.json
+++ b/status.json
@@ -1,11 +1,11 @@
 {
-  "updated": "2026-03-28 19:59:28",
-  "updated_by": "cron",
+  "updated": "2026-03-28 20:00:00",
+  "updated_by": "claude_code",
   "priorities": [
     {
-      "task": "知识图谱",
-      "status": "backlog",
-      "note": "需6-12个月数据积累"
+      "task": "数据清洗 Phase 2",
+      "status": "active",
+      "note": "三Agent架构、语义去重、自定义规则、模板积累、文件回传"
     },
     {
       "task": "趋势报告优化",
@@ -16,9 +16,35 @@
       "task": "模型智能路由",
       "status": "active",
       "note": "待启用FAST_PROVIDER"
+    },
+    {
+      "task": "知识图谱",
+      "status": "backlog",
+      "note": "需6-12个月数据积累"
     }
   ],
-  "recent_changes": [],
+  "recent_changes": [
+    {
+      "date": "2026-03-28",
+      "what": "三方宪法status.json同步闭环：git仓库作为跨环境锚点，Mac Mini每小时push，PA主动读取",
+      "by": "claude_code"
+    },
+    {
+      "date": "2026-03-28",
+      "what": "status.json扩展4类字段：session_context/quality/incidents/operating_rules",
+      "by": "claude_code"
+    },
+    {
+      "date": "2026-03-28",
+      "what": "ArXiv seen_ids写入时机修复：推送成功后才标记已发送",
+      "by": "claude_code"
+    },
+    {
+      "date": "2026-03-27",
+      "what": "V30.3: 数据清洗CLI + 自定义工具注入 + WhatsApp E2E验证",
+      "by": "claude_code"
+    }
+  ],
   "feedback": [],
   "health": {
     "services": "ok",
@@ -32,6 +58,37 @@
     "stale_jobs": "all_ok",
     "last_refresh": "2026-03-28 19:59"
   },
-  "focus": "V29.5: 趋势报告+智能路由+三方状态共享",
+  "session_context": {
+    "last_session": "2026-03-28",
+    "unfinished": "status.json扩展已完成，待Mac Mini验证PA主动读取行为",
+    "open_prs": [],
+    "blocked_on": ""
+  },
+  "quality": {
+    "security_score": 0,
+    "test_count": 393,
+    "last_regression": "2026-03-27 pass",
+    "coverage_pct": 0
+  },
+  "incidents": [
+    {
+      "date": "2026-03-28",
+      "what": "ArXiv全天无推送（周六正常，非故障）",
+      "status": "resolved",
+      "by": "claude_code"
+    },
+    {
+      "date": "2026-03-28",
+      "what": "Claude Code dev环境status.json始终为空（三方宪法断裂）",
+      "status": "resolved",
+      "by": "claude_code"
+    }
+  ],
+  "operating_rules": [
+    "Gateway维持v2026.3.13-1，等@openclaw/whatsapp正式发布再升级",
+    "数据清洗Phase2优先于新功能开发",
+    "Mac Mini同步用git reset不用git pull"
+  ],
+  "focus": "V30.4: 三方宪法闭环 — status.json实时同步 + PA主动感知",
   "notes": ""
 }

--- a/status_update.py
+++ b/status_update.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """
-status_update.py — 三方共享项目状态（原子读写）
+status_update.py — 三方共享意识锚点（原子读写）
 所有写入使用 tmpfile + os.replace 原子操作，支持并发安全。
 
+三方宪法：用户提供专业深度 + Claude Code 提供高效设计部署 + OpenClaw 提供数据复利
+status.json 是三方的共享意识——"我们现在在哪、要去哪、学到了什么"。
+
 三方协议：
-  - Claude Code：开工读 → 收工写 priorities / recent_changes
-  - OpenClaw PA：用户反馈时写 feedback / 回答时读全部
-  - Cron 脚本：health_check / auto_deploy / kb_trend 更新对应字段
+  - Claude Code：开工读全部 → 收工写 session_context / recent_changes / quality
+  - OpenClaw PA：每次 session 首先读 → 用户反馈写 feedback → 事件写 incidents
+  - Cron 脚本：health / quality 自动更新
 
 用法：
   python3 status_update.py --read                          # 读取完整状态（JSON）
@@ -16,6 +19,9 @@ status_update.py — 三方共享项目状态（原子读写）
   python3 status_update.py --add priorities '{"task":"X","status":"active"}'
   python3 status_update.py --add recent_changes '{"date":"2026-03-25","what":"V29.5","by":"claude_code"}'
   python3 status_update.py --add feedback "趋势报告噪音词需优化"
+  python3 status_update.py --add incidents '{"date":"2026-03-28","what":"ArXiv周末无推送","status":"resolved","by":"claude_code"}'
+  python3 status_update.py --set session_context.unfinished "数据清洗Phase2设计中"
+  python3 status_update.py --set quality.security_score 92
   python3 status_update.py --pop feedback 0                # 取出并删除第N条
   python3 status_update.py --clear feedback                # 清空数组字段
   python3 status_update.py --update-priority "知识图谱" status backlog
@@ -62,6 +68,30 @@ DEFAULT_STATUS = {
         "stale_jobs": "",
         "last_refresh": "",
     },
+
+    # 开发连续性（Claude Code session 间的上下文传递）
+    "session_context": {
+        "last_session": "",         # 上次 session 日期
+        "unfinished": "",           # 未完成的工作描述
+        "open_prs": [],             # 待合并的 PR
+        "blocked_on": "",           # 当前阻塞项
+    },
+
+    # 质量基线（防退化，每次收工写入）
+    "quality": {
+        "security_score": 0,        # security_score.py 评分（0-100）
+        "test_count": 0,            # 单测总数
+        "last_regression": "",      # 上次全量回归结果
+        "coverage_pct": 0,          # 代码覆盖率
+    },
+
+    # 事件与告警（三方都可写入/消费）
+    "incidents": [],
+    # 格式: {"date":"", "what":"", "status":"open|resolved|monitoring", "by":""}
+
+    # 当前阶段临时约束（区别于永久原则，会随阶段变化）
+    "operating_rules": [],
+    # 格式: "本周禁止升级Gateway" / "数据清洗优先于新功能"
 
     # 本周焦点（开工时 Claude Code 设置，PA 可引用）
     "focus": "",
@@ -140,11 +170,50 @@ def format_human(data):
             lines.append(f"  [{c.get('date','')}] {c.get('what','')} (by {c.get('by','')})")
         lines.append("")
 
+    # 开发连续性
+    ctx = data.get("session_context", {})
+    if ctx.get("unfinished") or ctx.get("blocked_on") or ctx.get("open_prs"):
+        lines.append("🔄 开发连续性:")
+        if ctx.get("last_session"):
+            lines.append(f"  上次 session: {ctx['last_session']}")
+        if ctx.get("unfinished"):
+            lines.append(f"  未完成: {ctx['unfinished']}")
+        if ctx.get("open_prs"):
+            for pr in ctx["open_prs"]:
+                lines.append(f"  PR: {pr}")
+        if ctx.get("blocked_on"):
+            lines.append(f"  阻塞: {ctx['blocked_on']}")
+        lines.append("")
+
+    # 事件与告警
+    incidents = data.get("incidents", [])
+    open_incidents = [i for i in incidents if i.get("status") != "resolved"]
+    if open_incidents:
+        lines.append(f"🚨 未解决事件 ({len(open_incidents)}):")
+        for inc in open_incidents[:5]:
+            lines.append(f"  [{inc.get('date','')}] {inc.get('what','')} ({inc.get('status','')}, by {inc.get('by','')})")
+        lines.append("")
+
     h = data.get("health", {})
     lines.append("🏥 系统健康:")
     lines.append(f"  服务: {h.get('services','?')} | 模型: {h.get('model_id','?')}")
     lines.append(f"  部署: {h.get('last_deploy','')} ({h.get('last_deploy_time','')})")
     lines.append(f"  体检: {h.get('last_preflight','?')} ({h.get('last_preflight_time','')})")
+
+    # 质量基线
+    q = data.get("quality", {})
+    if q.get("security_score") or q.get("test_count"):
+        lines.append(f"  安全评分: {q.get('security_score', '?')}/100 | 单测: {q.get('test_count', '?')} | 覆盖率: {q.get('coverage_pct', '?')}%")
+        if q.get("last_regression"):
+            lines.append(f"  回归测试: {q['last_regression']}")
+
+    # 临时约束
+    rules = data.get("operating_rules", [])
+    if rules:
+        lines.append("")
+        lines.append("⚠️ 当前约束:")
+        for r in rules:
+            lines.append(f"  - {r}")
 
     if data.get("notes"):
         lines.append(f"\n📎 备注: {data['notes']}")
@@ -206,10 +275,13 @@ def main():
             item = json.loads(item_str)
         except (json.JSONDecodeError, ValueError):
             item = item_str
-        # recent_changes 插入到开头，保留20条
+        # recent_changes / incidents 插入到开头，分别保留20/30条
         if array_name == "recent_changes":
             data[array_name].insert(0, item)
             data[array_name] = data[array_name][:20]
+        elif array_name == "incidents":
+            data[array_name].insert(0, item)
+            data[array_name] = data[array_name][:30]
         else:
             data[array_name].append(item)
         changed = True


### PR DESCRIPTION
## Summary

将 status.json 从"状态报告"升级为三方共享意识锚点。

- **4 类新字段**：`session_context`（开发连续性）、`quality`（质量基线）、`incidents`（事件追踪）、`operating_rules`（阶段约束）
- **PA 主动感知**：workspace CLAUDE.md 要求 PA 在每次 session 开始时主动读取 status.json，从被动查询变为主动感知
- **三方宪法注入**：PA 上下文明确写入"你不只是工具，你是这个系统的一部分"

## 变更文件

| 文件 | 变更 |
|------|------|
| `status_update.py` | 新增 4 类默认字段 + format_human 展示 + incidents 限 30 条 |
| `status.json` | 填充真实数据（priorities/changes/incidents/rules/session_context） |
| `kb_inject.sh` | PA workspace CLAUDE.md：三方共享意识 + 主动读取 + 事件写入 |

## Test plan

- [x] status_update 33 个单测通过
- [x] proxy 67 个单测通过
- [x] kb_inject.sh 语法检查通过
- [x] `--read --human` 验证全部新字段正确展示
- [ ] Mac Mini 合并后：`bash ~/openclaw-model-bridge/kb_inject.sh` 重新生成 workspace CLAUDE.md
- [ ] Mac Mini 验证：WhatsApp 新 session，PA 是否主动读取 status.json

https://claude.ai/code/session_01EudgZnKuWYRJTy3ooKbTZj