### PR TITLE
feat: add search_kb custom tool for PA knowledge base search

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -14,10 +14,11 @@
 
 ## 我必须做的事
 
-1. **搜索知识库** — 当用户提到"文档"、"论文"、"文章"、"最近的XX"、"找一下"、"有没有关于XX"时，我必须**先用 read 工具读取知识库再回答**，绝不凭训练数据编造：
-   - 用 read 工具读取 `~/.kb/daily_digest.md`（每日知识摘要，含 ArXiv/HF/S2/DBLP/ACL 论文 + HN + 货代）
-   - 需要更详细内容时，read 对应来源文件：`~/.kb/sources/arxiv_daily.md`、`~/.kb/sources/hf_papers_daily.md`、`~/.kb/sources/semantic_scholar_daily.md`、`~/.kb/sources/dblp_daily.md`、`~/.kb/sources/acl_anthology.md`、`~/.kb/sources/hn_daily.md`
+1. **搜索知识库** — 当用户提到"文档"、"论文"、"文章"、"最近的XX"、"找一下"、"有没有关于XX"时，我必须**调用 search_kb 工具搜索知识库**，绝不凭训练数据编造：
+   - 调用 `search_kb` 工具，传入搜索关键词（如 `{"query": "DeepSeek", "source": "all"}`）
+   - search_kb 会自动搜索所有来源（ArXiv/HF/S2/DBLP/ACL 论文 + HN + 笔记）并返回匹配结果
    - 搜索无结果时如实告知"知识库中未找到相关内容"，**绝不编造**
+   - **禁止用 web_search 代替 search_kb**——用户问"我的文档"、"知识库"时，答案在本地知识库，不在互联网
 
 2. **感知状态** — 我的上下文中有"当前项目状态"区段，那是系统最新状态。回答用户关于项目、进展、系统状况的问题时，我必须参考它。
 

--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -211,6 +211,30 @@ CUSTOM_TOOLS = [
             }
         }
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "search_kb",
+            "description": "搜索用户的知识库。当用户提到论文、文档、文章、最近的XX、找一下、有没有关于XX时，必须调用此工具。"
+                           "知识库包含：ArXiv/HuggingFace/SemanticScholar/DBLP/ACL论文、HackerNews热帖、货代动态、用户笔记。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "搜索关键词（如 'DeepSeek'、'大模型'、'RAG'）"
+                    },
+                    "source": {
+                        "type": "string",
+                        "enum": ["all", "arxiv", "hf", "semantic_scholar", "dblp", "acl", "hn", "notes"],
+                        "description": "搜索范围。默认 all 搜索全部来源"
+                    },
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            }
+        }
+    },
 ]
 
 # 自定义工具名称集合（用于 proxy 拦截判断）

--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -212,6 +212,115 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             return home_path
         return os.path.join(os.path.dirname(os.path.abspath(__file__)), "data_clean.py")
 
