### PR TITLE
auto: record kb_embed sources coverage issue as TODO

### DIFF
--- a/status.json
+++ b/status.json
@@ -146,7 +146,7 @@
   },
   "session_context": {
     "last_session": "2026-03-31",
-    "unfinished": "",
+    "unfinished": "kb_embed.py sources覆盖率不足(sources/*.md大文件分块索引不完整，PA统计严重低估ArXiv/HN/OpenClaw/货代数据量)",
     "open_prs": [],
     "blocked_on": ""
   },


### PR DESCRIPTION
sources/*.md large files (arxiv 4501 lines, openclaw 5117 lines) are under-indexed by kb_embed.py, causing PA to severely undercount KB data.

https://claude.ai/code/session_01KLHcMFLhM2Zy8xdJDs1vXK