### PR TITLE
fix: add new paper sources to KB digest and review pipelines

### DIFF
--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -88,6 +88,10 @@ if note_items:
 sources_map = {
     'arxiv_daily.md': ('ArXiv 论文', 1500),
     'hn_daily.md': ('HackerNews 热帖', 1500),
+    'hf_papers_daily.md': ('HuggingFace 论文', 1500),
+    'semantic_scholar_daily.md': ('Semantic Scholar 论文', 1500),
+    'dblp_daily.md': ('DBLP CS论文', 1500),
+    'acl_anthology.md': ('ACL Anthology NLP论文', 1000),
     'freight_daily.md': ('货代动态', 800),
     'openclaw_official.md': ('OpenClaw 更新', 800),
 }

--- a/kb_review.sh
+++ b/kb_review.sh
@@ -96,6 +96,10 @@ MAX_PER_SOURCE = 2000
 sources = {
     'arxiv_daily.md': 'ArXiv论文',
     'hn_daily.md': 'HackerNews',
+    'hf_papers_daily.md': 'HuggingFace论文',
+    'semantic_scholar_daily.md': 'Semantic Scholar论文',
+    'dblp_daily.md': 'DBLP CS论文',
+    'acl_anthology.md': 'ACL Anthology NLP论文',
     'freight_daily.md': '货代动态',
     'openclaw_official.md': 'OpenClaw更新',
 }
@@ -246,6 +250,10 @@ for f in sorted(glob.glob(os.path.join(notes_dir, '*.md')), reverse=True):
 sources_map = {
     'arxiv_daily.md': ('📄 ArXiv', 3),
     'hn_daily.md': ('🔥 HN', 3),
+    'hf_papers_daily.md': ('🤗 HF', 3),
+    'semantic_scholar_daily.md': ('📈 S2', 3),
+    'dblp_daily.md': ('📚 DBLP', 3),
+    'acl_anthology.md': ('📝 ACL', 2),
     'freight_daily.md': ('🚢 货代', 2),
     'openclaw_official.md': ('⚙️ OpenClaw', 1),
 }


### PR DESCRIPTION
kb_inject.sh and kb_review.sh had hardcoded source lists that only included ArXiv/HN. Added HF Papers, Semantic Scholar, DBLP, and ACL Anthology so new platforms appear in daily digest and weekly review.

https://claude.ai/code/session_0118GgreguCmcKLDCBAEtgqt