### PR TITLE
fix: allow session management tools through proxy

### DIFF
--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -20,6 +20,7 @@ ALLOWED_TOOLS = {
     "read", "write", "edit",
     "exec",
     "memory_search", "memory_get",
+    "sessions_spawn", "sessions_send", "sessions_history", "agents_list",
     "cron", "message", "tts",
     "image",
 }


### PR DESCRIPTION
## Summary
- proxy_filters.py ALLOWED_TOOLS was stripping sessions_spawn/send/history and agents_list
- These tools were configured in openclaw.json but never reached the LLM
- Total kept tools with this change: 11 + data_clean = 12 (at the limit)

## Test plan
- [ ] 67 unit tests pass
- [ ] Mac Mini: deploy + verify `tail ~/tool_proxy.log` shows 11 kept tools
- [ ] WhatsApp: test subagent delegation

https://claude.ai/code/session_01EudgZnKuWYRJTy3ooKbTZj