### PR TITLE
search_kb 全面加固：时间过滤 + source 过滤 + 竞争保护

### DIFF
--- a/kb_embed.py
+++ b/kb_embed.py
@@ -20,6 +20,7 @@ import hashlib
 import struct
 import glob
 import time
+import fcntl
 from datetime import datetime
 
 # ── 配置 ──────────────────────────────────────────────────────────────
@@ -44,8 +45,8 @@ def log(msg):
 
 
 def file_hash(path):
-    """快速 MD5（用于增量检测）"""
-    h = hashlib.md5()
+    """SHA256 哈希（用于增量检测 + 完整性校验）"""
+    h = hashlib.sha256()
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             h.update(chunk)
@@ -59,12 +60,23 @@ def load_meta():
     return {"version": 2, "model": "", "dim": 0, "chunks": []}
 
 
+LOCK_FILE = os.path.join(INDEX_DIR, ".lock")
+
+
 def save_meta(meta):
     os.makedirs(INDEX_DIR, exist_ok=True)
     tmp = META_FILE + ".tmp"
     with open(tmp, "w") as f:
         json.dump(meta, f, ensure_ascii=False)
     os.replace(tmp, META_FILE)
+
+
+def _acquire_exclusive_lock():
+    """获取排他锁（写操作），阻塞直到所有读操作完成"""
+    os.makedirs(INDEX_DIR, exist_ok=True)
+    lock_fd = open(LOCK_FILE, "w")
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    return lock_fd
 
 
 def append_vectors(vecs, dim):
@@ -468,22 +480,26 @@ def main():
         # 有删除，需要完整重写（罕见路径）
         pass
 
-    # 追加新 chunks 和向量
-    meta["chunks"].extend(batch_meta)
-    append_vectors(vectors, dim)
+    # 追加新 chunks 和向量（排他锁保护，防止搜索读到半写数据）
+    lock_fd = _acquire_exclusive_lock()
+    try:
+        meta["chunks"].extend(batch_meta)
+        append_vectors(vectors, dim)
 
-    # 如果有文件变更（删除了旧 chunks），需要重建向量文件
-    old_file_set = {c.get("file") for c in remaining_old}
-    changed_files = set()
-    for m in batch_meta:
-        if m["file"] in indexed_hashes:
-            changed_files.add(m["file"])
+        # 如果有文件变更（删除了旧 chunks），需要重建向量文件
+        old_file_set = {c.get("file") for c in remaining_old}
+        changed_files = set()
+        for m in batch_meta:
+            if m["file"] in indexed_hashes:
+                changed_files.add(m["file"])
 
-    if changed_files:
-        log(f"检测到 {len(changed_files)} 个文件变更，重建向量文件...")
-        _rebuild_vectors(meta, dim)
+        if changed_files:
+            log(f"检测到 {len(changed_files)} 个文件变更，重建向量文件...")
+            _rebuild_vectors(meta, dim)
 
-    save_meta(meta)
+        save_meta(meta)
+    finally:
+        lock_fd.close()
     log(f"完成: 新增 {new_chunks} chunks, 跳过 {skip_count} 文件, "
         f"失败 {error_count}, 总计 {len(meta['chunks'])} chunks")
 

--- a/kb_rag.py
+++ b/kb_rag.py
@@ -19,6 +19,7 @@ import os
 import sys
 import json
 import struct
+import fcntl
 import numpy as np
 from datetime import datetime
 
@@ -29,6 +30,9 @@ META_FILE = os.path.join(INDEX_DIR, "meta.json")
 VECS_FILE = os.path.join(INDEX_DIR, "vectors.bin")
 DEFAULT_TOP_K = 5
 SIMILARITY_THRESHOLD = 0.25  # 低于此分数的结果不返回
+
+
+LOCK_FILE = os.path.join(INDEX_DIR, ".lock")
 
 
 def load_meta():
@@ -48,6 +52,18 @@ def load_vectors(count, dim):
     return data[:expected].reshape(count, dim)
 
 
