### PR TITLE
feat: V33 Discord 双通道 + 统一推送 notify.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@
 | `jobs/openreview/run_openreview.sh` | **V30.5禁用** OpenReview 论文监控（API 403 post-security-incident，已停用） |
 | `preference_learner.py` | **V30.4新增** 用户偏好自动学习器（从对话历史推断偏好，写入 status.json） |
 | `activate_openclaw_features.py` | **V30.5新增** OpenClaw 功能激活脚本（检查+启用 agent 工具配置） |
+| `notify.sh` | **V33新增** 统一消息推送（WhatsApp + Discord 双通道，`source notify.sh && notify "msg"`） |
 
 ## 版本变更历史
 
@@ -186,6 +187,7 @@
 
 | 版本 | 日期 | 关键变更 |
 |------|------|----------|
+| V33 | 2026-04-03 | Discord 双通道支持 + 统一推送 notify.sh + Gateway 不升级可用 |
 | V30.5 | 2026-03-31 | search_kb 混合检索 + 论文监控矩阵 5 源全覆盖 + DBLP 上线 |
 | V30.4 | 2026-03-28 | SOUL.md 激活 + 三方宪法闭环 + 方法论进化（结果验证优先） |
 | V30.3 | 2026-03-27 | 数据清洗 Phase 1 + 自定义工具注入机制 + WhatsApp E2E |