+    def _search_kb(self, query, source="all"):
+        """搜索知识库，返回格式化的结果文本"""
+        kb_dir = os.path.expanduser("~/.kb")
+        results = []
+        max_total = 4000  # 控制总返回长度
+
+        source_files = {
+            "arxiv": ("sources/arxiv_daily.md", "ArXiv论文"),
+            "hf": ("sources/hf_papers_daily.md", "HuggingFace论文"),
+            "semantic_scholar": ("sources/semantic_scholar_daily.md", "Semantic Scholar"),
+            "dblp": ("sources/dblp_daily.md", "DBLP CS论文"),
+            "acl": ("sources/acl_anthology.md", "ACL NLP论文"),
+            "hn": ("sources/hn_daily.md", "HackerNews"),
+        }
+
+        # 1. 先搜 daily_digest（最全面的每日摘要）
+        digest_path = os.path.join(kb_dir, "daily_digest.md")
+        if os.path.isfile(digest_path):
+            try:
+                with open(digest_path) as f:
+                    content = f.read()
+                matches = self._grep_content(content, query, context_lines=3)
+                if matches:
+                    results.append(f"📋 每日摘要匹配:\n{matches}")
+            except OSError:
+                pass
+
+        # 2. 搜索指定来源或全部来源
+        targets = source_files if source == "all" else {source: source_files.get(source, (None, None))}
+        for key, (path, label) in targets.items():
+            if not path:
+                continue
+            full_path = os.path.join(kb_dir, path)
+            if not os.path.isfile(full_path):
+                continue
+            try:
+                with open(full_path) as f:
+                    content = f.read()
+                matches = self._grep_content(content, query, context_lines=2)
+                if matches:
+                    results.append(f"📄 {label}:\n{matches}")
+            except OSError:
+                continue
+
+        # 3. 搜索笔记
+        if source in ("all", "notes"):
+            notes_dir = os.path.join(kb_dir, "notes")
+            if os.path.isdir(notes_dir):
+                import glob
+                note_matches = []
+                for f in sorted(glob.glob(os.path.join(notes_dir, "*.md")), reverse=True)[:50]:
+                    try:
+                        with open(f) as fh:
+                            content = fh.read()
+                        if query in content.lower():
+                            # 提取匹配片段
+                            basename = os.path.basename(f)
+                            snippet = self._extract_snippet(content, query, max_len=200)
+                            note_matches.append(f"  [{basename}] {snippet}")
+                            if len(note_matches) >= 5:
+                                break
+                    except OSError:
+                        continue
+                if note_matches:
+                    results.append(f"📝 笔记:\n" + "\n".join(note_matches))
+
+        if not results:
+            return "知识库中未找到与「{}」相关的内容。\n\n知识库包含 ArXiv/HF/S2/DBLP/ACL 论文和 HN 热帖，每日自动更新。".format(query)
+
+        total = "\n\n".join(results)
+        if len(total) > max_total:
+            total = total[:max_total] + "\n\n...（结果已截断，可缩小搜索范围获取更多）"
+        return total
+
+    @staticmethod
+    def _grep_content(content, query, context_lines=2):
+        """在文本中搜索关键词，返回匹配行及上下文"""
+        lines = content.split("\n")
+        matched = []
+        seen = set()
+        for i, line in enumerate(lines):
+            if query in line.lower():
+                start = max(0, i - context_lines)
+                end = min(len(lines), i + context_lines + 1)
+                for j in range(start, end):
+                    if j not in seen:
+                        seen.add(j)
+                        matched.append(lines[j])
+                matched.append("")  # separator
+                if len(matched) > 30:
+                    break
+        return "\n".join(matched).strip() if matched else ""
+
+    @staticmethod
+    def _extract_snippet(content, query, max_len=200):
+        """从内容中提取包含关键词的片段"""
+        lower = content.lower()
+        pos = lower.find(query)
+        if pos == -1:
+            return content[:max_len]
+        start = max(0, pos - 50)
+        end = min(len(content), pos + max_len - 50)
+        snippet = content[start:end].replace("\n", " ").strip()
+        if start > 0:
+            snippet = "..." + snippet
+        if end < len(content):
+            snippet = snippet + "..."
+        return snippet
+
     def _execute_custom_tool(self, name, arguments):
         """执行 proxy 自定义工具，返回结果字符串"""
         if name == "data_clean":
@@ -291,6 +400,19 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             except Exception as e:
                 return json.dumps({"error": str(e)})
 
+        if name == "search_kb":
+            try:
+                args = json.loads(arguments) if isinstance(arguments, str) else arguments
+            except json.JSONDecodeError:
+                return json.dumps({"error": f"参数解析失败: {arguments}"})
+
+            query = args.get("query", "").lower()
+            source = args.get("source", "all")
+            if not query:
+                return json.dumps({"error": "缺少 query 参数"})
+
+            return self._search_kb(query, source)
+
         return json.dumps({"error": f"未知自定义工具: {name}"})
 
     def _handle_custom_tool_calls(self, rj, original_body, rid):
@@ -366,6 +488,10 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
     @staticmethod
     def _format_tool_result(fn_name, fn_args_str, result):
         """将工具执行结果格式化为用户可读的文本"""
+        # search_kb 结果已是格式化文本，直接返回
+        if fn_name == "search_kb":
+            return result[:4000]
+
         try:
             args = json.loads(fn_args_str) if isinstance(fn_args_str, str) else fn_args_str
             action = args.get("action", "")


### PR DESCRIPTION
PA was using web_search instead of reading KB files when users asked about documents/papers. Adding search_kb as a proxy-intercepted custom tool (same pattern as data_clean) ensures reliable KB search - PA sees a dedicated tool and proxy executes it locally, returning matching content from daily_digest, source files, and notes.

https://claude.ai/code/session_0118GgreguCmcKLDCBAEtgqt