+def _acquire_shared_lock():
+    """获取共享锁（读操作），防止与 reindex 写操作竞争"""
+    os.makedirs(INDEX_DIR, exist_ok=True)
+    lock_fd = open(LOCK_FILE, "w")
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
+    except OSError:
+        # 如果无法立即获取锁（reindex 正在进行），等待最多 5 秒
+        fcntl.flock(lock_fd, fcntl.LOCK_SH)
+    return lock_fd
+
+
 def get_chunk_text(chunk_meta):
     """获取 chunk 的完整文本
 
@@ -57,19 +73,98 @@ def get_chunk_text(chunk_meta):
     return chunk_meta.get("text", chunk_meta.get("preview", ""))
 
 
-def search(query, top_k, output_mode="text"):
+def search(query, top_k, output_mode="text", source=None, recent_hours=None):
     """执行语义搜索
 
     output_mode: "text" | "context" | "json"
+    source: 过滤来源类型（如 "arxiv", "note"），None 表示全部
+    recent_hours: 如果设置，返回最近 N 小时内索引的内容（按时间倒序，忽略语义相关度）
     """
-    meta = load_meta()
+    # 获取共享锁，防止与 reindex 竞争导致读到半写数据
+    lock_fd = _acquire_shared_lock()
+    try:
+        meta = load_meta()
+    except Exception:
+        lock_fd.close()
+        raise
+
     if not meta or not meta.get("chunks"):
+        lock_fd.close()
         print("索引为空，请先运行: python3 kb_embed.py", file=sys.stderr)
         sys.exit(1)
 
     chunks = meta["chunks"]
     dim = meta.get("dim", 384)
+
+    # source 过滤：映射 search_kb 的 source 参数到索引中的 source_type
+    SOURCE_TYPE_MAP = {
+        "arxiv": "source", "hf": "source", "semantic_scholar": "source",
+        "dblp": "source", "acl": "source", "hn": "source",
+        "notes": "note",
+    }
+    # source 对应的文件名关键词（用于精确过滤）
+    SOURCE_FILE_KEYWORDS = {
+        "arxiv": "arxiv", "hf": "hf_papers", "semantic_scholar": "semantic_scholar",
+        "dblp": "dblp", "acl": "acl_anthology", "hn": "hn_daily",
+    }
+
+    def chunk_matches_source(c, src):
+        """判断 chunk 是否匹配指定 source"""
+        if not src or src == "all":
+            return True
+        if src == "notes":
+            return c.get("source_type") == "note"
+        keyword = SOURCE_FILE_KEYWORDS.get(src)
+        if keyword:
+            return keyword in os.path.basename(c.get("file", "")).lower()
+        return True
+
+    # ── recent 模式：按时间排序，不需要语义搜索 ──
+    if recent_hours is not None:
+        lock_fd.close()  # 数据已加载到内存，释放锁
+        cutoff = datetime.now().timestamp() - recent_hours * 3600
+        recent_chunks = []
+        for c in chunks:
+            if not chunk_matches_source(c, source):
+                continue
+            indexed_at = c.get("indexed_at", "")
+            if indexed_at:
+                try:
+                    ts = datetime.fromisoformat(indexed_at).timestamp()
+                    if ts >= cutoff:
+                        recent_chunks.append((ts, c))
+                except (ValueError, TypeError):
+                    pass
+        # 按时间倒序
+        recent_chunks.sort(key=lambda x: x[0], reverse=True)
+
+        results = []
+        seen_files = set()
+        for ts, c in recent_chunks:
+            fname = os.path.basename(c.get("file", ""))
+            if fname in seen_files:
+                continue  # 每文件只取一个代表 chunk
+            seen_files.add(fname)
+            full_text = get_chunk_text(c)
+            results.append({
+                "score": 1.0,
+                "text": full_text,
+                "file": c.get("file", ""),
+                "filename": fname,
+                "source_type": c.get("source_type", ""),
+                "chunk_idx": c.get("chunk_idx", 0),
+                "char_len": len(full_text),
+                "indexed_at": c.get("indexed_at", ""),
+            })
+            if len(results) >= top_k:
+                break
+
+        return _format_output(query, results, top_k, output_mode)
+
+    # ── 语义搜索模式 ──
     vectors = load_vectors(len(chunks), dim)
+    lock_fd.close()  # 数据已加载到内存，释放锁
+
     if vectors is None:
         print("向量文件损坏或不存在", file=sys.stderr)
         sys.exit(1)
@@ -89,6 +184,13 @@ def search(query, top_k, output_mode="text"):
     safe_vectors = vectors / norms
     scores = safe_vectors @ query_vec
     scores = np.nan_to_num(scores, nan=0.0, posinf=0.0, neginf=0.0)
+
+    # source 过滤：将不匹配的 chunk 分数置零
+    if source and source != "all":
+        for i, c in enumerate(chunks):
+            if not chunk_matches_source(c, source):
+                scores[i] = 0.0
+
     top_indices = np.argsort(scores)[::-1][:top_k]
 
     results = []
@@ -108,12 +210,15 @@ def search(query, top_k, output_mode="text"):
             "char_len": len(full_text),
         })
 
-    # 输出
+    return _format_output(query, results, top_k, output_mode)
+
+
+def _format_output(query, results, top_k, output_mode):
+    """格式化搜索结果输出"""
     if output_mode == "json":
         print(json.dumps({"query": query, "results": results}, ensure_ascii=False, indent=2))
 
     elif output_mode == "context":
-        # LLM 可直接使用的上下文格式
         if not results:
             print("（未找到相关内容）")
             return results
@@ -135,7 +240,6 @@ def search(query, top_k, output_mode="text"):
         for i, r in enumerate(results, 1):
             src_icon = "📝" if r["source_type"] == "note" else "📰"
             print(f"  {i}. [{r['score']:.3f}] {src_icon} {r['filename']}")
-            # 显示预览（前 150 字符）
             preview = r["text"][:150].replace("\n", " ")
             print(f"     {preview}...")
             print()
@@ -178,6 +282,8 @@ def main():
     # 解析参数
     top_k = DEFAULT_TOP_K
     output_mode = "text"
+    source = None
+    recent_hours = None
 
     if "--top" in args:
         idx = args.index("--top")
@@ -185,6 +291,23 @@ def main():
             top_k = int(args[idx + 1])
             args = [a for i, a in enumerate(args) if i != idx and i != idx + 1]
         else:
+            args = [a for i, a in enumerate(args) if i != idx]
+
+    if "--source" in args:
+        idx = args.index("--source")
+        if idx + 1 < len(args):
+            source = args[idx + 1]
+            args = [a for i, a in enumerate(args) if i != idx and i != idx + 1]
+        else:
+            args = [a for i, a in enumerate(args) if i != idx]
+
+    if "--recent" in args:
+        idx = args.index("--recent")
+        if idx + 1 < len(args):
+            recent_hours = int(args[idx + 1])
+            args = [a for i, a in enumerate(args) if i != idx and i != idx + 1]
+        else:
+            recent_hours = 24  # 默认24小时
             args = [a for i, a in enumerate(args) if i != idx]
 
     if "--context" in args:
@@ -196,16 +319,21 @@ def main():
         args = [a for a in args if a != "--json"]
 
     query_parts = [a for a in args if not a.startswith("--")]
-    if not query_parts:
+
+    # recent 模式不需要 query
+    if not query_parts and recent_hours is None:
         print("用法: python3 kb_rag.py \"查询文本\"")
-        print("      python3 kb_rag.py --context \"查询\"     # LLM 上下文格式")
-        print("      python3 kb_rag.py --json \"查询\"        # JSON 输出")
-        print("      python3 kb_rag.py --top 10 \"查询\"      # top-K")
-        print("      python3 kb_rag.py --stats              # 索引统计")
+        print("      python3 kb_rag.py --context \"查询\"           # LLM 上下文格式")
+        print("      python3 kb_rag.py --json \"查询\"              # JSON 输出")
+        print("      python3 kb_rag.py --top 10 \"查询\"            # top-K")
+        print("      python3 kb_rag.py --source arxiv \"查询\"      # 按来源过滤")
+        print("      python3 kb_rag.py --recent 24                # 最近24小时内容")
+        print("      python3 kb_rag.py --recent 24 --json         # 最近内容JSON格式")
+        print("      python3 kb_rag.py --stats                    # 索引统计")
         return
 
-    query = " ".join(query_parts)
-    search(query, top_k, output_mode)
+    query = " ".join(query_parts) if query_parts else "recent"
+    search(query, top_k, output_mode, source=source, recent_hours=recent_hours)
 
 
 if __name__ == "__main__":

--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -215,19 +215,24 @@ CUSTOM_TOOLS = [
         "type": "function",
         "function": {
             "name": "search_kb",
-            "description": "搜索用户的知识库。当用户提到论文、文档、文章、最近的XX、找一下、有没有关于XX时，必须调用此工具。"
-                           "知识库包含：ArXiv/HuggingFace/SemanticScholar/DBLP/ACL论文、HackerNews热帖、货代动态、用户笔记。",
+            "description": "搜索用户的知识库。当用户提到论文、文档、文章、最近的XX、今天有什么、找一下、有没有关于XX时，必须调用此工具。"
+                           "知识库包含：ArXiv/HuggingFace/SemanticScholar/DBLP/ACL论文、HackerNews热帖、货代动态、用户笔记。"
+                           "当用户问'今天/最近有什么新内容'时，设置 recent_hours=24。",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "搜索关键词（如 'DeepSeek'、'大模型'、'RAG'）"
+                        "description": "搜索关键词（如 'DeepSeek'、'大模型'、'RAG'）。当使用 recent_hours 时可为空或描述性文字"
                     },
                     "source": {
                         "type": "string",
                         "enum": ["all", "arxiv", "hf", "semantic_scholar", "dblp", "acl", "hn", "notes"],
                         "description": "搜索范围。默认 all 搜索全部来源"
+                    },
+                    "recent_hours": {
+                        "type": "integer",
+                        "description": "返回最近N小时内更新的内容（按时间倒序）。用于'今天有什么新内容'类查询，设24即可"
                     },
                 },
                 "required": ["query"],

--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -221,14 +221,27 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             return home_path
         return os.path.join(os.path.dirname(os.path.abspath(__file__)), "data_clean.py")
 
-    def _search_kb(self, query, source="all"):
-        """搜索知识库：语义搜索优先，关键词补充"""
-        max_total = 4000
+    # search_kb 合法 source 值
+    VALID_SOURCES = {"all", "arxiv", "hf", "semantic_scholar", "dblp", "acl", "hn", "notes"}
+
+    def _search_kb(self, query, source="all", recent_hours=None):
+        """搜索知识库：语义搜索优先，关键词补充
+
+        source: 来源过滤（传递到 kb_rag 语义搜索 + 关键词搜索）
+        recent_hours: 最近N小时模式（按时间排序，不做语义匹配）
+        """
+        t0 = time.monotonic()
+        max_total = 6000  # 扩大到6000字符，减少信息丢失
         results = []
         seen_files = set()
 
+        # ── source 参数校验 ──
+        if source not in self.VALID_SOURCES:
+            log(f"WARN: search_kb invalid source '{source}', fallback to 'all'")
+            source = "all"
+
         # ── 1. 语义搜索（kb_rag）──
-        semantic_results = self._semantic_search(query, top_k=8)
+        semantic_results = self._semantic_search(query, top_k=8, source=source, recent_hours=recent_hours)
         if semantic_results:
             items = []
             for r in semantic_results:
@@ -236,42 +249,78 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 score = r.get("score", 0)
                 text = r.get("text", "").strip()
                 src = r.get("source_type", "")
+                indexed_at = r.get("indexed_at", "")
                 seen_files.add(fname)
-                # 截取片段
-                snippet = text[:300] + ("..." if len(text) > 300 else "")
+                # 截取片段（按段落边界截断，避免断句）
+                snippet = text[:300]
+                last_newline = snippet.rfind("\n", 200)
+                if last_newline > 0 and len(text) > 300:
+                    snippet = snippet[:last_newline] + "..."
+                elif len(text) > 300:
+                    snippet += "..."
                 icon = "📄" if src == "source" else "📝"
-                items.append(f"{icon} [{fname}] (相关度:{score:.2f})\n{snippet}")
-            results.append("🔍 语义搜索结果:\n\n" + "\n\n".join(items))
+                time_info = f" 索引:{indexed_at[:16]}" if indexed_at else ""
+                items.append(f"{icon} [{fname}] (相关度:{score:.2f}{time_info})\n{snippet}")
 
-        # ── 2. 关键词补充（捕获精确匹配但语义搜索遗漏的）──
-        keyword_results = self._keyword_search(query, source, exclude_files=seen_files)
-        if keyword_results:
-            results.append("📎 关键词补充:\n\n" + keyword_results)
+            header = "🕐 最近更新:" if recent_hours else "🔍 语义搜索结果:"
+            results.append(f"{header}\n\n" + "\n\n".join(items))
+
+        # ── 2. 关键词补充（recent 模式跳过，避免重复）──
+        if not recent_hours:
+            keyword_results = self._keyword_search(query, source, exclude_files=seen_files)
+            if keyword_results:
+                results.append("📎 关键词补充:\n\n" + keyword_results)
+
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        log(f"search_kb: query='{query[:50]}' source={source} recent={recent_hours} "
+            f"semantic={len(semantic_results) if semantic_results else 0} "
+            f"results={len(results)} {elapsed_ms}ms")
 
         if not results:
             return "知识库中未找到与「{}」相关的内容。\n\n知识库包含 ArXiv/HF/S2/DBLP/ACL 论文和 HN 热帖，每日自动更新。".format(query)
 
         total = "\n\n".join(results)
         if len(total) > max_total:
-            total = total[:max_total] + "\n\n...（结果已截断，可缩小搜索范围获取更多）"
+            # 按段落边界截断，不在句中断开
+            cutoff = total.rfind("\n\n", 0, max_total)
+            if cutoff < max_total * 0.7:
+                cutoff = max_total
+            total = total[:cutoff] + "\n\n...（结果已截断，可缩小搜索范围获取更多）"
         return total
 
-    def _semantic_search(self, query, top_k=8):
-        """调用 kb_rag 进行语义搜索，失败时返回空列表"""
+    def _semantic_search(self, query, top_k=8, source=None, recent_hours=None):
+        """调用 kb_rag 进行语义搜索，失败时返回空列表并记录日志"""
         try:
             # kb_rag.py 可能在 HOME 目录或仓库目录
             rag_path = os.path.expanduser("~/kb_rag.py")
             if not os.path.exists(rag_path):
                 rag_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "kb_rag.py")
             if not os.path.exists(rag_path):
+                log("WARN: kb_rag.py not found, semantic search disabled")
                 return []
 
-            cmd = [sys.executable, rag_path, "--json", "--top", str(top_k), query]
+            cmd = [sys.executable, rag_path, "--json", "--top", str(top_k)]
+            if source and source != "all":
+                cmd += ["--source", source]
+            if recent_hours:
+                cmd += ["--recent", str(recent_hours)]
+            cmd.append(query)
+
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
             if result.returncode != 0:
+                log(f"WARN: kb_rag exited {result.returncode}: {result.stderr[:200]}")
                 return []
-            return json.loads(result.stdout)
-        except (subprocess.TimeoutExpired, json.JSONDecodeError, Exception):
+            data = json.loads(result.stdout)
+            # --json 输出格式: {"query": "...", "results": [...]}
+            return data.get("results", data) if isinstance(data, dict) else data
+        except subprocess.TimeoutExpired:
+            log("ERROR: kb_rag semantic search timeout (30s)")
+            return []
+        except json.JSONDecodeError as e:
+            log(f"ERROR: kb_rag JSON parse failed: {e}")
+            return []
+        except Exception as e:
+            log(f"ERROR: kb_rag semantic search failed: {e}")
             return []
 
     def _keyword_search(self, query, source="all", exclude_files=None):
@@ -306,12 +355,17 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             except OSError:
                 continue
 
-        # 搜索笔记
+        # 搜索笔记（notes + topics）
         if source in ("all", "notes"):
-            notes_dir = os.path.join(kb_dir, "notes")
-            if os.path.isdir(notes_dir):
+            note_dirs = [
+                (os.path.join(kb_dir, "notes"), "📝"),
+                (os.path.join(kb_dir, "topics"), "🏷️"),
+            ]
+            for note_dir, icon in note_dirs:
+                if not os.path.isdir(note_dir):
+                    continue
                 import glob
-                for f in sorted(glob.glob(os.path.join(notes_dir, "*.md")), reverse=True)[:50]:
+                for f in sorted(glob.glob(os.path.join(note_dir, "*.md")), reverse=True)[:50]:
                     basename = os.path.basename(f)
                     if basename in exclude_files:
                         continue
@@ -320,11 +374,13 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                             content = fh.read()
                         if query in content.lower():
                             snippet = self._extract_snippet(content, query, max_len=200)
-                            items.append(f"📝 [{basename}] {snippet}")
-                            if len(items) >= 8:
+                            items.append(f"{icon} [{basename}] {snippet}")
+                            if len(items) >= 10:
                                 break
                     except OSError:
                         continue
+                if len(items) >= 10:
+                    break
 
         return "\n\n".join(items) if items else ""
 
@@ -448,12 +504,18 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             except json.JSONDecodeError:
                 return json.dumps({"error": f"参数解析失败: {arguments}"})
 
-            query = args.get("query", "").lower()
+            query = args.get("query", "").strip()
             source = args.get("source", "all")
-            if not query:
+            recent_hours = args.get("recent_hours")
+
+            # recent 模式允许空 query
+            if not query and not recent_hours:
                 return json.dumps({"error": "缺少 query 参数"})
 
-            return self._search_kb(query, source)
+            # query 转小写用于关键词搜索（语义搜索不受影响）
+            query_lower = query.lower() if query else "recent"
+
+            return self._search_kb(query_lower, source, recent_hours=recent_hours)
 
         return json.dumps({"error": f"未知自定义工具: {name}"})
 
@@ -545,7 +607,7 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             req = Request(url, data=json.dumps(followup_body).encode(), method="POST")
             req.add_header("Content-Type", "application/json")
             req.add_header("X-Request-ID", f"{rid}-kb")
-            with _safe_urlopen(req, timeout=120) as resp:
+            with _safe_urlopen(req, timeout=60) as resp:
                 resp_body = resp.read()
                 rj = json.loads(resp_body)
                 content = rj.get("choices", [{}])[0].get("message", {}).get("content", "")


### PR DESCRIPTION
## Summary

- **P0 时间过滤**：新增 `recent_hours` 参数，支持"今天有什么新内容"按 `indexed_at` 时间倒序返回（修复 PA 回答"暂无新增"的 bug）
- **P0 source 过滤**：语义搜索按文件名关键词精确过滤，`source="arxiv"` 只匹配 arxiv 相关 chunk（之前声明了参数但未实现）
- **P0 错误日志**：语义搜索超时/崩溃/解析失败全部记录详细日志，不再静默返回空列表
- **P1 文件锁**：`fcntl` 共享锁（搜索读）+ 排他锁（reindex 写），防止 cron 重建索引时搜索读到半写数据
- **P1 参数校验**：source 无效值 fallback 到 all 并记录警告；followup LLM 超时 120s → 60s
- **P2 优化**：搜索性能日志、MD5 → SHA256、notes 关键词搜索扩展到 topics 目录、结果截断改为段落边界

## Test plan

- [x] 394 单测全通过（proxy_filters 70 + registry 18 + cron 94 + status 33 + adapter 36 + kb 44 + audit 19 + data_clean 80）
- [ ] Mac Mini 同步后 `python3 kb_embed.py --reindex`（SHA256 迁移）
- [ ] `bash restart.sh` 重启 Proxy
- [ ] WhatsApp 测试：问 PA "今天KB有什么新内容"，验证返回实际内容
- [ ] WhatsApp 测试：问 PA "最近的ArXiv论文"，验证 source 过滤生效

https://claude.ai/code/session_019ghGvZMmGsuFFz7wiN7VTk