### PR TITLE
fix: preflight $HOME expansion + JSON merge driver for status.json

### DIFF
--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -150,7 +150,8 @@ if $FULL_MODE; then
     while IFS= read -r map_line; do
         [ -n "$map_line" ] && FILE_MAP+=("$map_line")
     done < <(python3 -c "
-import re
+import re, os
+home = os.path.expanduser('~')
 with open('$SCRIPT_DIR/auto_deploy.sh') as f:
     in_map = False
     for line in f:
@@ -161,7 +162,8 @@ with open('$SCRIPT_DIR/auto_deploy.sh') as f:
         if in_map:
             m = re.search(r'\"([^\"]+)\"', line)
             if m and '|' in m.group(1):
-                print(m.group(1))
+                # 展开 \$HOME 为实际路径
+                print(m.group(1).replace('\$HOME', home))
 " 2>/dev/null)
 
     DRIFT_COUNT=0
@@ -559,7 +561,7 @@ for line in crontab_lines:
     if not line or line.startswith('#'):
         continue
     # 匹配 bash .sh 和 python3 .py 两种模式
-    m = re.search(r'(?:bash\s+(?:-\w+\s+)?[\'"]?|python3\s+)([^\s>|"\']+\.(?:sh|py))', line)
+    m = re.search(r"(?:bash\s+(?:-\w+\s+)?['\"]?|python3\s+)([^\s>|\"']+\.(?:sh|py))", line)
     if not m:
         continue
     cron_path = m.group(1).replace('~/', os.path.expanduser('~/')).replace('$HOME/', os.path.expanduser('~/'))

--- a/status.json
+++ b/status.json
@@ -1,6 +1,6 @@
 {
-  "updated": "2026-03-31 01:00:01",
-  "updated_by": "cron",
+  "updated": "2026-03-31 01:27:07",
+  "updated_by": "claude_code",
   "priorities": [
     {
       "task": "数据清洗 Phase 2",
@@ -74,6 +74,11 @@
     }
   ],
   "recent_changes": [
+    {
+      "date": "2026-03-31",
+      "what": "V31续: FILE_MAP补齐7个遗漏文件+preflight双向校验(防止再遗漏)+动态context裁剪(70%/85%自动削减历史消息,防止260K溢出)+check_registry FILE_MAP缺失改为ERROR",
+      "by": "claude_code"
+    },
     {
       "date": "2026-03-31",
       "what": "V31: watchdog全面升级8维度监控（11job+服务健康+磁盘+crontab条目数+KB新鲜度+日志扫描加强+告警分级）+ search_kb混合检索上线 + 论文监控5源全覆盖 + Zhihu文章",


### PR DESCRIPTION
## Summary
- **Preflight #6**: Python parser now expands `$HOME` to actual path, fixing false "运行时副本不存在"
- **Preflight #15**: Fixed heredoc single-quote conflict causing "unexpected EOF" syntax error
- **status.json merge driver**: JSON-aware merge eliminates recurring PR conflicts
  - cron keys (health, updated) → always take main
  - Claude Code keys (priorities, quality) → always take branch
  - Arrays (recent_changes) → merge + dedup both sides

## Why
status.json conflicts happened on every PR because cron and Claude Code write different JSON keys to the same file. Git's text merge can't handle this. Custom merge driver resolves at JSON key level.