### PR TITLE
feat: dynamic context pruning to prevent Qwen 260K token overflow

### DIFF
--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -263,10 +263,28 @@ def should_strip_tools(messages):
     return False
 
 
-def truncate_messages(messages, max_bytes=MAX_REQUEST_BYTES):
-    """截断旧消息以控制请求体大小。保留所有 system 消息 + 最近的非 system 消息。
+def truncate_messages(messages, max_bytes=MAX_REQUEST_BYTES, last_prompt_tokens=0):
+    """截断旧消息以控制请求体大小和 token 用量。
+
+    保留所有 system 消息 + 最近的非 system 消息。
+    V31: 当上一次 prompt_tokens 已接近 context limit 时，动态缩减 max_bytes
+    以主动削减历史消息，防止 context 溢出。
     返回 (truncated_messages, dropped_count)。
     """
+    # ── V31: 基于上一次 prompt_tokens 的动态裁剪 ──
+    # 原理：prompt_tokens 反映 LLM 实际消耗，包括 system prompt、tool schema、
+    # KV cache 等 messages bytes 无法衡量的开销。
+    # 当 prompt_tokens 已高时，主动压缩 messages 给 LLM 更多呼吸空间。
+    if last_prompt_tokens > 0 and CONTEXT_LIMIT > 0:
+        usage_pct = last_prompt_tokens / CONTEXT_LIMIT
+        if usage_pct >= 0.85:
+            # 临界：只保留最近 ~50KB 消息（大幅裁剪）
+            max_bytes = min(max_bytes, 50000)
+        elif usage_pct >= 0.70:
+            # 预警：保留最近 ~100KB 消息（适度裁剪）
+            max_bytes = min(max_bytes, 100000)
+        # < 70%: 使用默认 200KB，不额外裁剪
+
     system = [m for m in messages if m.get("role") == "system"]
     others = [m for m in messages if m.get("role") != "system"]
     # 截断超大 system 消息（保留前 max_bytes/2 字符）

--- a/test_tool_proxy.py
+++ b/test_tool_proxy.py
@@ -239,6 +239,45 @@ class TestTruncateMessages(unittest.TestCase):
         result, dropped = truncate_messages(msgs, max_bytes=1000)
         self.assertEqual(result[0]["role"], "system")
 
+    def test_dynamic_trim_at_85pct(self):
+        """V31: 当 last_prompt_tokens >= 85% of context limit 时，动态缩减 max_bytes 到 50KB。"""
+        msgs = [
+            {"role": "system", "content": "sys"},
+        ] + [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": "X" * 5000}
+            for i in range(40)  # ~200KB of messages
+        ]
+        # 不传 last_prompt_tokens → 使用默认 200KB，大部分保留
+        _, dropped_default = truncate_messages(msgs, max_bytes=200000)
+        # 传入 85% token 用量 → 动态缩减到 50KB，裁剪更多
+        _, dropped_85pct = truncate_messages(msgs, max_bytes=200000,
+                                             last_prompt_tokens=int(260000 * 0.86))
+        self.assertGreater(dropped_85pct, dropped_default)
+
+    def test_dynamic_trim_at_70pct(self):
+        """V31: 70-85% 区间，缩减到 100KB。"""
+        msgs = [
+            {"role": "system", "content": "sys"},
+        ] + [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": "X" * 5000}
+            for i in range(40)
+        ]
+        _, dropped_default = truncate_messages(msgs, max_bytes=200000)
+        _, dropped_70pct = truncate_messages(msgs, max_bytes=200000,
+                                             last_prompt_tokens=int(260000 * 0.72))
+        self.assertGreater(dropped_70pct, dropped_default)
+
+    def test_dynamic_trim_below_70pct(self):
+        """V31: < 70% 时不额外裁剪。"""
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "Hi"},
+        ]
+        _, dropped_normal = truncate_messages(msgs, max_bytes=200000)
+        _, dropped_low = truncate_messages(msgs, max_bytes=200000,
+                                           last_prompt_tokens=int(260000 * 0.5))
+        self.assertEqual(dropped_normal, dropped_low)  # 同样为 0
+
 
 class TestBuildSSE(unittest.TestCase):
 

--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -659,12 +659,13 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 was_streaming = body.get("stream", False)
                 body["stream"] = False
 
-                # Truncate old messages
+                # Truncate old messages (V31: 动态裁剪，基于上次 prompt_tokens)
                 msgs = body.get("messages", [])
-                truncated, dropped = truncate_messages(msgs)
+                last_pt = proxy_stats.last_prompt_tokens
+                truncated, dropped = truncate_messages(msgs, last_prompt_tokens=last_pt)
                 if dropped:
                     body["messages"] = truncated
-                    log(f"[{rid}] WARN: Truncated {dropped} old messages ({len(msgs)} -> {len(truncated)} msgs)")
+                    log(f"[{rid}] WARN: Truncated {dropped} old messages ({len(msgs)} -> {len(truncated)} msgs, last_pt={last_pt:,})")
 
                 # 多模态媒体注入：检测 <media:image> 并注入 base64 图片
                 msgs = body.get("messages", [])


### PR DESCRIPTION
When last request's prompt_tokens approaches the 260K context limit, Proxy now dynamically reduces the message history sent to LLM:
  - >= 85%: shrink to 50KB messages (aggressive pruning)
  - >= 70%: shrink to 100KB messages (moderate pruning)
  - < 70%: default 200KB (no change)

This prevents context from ever reaching 90%+ by proactively trimming old messages before they accumulate. Combined with Gateway's contextPruning (cache-ttl 6h), provides two layers of protection.

https://claude.ai/code/session_0118GgreguCmcKLDCBAEtgqt