### PR TITLE
full_regression: 修复 bandit PATH（macOS pip3 用户安装路径）

### DIFF
--- a/full_regression.sh
+++ b/full_regression.sh
@@ -4,6 +4,9 @@
 # 用法：bash full_regression.sh
 set -uo pipefail
 
+# macOS pip3 用户安装的可执行文件路径（bandit 等）
+export PATH="$HOME/Library/Python/3.9/bin:$PATH"
+
 PASS=0
 FAIL=0
 TOTAL_TESTS=0


### PR DESCRIPTION
~/Library/Python/3.9/bin/ 不在默认 PATH 中，
command -v bandit 找不到导致误报"未安装"

https://claude.ai/code/session_019ghGvZMmGsuFFz7wiN7VTk