### PR TITLE
fix: Discord target 需要 user: 前缀 + 文档修正配对流程

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -556,18 +556,28 @@ FORCE_SYSTEM = """你是Wei，一个专业AI助手。身份已完全确认，onb
 **环境变量**（添加到 `~/.zshrc` 和 `~/.bash_profile`）：
 ```bash
 export DISCORD_BOT_TOKEN="你的Bot Token"
-export DISCORD_TARGET="你的Discord用户ID"   # 开发者模式右键复制
+export DISCORD_TARGET="你的Discord用户ID"   # 开发者模式右键复制（纯数字）
 ```
 
-**Gateway 配对**：
+**添加通道 + 配对**：
 ```bash
-# 重启 Gateway 后，在 Discord 中 DM 你的 Bot
-# Bot 回复配对码，然后在 Mac Mini 上执行：
+# 用 CLI 添加 Discord 通道（会自动写入 openclaw.json）
+openclaw channels add --channel discord --token "$DISCORD_BOT_TOKEN"
+
+# 重启 Gateway
+bash ~/restart.sh
+
+# 在 Discord 中 DM Bot，Bot 回复配对码，然后执行：
 openclaw pairing approve discord <配对码>
 
 # 验证通道状态
 openclaw channels list
-openclaw channels status
+openclaw channels status --probe
+```
+
+**推送命令格式**（Discord target 需要 `user:` 前缀）：
+```bash
+openclaw message send --channel discord --target "user:$DISCORD_TARGET" --message "测试" --json
 ```
 
 **推送通道迁移**：

--- a/notify.sh
+++ b/notify.sh
@@ -51,9 +51,9 @@ notify() {
         fi
     fi
 
-    # Discord
+    # Discord（target 格式: user:<ID>）
     if echo "$channels" | grep -q "discord" && [ -n "$_NOTIFY_DISCORD_TARGET" ]; then
-        if "$OPENCLAW" message send --channel discord --target "$_NOTIFY_DISCORD_TARGET" --message "$msg" --json >/dev/null 2>&1; then
+        if "$OPENCLAW" message send --channel discord --target "user:$_NOTIFY_DISCORD_TARGET" --message "$msg" --json >/dev/null 2>&1; then
             sent=$((sent + 1))
         else
             echo "[notify] WARN: Discord 发送失败" >&2


### PR DESCRIPTION
- notify.sh: Discord target 从 "$ID" 改为 "user:$ID"
- docs/config.md: 改用 openclaw channels add 命令（而非手动编辑 json）
- docs/config.md: 补充 openclaw message send 的正确 target 格式

https://claude.ai/code/session_01756S75KfsGm5oR2guy39Zo

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