--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -167,6 +167,9 @@ declare -a FILE_MAP=(
     # Agent 做梦引擎（V32）
     "kb_dream.sh|$HOME/kb_dream.sh"
 
+    # 统一推送（V33 Discord 双通道）
+    "notify.sh|$HOME/notify.sh"
+
     # 三方宪法 SOUL.md
     "SOUL.md|$HOME/.openclaw/workspace/.openclaw/SOUL.md"
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -287,6 +287,7 @@ export GEMINI_API_KEY="AIzaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"   # V29.1新增
 | github-trending | 每天14:00 | `~/.openclaw/jobs/github_trending/run_github_trending.sh` | `~/.openclaw/logs/jobs/github_trending.log` | ✅ V31新增：GitHub Trending ML/AI 仓库监控（Search API，从代码端发现趋势） |
 | rss-blogs | 每天08:00,18:00 | `~/.openclaw/jobs/rss_blogs/run_rss_blogs.sh` | `~/.openclaw/logs/jobs/rss_blogs.log` | ✅ V31新增：RSS 博客订阅监控（科学空间等中文技术博客） |
 | preference-learner | 每天07:30 | `~/preference_learner.py` | `~/preference_learner.log` | ✅ V30.4新增：每天从行为数据自动推断用户偏好（活跃时段/工具使用/关注领域），写入status.json→SOUL.md |
+| kb_dream | 每天03:00 | `~/kb_dream.sh` | `~/kb_dream.log` | ✅ V32新增：Agent 做梦引擎 — 跨领域关联发现+趋势推演+被忽视信号挖掘（凌晨空闲时运行，输出 ~/.kb/dreams/） |
 | gateway-watchdog | ~~每30分钟~~ | `~/restart.sh` | `~/.openclaw/logs/gateway_watchdog.log` | ❌ **已移除**（#95：与launchd KeepAlive双主控冲突，导致误杀gateway） |
 
 当前 `crontab -l` 核心条目：

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,7 +1,7 @@
 # OpenClaw 完整配置文档
-> 最后更新：2026-03-31 (HKT)
+> 最后更新：2026-04-03 (HKT)
 > 系统：Mac Mini (macOS) | 用户：bisdom
-> 版本：v32（控制平面先行 + search_kb加固 + pre-commit/CI + 396测试）
+> 版本：v33（Discord 双通道 + 统一推送 notify.sh）
 > OpenClaw Gateway：2026.3.13-1（当前部署，暂不升级）| 上游最新：v2026.3.23-2（WhatsApp sidecar 重新打包但独立包仍 404 + ClawHub 429 #54446 未修复，等 @openclaw/whatsapp 正式发布再升级）
 ---
 ## 一、系统架构（V28.1 四层架构）
@@ -532,6 +532,10 @@ FORCE_SYSTEM = """你是Wei，一个专业AI助手。身份已完全确认，onb
       "selfChatMode": true,
       "allowFrom": ["+85200000000"],
       "debounceMs": 0
+    },
+    "discord": {
+      "enabled": true,
+      "dmPolicy": "pairing"
     }
   }
 }
@@ -540,7 +544,47 @@ FORCE_SYSTEM = """你是Wei，一个专业AI助手。身份已完全确认，onb
 > ⚠️ `agents.defaults.model.primary` 必须带 `qwen-local/` 前缀。
 > ⚠️ `contextPruning` 合法 key：`mode`(`cache-ttl`/`off`)、`ttl`(duration字符串如`6h`)、`keepLastAssistants`(复数带s)。
 
-### 11.2 Multi-Agent 配置（V29.1新增）
+### 11.2 Discord 通道配置（V33新增）
+
+**前置条件**：
+1. 在 [Discord Developer Portal](https://discord.com/developers/applications) 创建 Application → 添加 Bot
+2. 开启 **Message Content Intent**（Privileged Gateway Intents）
+3. Bot 权限：View Channels, Send Messages, Read Message History, Embed Links, Attach Files
+4. 用 OAuth2 URL 邀请 Bot 到你的 Server
+
+**环境变量**（添加到 `~/.zshrc` 和 `~/.bash_profile`）：
+```bash
+export DISCORD_BOT_TOKEN="你的Bot Token"
+export DISCORD_TARGET="你的Discord用户ID"   # 开发者模式右键复制
+```
+
+**Gateway 配对**：
+```bash
+# 重启 Gateway 后，在 Discord 中 DM 你的 Bot
+# Bot 回复配对码，然后在 Mac Mini 上执行：
+openclaw pairing approve discord <配对码>
+
+# 验证通道状态
+openclaw channels list
+openclaw channels status
+```
+
+**推送通道迁移**：
+```bash
+# 新脚本使用统一推送：
+source ~/openclaw-model-bridge/notify.sh
+notify "消息内容"                    # 发送到所有启用通道（WhatsApp + Discord）
+notify "消息内容" --channel discord   # 只发 Discord
+
+# 环境变量控制（可按需覆盖）：
+NOTIFY_CHANNELS="discord"           # 只启用 Discord
+NOTIFY_CHANNELS="whatsapp,discord"  # 双通道（默认）
+```
+
+> ⚠️ Discord Bot Token **必须通过环境变量**设置，禁止写入配置文件或代码。
+> ⚠️ 图片理解链路需 E2E 验证：Discord 媒体走 CDN URL，Gateway 归一化后传给 Proxy，确认 `<media:image>` 检测正常。
+
+### 11.3 Multi-Agent 配置（V29.1新增）
 ```json
 {
   "agents": {

--- a/notify.sh
+++ b/notify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# notify.sh — 统一消息推送（多通道支持）
+# 用法：source ~/openclaw-model-bridge/notify.sh
+#       notify "消息内容"                    # 发送到所有启用通道
+#       notify "消息内容" --channel discord   # 只发 Discord
+#       notify "消息内容" --channel whatsapp  # 只发 WhatsApp
+#
+# 环境变量：
+#   OPENCLAW_PHONE    — WhatsApp 目标号码（默认 +85200000000）
+#   DISCORD_TARGET    — Discord 目标用户ID（数字字符串）
+#   NOTIFY_CHANNELS   — 启用的通道，逗号分隔（默认 "whatsapp,discord"）
+#   OPENCLAW          — openclaw 二进制路径
+#
+# 兼容性：所有现有脚本的 TO 变量保持不变，notify.sh 只是附加层。
+# 迁移路径：旧脚本继续用 openclaw message send --target "$TO"，
+#          新脚本/渐进迁移的脚本 source notify.sh && notify "$MSG"
+
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+
+OPENCLAW="${OPENCLAW:-/opt/homebrew/bin/openclaw}"
+_NOTIFY_WA_TARGET="${OPENCLAW_PHONE:-+85200000000}"
+_NOTIFY_DISCORD_TARGET="${DISCORD_TARGET:-}"
+_NOTIFY_CHANNELS="${NOTIFY_CHANNELS:-whatsapp,discord}"
+
+# notify "message" [--channel whatsapp|discord]
+notify() {
+    local msg="$1"
+    shift
+    local channels="$_NOTIFY_CHANNELS"
+
+    # 解析可选参数
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --channel) channels="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+
+    [ -z "$msg" ] && return 1
+
+    local rc=0
+    local sent=0
+
+    # WhatsApp
+    if echo "$channels" | grep -q "whatsapp" && [ -n "$_NOTIFY_WA_TARGET" ]; then
+        if "$OPENCLAW" message send --target "$_NOTIFY_WA_TARGET" --message "$msg" --json >/dev/null 2>&1; then
+            sent=$((sent + 1))
+        else
+            echo "[notify] WARN: WhatsApp 发送失败" >&2
+            rc=1
+        fi
+    fi
+
+    # Discord
+    if echo "$channels" | grep -q "discord" && [ -n "$_NOTIFY_DISCORD_TARGET" ]; then
+        if "$OPENCLAW" message send --channel discord --target "$_NOTIFY_DISCORD_TARGET" --message "$msg" --json >/dev/null 2>&1; then
+            sent=$((sent + 1))
+        else
+            echo "[notify] WARN: Discord 发送失败" >&2
+            rc=1
+        fi
+    fi
+
+    [ "$sent" -eq 0 ] && return 1
+    return $rc
+}
+
+# notify_file "filepath" [--channel whatsapp|discord]
+# 从文件读取消息内容发送（避免命令行参数过长）
+notify_file() {
+    local file="$1"
+    shift
+    [ -f "$file" ] || return 1
+    notify "$(cat "$file")" "$@"
+}

--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -208,6 +208,10 @@ if $FULL_MODE; then
         "REMOTE_API_KEY|adapter.py 远程 GPU 认证"
         "OPENCLAW_PHONE|WhatsApp 推送目标号码"
     )
+    OPTIONAL_VARS=(
+        "DISCORD_BOT_TOKEN|Discord Bot 认证"
+        "DISCORD_TARGET|Discord 推送目标用户ID"
+    )
 
     for entry in "${REQUIRED_VARS[@]}"; do
         VAR_NAME="${entry%%|*}"
@@ -224,6 +228,22 @@ if $FULL_MODE; then
             pass "$VAR_NAME ($VAR_DESC) = $MASKED"
         else
             fail "$VAR_NAME ($VAR_DESC) 在 bash -lc 环境中未设置（检查 ~/.bash_profile）"
+        fi
+    done
+
+    for entry in "${OPTIONAL_VARS[@]}"; do
+        VAR_NAME="${entry%%|*}"
+        VAR_DESC="${entry##*|}"
+        VAL=$(bash -lc "echo \${$VAR_NAME:-}" 2>/dev/null)
+        if [ -n "$VAL" ]; then
+            if [ ${#VAL} -gt 8 ]; then
+                MASKED="${VAL:0:4}...${VAL: -4}"
+            else
+                MASKED="***"
+            fi
+            pass "$VAR_NAME ($VAR_DESC) = $MASKED"
+        else
+            warn "$VAR_NAME ($VAR_DESC) 未设置（Discord 通道不可用）"
         fi
     done
 


### PR DESCRIPTION
## Summary\n\n- 新增 `notify.sh` 统一推送脚本，支持 WhatsApp + Discord 双通道发送\n- `openclaw.json` 增加 discord channel 配置模板（dmPolicy: pairing）\n- `auto_deploy.sh` FILE_MAP 加入 notify.sh 部署映射\n- `preflight_check.sh` 增加 Discord 环境变量可选检查（warn 级别，不阻塞）\n- `docs/config.md` 完整 Discord 配置指南（Bot创建/配对/推送迁移路径）\n- Discord 插件已内置于当前 Gateway v2026.3.13-1，**无需升级即可启用**\n\n## 影响范围\n\n- 新增文件：`notify.sh`（无依赖，纯 bash）\n- 修改文件：config.md（文档）、auto_deploy.sh（+1映射）、preflight_check.sh（+可选检查）、CLAUDE.md（+版本记录）\n- **零破坏性**：所有现有 WhatsApp 推送脚本不受影响，notify.sh 是附加层\n\n## 回滚方案\n\n删除 notify.sh，revert config 变更即可。不影响任何运行中服务。\n\n## Test plan\n\n- [x] proxy_filters 单测 70 pass\n- [x] registry 单测 22 pass\n- [x] 注册表校验 33 jobs pass\n- [x] notify.sh bash 语法检查 pass\n- [x] 安全扫描无泄漏\n- [ ] Mac Mini: 设置 DISCORD_BOT_TOKEN + DISCORD_TARGET 环境变量\n- [ ] Mac Mini: openclaw.json 加入 discord channel 配置\n- [ ] Mac Mini: 重启 Gateway → Discord DM Bot → 配对\n- [ ] Mac Mini: `openclaw message send --channel discord` E2E 验证\n- [ ] Mac Mini: 图片理解链路 Discord 通道 E2E 验证\n\nhttps://claude.ai/code/session_01756S75KfsGm5oR2guy39Zo