### PR TITLE
feat: inject status snapshot into PA workspace directly

### DIFF
--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -428,6 +428,18 @@ bash ~/kb_write.sh "用户的反馈内容" "feedback" "feedback"
 
 MDEOF
 
+# 追加三方共享意识快照（status.json 直接注入，PA 无需调用工具即可感知）
+STATUS_SNAPSHOT=$(python3 "$HOME/status_update.py" --read --human 2>/dev/null || echo "（状态暂不可用）")
+cat >> "$WORKSPACE_TMP" << MDEOF
+## 三方共享意识（实时快照）
+以下是当前系统状态，每次 kb_inject 运行时自动刷新。
+回答用户关于项目进展、系统状态、优先级等问题时，直接参考此快照。
+如需最新数据，用 exec 工具执行：\`python3 ~/status_update.py --read --human\`
+
+$STATUS_SNAPSHOT
+
+MDEOF
+
 # 追加动态 KB 摘要
 cat >> "$WORKSPACE_TMP" << MDEOF
 ## 知识库

--- a/kb_status_refresh.sh
+++ b/kb_status_refresh.sh
@@ -96,7 +96,40 @@ python3 "$STATUS_UPDATE" --set health.last_refresh "$TS" --by cron 2>/dev/null |
 
 echo "[$TS] kb_status_refresh: services=$SVC_STATUS stale_jobs=${STALE_JOBS:-unknown}"
 
-# ── 5. 同步 status.json 到 git 仓库（三方宪法跨环境锚点）─────────
+# ── 5. 刷新 workspace CLAUDE.md 中的状态快照（PA 实时感知）─────────
+# kb_inject.sh 每天只运行一次，但 status.json 每小时更新
+# 这里用 sed 替换快照区域，确保 PA 拿到的状态不超过 1 小时
+WORKSPACE_MD="$HOME/.openclaw/workspace/.openclaw/CLAUDE.md"
+if [ -f "$WORKSPACE_MD" ]; then
+    NEW_SNAPSHOT=$(python3 "$STATUS_UPDATE" --read --human 2>/dev/null)
+    if [ -n "$NEW_SNAPSHOT" ]; then
+        python3 - "$WORKSPACE_MD" "$NEW_SNAPSHOT" << 'PYEOF'
+import sys, re
+
+ws_file, snapshot = sys.argv[1], sys.argv[2]
+with open(ws_file) as f:
+    content = f.read()
+
+# 替换快照区域：从 "## 三方共享意识（实时快照）" 到下一个 "## " 标题
+pattern = r'(## 三方共享意识（实时快照）\n).*?(\n## )'
+header = "## 三方共享意识（实时快照）\n"
+header += "以下是当前系统状态，每小时自动刷新。\n"
+header += "回答用户关于项目进展、系统状态、优先级等问题时，直接参考此快照。\n"
+header += "如需最新数据，用 exec 工具执行：`python3 ~/status_update.py --read --human`\n\n"
+header += snapshot + "\n"
+
+new_content = re.sub(pattern, header + r'\2', content, count=1, flags=re.DOTALL)
+if new_content != content:
+    tmp = ws_file + '.tmp'
+    with open(tmp, 'w') as f:
+        f.write(new_content)
+    import os; os.replace(tmp, ws_file)
+    print(f"[status_refresh] workspace CLAUDE.md snapshot updated", file=sys.stderr)
+PYEOF
+    fi
+fi
+
+# ── 6. 同步 status.json 到 git 仓库（三方宪法跨环境锚点）─────────
 # Claude Code dev 通过 git 读取此文件，因此每次刷新后推送到仓库
 REPO_DIR="$HOME/openclaw-model-bridge"
 REPO_STATUS="$REPO_DIR/status.json"


### PR DESCRIPTION
## Summary

PA (Qwen3) 不会可靠地在简单问候时主动调用工具读取 status.json。改为直接将状态快照注入 workspace CLAUDE.md，PA 每次 session 自动加载，零工具调用。

## 方案

| 注入点 | 频率 | 机制 |
|--------|------|------|
| `kb_inject.sh` | 每天 07:00 | 生成 workspace CLAUDE.md 时追加 status 快照 |
| `kb_status_refresh.sh` | 每小时 | 原地替换 workspace CLAUDE.md 中的快照区域 |

PA 拿到的状态数据不超过 1 小时。

## Test plan

- [x] 33 个 status_update 单测通过
- [x] Shell 语法检查通过
- [ ] Mac Mini: `bash ~/openclaw-model-bridge/kb_inject.sh` 重新生成 workspace
- [ ] WhatsApp: 发"你好"验证 PA 回复中是否体现状态感知

https://claude.ai/code/session_01EudgZnKuWYRJTy3ooKbTZj