### PR TITLE
fix: URL-encode > as %3E in GitHub Search API query

### DIFF
--- a/jobs/github_trending/run_github_trending.sh
+++ b/jobs/github_trending/run_github_trending.sh
@@ -38,7 +38,7 @@ HEADER_FILE="$CACHE/curl_headers.txt"
 # 搜索策略：多个 topic 关键词，按 stars 排序
 # GitHub Search API：免费未认证 10次/分钟，认证 30次/分钟
 TOPICS="machine-learning+OR+deep-learning+OR+llm+OR+large-language-model+OR+transformer+OR+diffusion+OR+rag+OR+ai-agent"
-SEARCH_URL="https://api.github.com/search/repositories?q=${TOPICS}+created:>${WEEK_AGO}&sort=stars&order=desc&per_page=50"
+SEARCH_URL="https://api.github.com/search/repositories?q=${TOPICS}+created:%3E${WEEK_AGO}&sort=stars&order=desc&per_page=50"
 
 FETCH_OK=false
 for attempt in 1 2 3; do


### PR DESCRIPTION
The > in created:>DATE was causing shell interpretation issues.

https://claude.ai/code/session_01KLHcMFLhM2Zy8xdJDs1vXK