### PR TITLE
feat: Discord 分频道推送 + 全脚本多通道适配

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -261,6 +261,7 @@ if [ "$MINUTE" -lt 2 ]; then
         # 漂移发现时推送 WhatsApp 告警
         DRIFT_MSG="⚠️ 漂移检测: 修复 ${DRIFT} 个部署文件不一致，已自动覆盖。详见 auto_deploy.log"
         openclaw message send --channel whatsapp --target "${OPENCLAW_PHONE:-+85200000000}" --message "$DRIFT_MSG" --json >/dev/null 2>&1 || true
+        openclaw message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$DRIFT_MSG" --json >/dev/null 2>&1 || true
     fi
 
     # ── 3c. Crontab 引号完整性检查（每小时整点，与漂移检测同步）──────────
@@ -283,6 +284,7 @@ if [ "$MINUTE" -lt 2 ]; then
 ${CRONTAB_ISSUES}
 请立即检查: crontab -l"
         openclaw message send --channel whatsapp --target "${OPENCLAW_PHONE:-+85200000000}" --message "$CRON_MSG" --json >/dev/null 2>&1 || true
+        openclaw message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$CRON_MSG" --json >/dev/null 2>&1 || true
     fi
 
     # ── 3d. Crontab 条目数监控（V30新增：防止意外清空）─────────────────
@@ -305,6 +307,7 @@ ${CRONTAB_ISSUES}
 1. bash ~/crontab_safe.sh restore
 2. 或: bash ~/cron_doctor.sh"
             openclaw message send --channel whatsapp --target "${OPENCLAW_PHONE:-+85200000000}" --message "$CRON_ALERT" --json >/dev/null 2>&1 || true
+            openclaw message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$CRON_ALERT" --json >/dev/null 2>&1 || true
             date +%s > "$CRON_COUNT_FILE.alert"
         fi
     else
@@ -353,6 +356,7 @@ $FAIL_LINES
             echo "$(date) ❌ preflight_check 失败:" >> "$LOG"
             echo "$PREFLIGHT_OUT" >> "$LOG"
             openclaw message send --channel whatsapp --target "${OPENCLAW_PHONE:-+85200000000}" --message "$ALERT_MSG" --json >/dev/null 2>&1 || true
+            openclaw message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ALERT_MSG" --json >/dev/null 2>&1 || true
         else
             echo "$(date) ✅ preflight_check 通过" >> "$LOG"
             # 更新三方共享状态

--- a/health_check.sh
+++ b/health_check.sh
@@ -126,6 +126,7 @@ echo "[health] JSON written to $HEALTH_JSON"
 # === 推送到WhatsApp ===
 if $OPENCLAW message send --channel whatsapp --target "$PHONE" --message "$REPORT" --json 2>>"$HOME/health_check.log"; then
     echo "[health] WhatsApp 推送成功"
+    $OPENCLAW message send --channel discord --target "${DISCORD_CH_DAILY:-}" --message "$REPORT" --json >/dev/null 2>&1 || true
 else
     echo "[health] ERROR: WhatsApp 推送失败，检查 gateway 状态" >> "$HOME/health_check.log"
 fi

--- a/job_watchdog.sh
+++ b/job_watchdog.sh
@@ -569,6 +569,7 @@ ALERT_LOG="$HOME/.openclaw_alerts.log"
     echo "$ALERT_MSG" >> "$ALERT_LOG"
     echo "================================" >> "$ALERT_LOG"
 }
+"$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ALERT_MSG" --json >/dev/null 2>&1 || true
 
 # 本地告警文件始终写入（供 cron_doctor / SSH 检查时查看）
 echo "[$TS] ALERT: ${#ALERTS[@]} issues (${CRITICAL_COUNT} critical, ${WARNING_COUNT} warning)" >> "$ALERT_LOG"

--- a/jobs/acl_anthology/run_acl_anthology.sh
+++ b/jobs/acl_anthology/run_acl_anthology.sh
@@ -359,6 +359,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${PAPER_COUNT} 篇论文"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_PAPERS:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     if [ -f "$NEW_IDS_FILE" ]; then
         cat "$NEW_IDS_FILE" >> "$SEEN_FILE"
     fi

--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -376,6 +376,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${PAPER_COUNT} 篇论文"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_PAPERS:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     # 推送成功后才标记为已发送（防止推送失败后论文被跳过）
     if [ -f "$NEW_IDS_FILE" ]; then
         cat "$NEW_IDS_FILE" >> "$SEEN_FILE"

--- a/jobs/dblp/run_dblp.sh
+++ b/jobs/dblp/run_dblp.sh
@@ -378,6 +378,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${PAPER_COUNT} 篇论文"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_PAPERS:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     if [ -f "$NEW_IDS_FILE" ]; then
         cat "$NEW_IDS_FILE" >> "$SEEN_FILE"
         log "已标记 ${PAPER_COUNT} 篇为已发送"

--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -290,6 +290,7 @@ PYEOF2
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${NEW_COUNT} 条商机（${DAY}）"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_FREIGHT:-}" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1 || true
     printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$NEW_COUNT" > "$STATUS_FILE"
 else
     log "ERROR: 推送失败（${NEW_COUNT} 条待发）: $(cat "$SEND_ERR" | head -3)"

--- a/jobs/github_trending/run_github_trending.sh
+++ b/jobs/github_trending/run_github_trending.sh
@@ -341,6 +341,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${REPO_COUNT} 个仓库"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_TECH:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     if [ -f "$NEW_IDS_FILE" ]; then
         cat "$NEW_IDS_FILE" >> "$SEEN_FILE"
         log "已标记 ${REPO_COUNT} 个为已发送"

--- a/jobs/hf_papers/run_hf_papers.sh
+++ b/jobs/hf_papers/run_hf_papers.sh
@@ -391,6 +391,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${PAPER_COUNT} 篇论文"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_PAPERS:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     if [ -f "$NEW_IDS_FILE" ]; then
         cat "$NEW_IDS_FILE" >> "$SEEN_FILE"
         log "已标记 ${PAPER_COUNT} 篇为已发送"

--- a/jobs/openclaw_official/run.sh
+++ b/jobs/openclaw_official/run.sh
@@ -203,6 +203,7 @@ rsync -a --quiet "$HOME/.kb/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true
 SEND_ERR=$(mktemp)
 if openclaw message send --channel whatsapp --target "$TO" --message "$(cat "$MSG")" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${new_count} 条 releases 更新。"
+    openclaw message send --channel discord --target "${DISCORD_CH_TECH:-}" --message "$(cat "$MSG")" --json >/dev/null 2>&1 || true
     printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$new_count" > "$STATUS_FILE"
 else
     log "ERROR: 推送失败（${new_count} 条待发）: $(cat "$SEND_ERR" | head -3)"

--- a/jobs/openclaw_official/run_discussions.sh
+++ b/jobs/openclaw_official/run_discussions.sh
@@ -153,6 +153,7 @@ done < "$CACHE/discussions_send.txt"
 SEND_ERR=$(mktemp)
 if openclaw message send --channel whatsapp --target "$TO" --message "$(cat "$MSG")" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${cnt} 条新 issue（含LLM富摘要）。"
+    openclaw message send --channel discord --target "${DISCORD_CH_TECH:-}" --message "$(cat "$MSG")" --json >/dev/null 2>&1 || true
     printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$cnt" > "$STATUS_FILE"
 else
     log "ERROR: 推送失败（${cnt} 条待发）: $(cat "$SEND_ERR" | head -3)"

--- a/jobs/rss_blogs/run_rss_blogs.sh
+++ b/jobs/rss_blogs/run_rss_blogs.sh
@@ -316,6 +316,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${TOTAL_NEW} 篇文章"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_TECH:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     # 标记为已发送
     $PYTHON3 -c "
 import json, sys

--- a/jobs/semantic_scholar/run_semantic_scholar.sh
+++ b/jobs/semantic_scholar/run_semantic_scholar.sh
@@ -352,6 +352,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${PAPER_COUNT} 篇论文"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_PAPERS:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     if [ -f "$NEW_IDS_FILE" ]; then
         cat "$NEW_IDS_FILE" >> "$SEEN_FILE"
         log "已标记 ${PAPER_COUNT} 篇为已发送"

--- a/kb_dream.sh
+++ b/kb_dream.sh
@@ -237,6 +237,7 @@ $(echo "$DREAM_RESULT" | head -c 800)"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$WA_MSG" --json >/dev/null 2>"$SEND_ERR"; then
     log "梦境已推送到 WhatsApp"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_DAILY:-}" --message "$WA_MSG" --json >/dev/null 2>&1 || true
     printf '{"time":"%s","status":"ok","chars":%d,"sources":%d,"dream_bytes":%d,"sent":true}\n' \
         "$TS" "$TOTAL_CHARS" "$SRC_COUNT" "$(wc -c < "$DREAM_FILE" | tr -d ' ')" > "$STATUS_FILE"
 else

--- a/kb_evening.sh
+++ b/kb_evening.sh
@@ -53,6 +53,7 @@ fi
 
 if openclaw message send --channel whatsapp --target "$PHONE" --message "$MSG" --json 2>>"$HOME/kb_evening.log" >/dev/null; then
     log "发送完成: $DATE"
+    openclaw message send --channel discord --target "${DISCORD_CH_DAILY:-}" --message "$MSG" --json >/dev/null 2>&1 || true
     printf '{"time":"%s","status":"ok","sent":true}\n' "$TS" > "$STATUS_FILE"
 else
     log "ERROR: 消息发送失败，请检查 gateway。"

--- a/kb_inject.sh
+++ b/kb_inject.sh
@@ -345,6 +345,7 @@ PYEOF
 SEND_ERR=$(mktemp)
 if openclaw message send --channel whatsapp --target "$PHONE" --message "$WA_MSG" --json >/dev/null 2>"$SEND_ERR"; then
     log "每日摘要已推送 WhatsApp"
+    openclaw message send --channel discord --target "${DISCORD_CH_DAILY:-}" --message "$WA_MSG" --json >/dev/null 2>&1 || true
 else
     log "WARNING: WhatsApp 推送失败: $(head -3 "$SEND_ERR" 2>/dev/null)"
     # 本地告警回退（V30: 监控不依赖被监控对象）

--- a/kb_review.sh
+++ b/kb_review.sh
@@ -360,6 +360,7 @@ ${LLM_SHORT}
 SEND_ERR=$(mktemp)
 if openclaw message send --channel whatsapp --target "$PHONE" --message "$WA_MSG" --json >/dev/null 2>"$SEND_ERR"; then
     log "回顾已推送 WhatsApp"
+    openclaw message send --channel discord --target "${DISCORD_CH_DAILY:-}" --message "$WA_MSG" --json >/dev/null 2>&1 || true
     printf '{"time":"%s","status":"ok","notes":%d,"llm":true}\n' "$TS" "$NOTE_COUNT" > "$STATUS_FILE"
 else
     log "ERROR: WhatsApp 推送失败: $(head -3 "$SEND_ERR" 2>/dev/null)"

--- a/notify.sh
+++ b/notify.sh
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
-# notify.sh — 统一消息推送（多通道支持）
+# notify.sh — 统一消息推送（多通道 + 分频道支持）
 # 用法：source ~/openclaw-model-bridge/notify.sh
-#       notify "消息内容"                    # 发送到所有启用通道
-#       notify "消息内容" --channel discord   # 只发 Discord
-#       notify "消息内容" --channel whatsapp  # 只发 WhatsApp
+#       notify "消息内容"                             # WhatsApp + Discord DM
+#       notify "消息内容" --topic papers               # WhatsApp + Discord #论文
+#       notify "消息内容" --topic alerts               # WhatsApp + Discord #告警
+#       notify "消息内容" --channel discord --topic papers  # 只发 Discord #论文
+#       notify "消息内容" --channel whatsapp            # 只发 WhatsApp
+#
+# Topic 频道映射（Discord Server 频道）：
+#   papers  → #论文（arxiv/hf/s2/dblp/acl）
+#   freight → #货代（freight_watcher）
+#   alerts  → #告警（auto_deploy/watchdog/preflight）
+#   daily   → #日报（kb_dream/kb_review/health_check）
+#   tech    → #技术（hn/github_trending/rss_blogs/openclaw）
+#   (空)    → DM（私信，默认）
 #
 # 环境变量：
-#   OPENCLAW_PHONE    — WhatsApp 目标号码（默认 +85200000000）
-#   DISCORD_TARGET    — Discord 目标用户ID（数字字符串）
-#   NOTIFY_CHANNELS   — 启用的通道，逗号分隔（默认 "whatsapp,discord"）
-#   OPENCLAW          — openclaw 二进制路径
-#
-# 兼容性：所有现有脚本的 TO 变量保持不变，notify.sh 只是附加层。
-# 迁移路径：旧脚本继续用 openclaw message send --target "$TO"，
-#          新脚本/渐进迁移的脚本 source notify.sh && notify "$MSG"
+#   OPENCLAW_PHONE      — WhatsApp 目标号码（默认 +85200000000）
+#   DISCORD_TARGET      — Discord 目标用户ID（DM 用）
+#   DISCORD_CH_PAPERS   — Discord #论文 频道ID
+#   DISCORD_CH_FREIGHT  — Discord #货代 频道ID
+#   DISCORD_CH_ALERTS   — Discord #告警 频道ID
+#   DISCORD_CH_DAILY    — Discord #日报 频道ID
+#   DISCORD_CH_TECH     — Discord #技术 频道ID
+#   NOTIFY_CHANNELS     — 启用的通道，逗号分隔（默认 "whatsapp,discord"）
+#   OPENCLAW            — openclaw 二进制路径
 
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 
@@ -22,16 +33,30 @@ _NOTIFY_WA_TARGET="${OPENCLAW_PHONE:-+85200000000}"
 _NOTIFY_DISCORD_TARGET="${DISCORD_TARGET:-}"
 _NOTIFY_CHANNELS="${NOTIFY_CHANNELS:-whatsapp,discord}"
 
-# notify "message" [--channel whatsapp|discord]
+# topic → Discord channel ID 映射
+_notify_discord_target_for_topic() {
+    case "$1" in
+        papers)  echo "${DISCORD_CH_PAPERS:-}" ;;
+        freight) echo "${DISCORD_CH_FREIGHT:-}" ;;
+        alerts)  echo "${DISCORD_CH_ALERTS:-}" ;;
+        daily)   echo "${DISCORD_CH_DAILY:-}" ;;
+        tech)    echo "${DISCORD_CH_TECH:-}" ;;
+        *)       echo "" ;;
+    esac
+}
+
+# notify "message" [--channel whatsapp|discord] [--topic papers|freight|alerts|daily|tech]
 notify() {
     local msg="$1"
     shift
     local channels="$_NOTIFY_CHANNELS"
+    local topic=""
 
     # 解析可选参数
     while [ $# -gt 0 ]; do
         case "$1" in
             --channel) channels="$2"; shift 2 ;;
+            --topic)   topic="$2"; shift 2 ;;
             *) shift ;;
         esac
     done
@@ -41,7 +66,7 @@ notify() {
     local rc=0
     local sent=0
 
-    # WhatsApp（多通道环境必须指定 --channel）
+    # WhatsApp（所有 topic 都发到同一个号码）
     if echo "$channels" | grep -q "whatsapp" && [ -n "$_NOTIFY_WA_TARGET" ]; then
         if "$OPENCLAW" message send --channel whatsapp --target "$_NOTIFY_WA_TARGET" --message "$msg" --json >/dev/null 2>&1; then
             sent=$((sent + 1))
@@ -51,13 +76,24 @@ notify() {
         fi
     fi
 
-    # Discord（target 格式: user:<ID>）
-    if echo "$channels" | grep -q "discord" && [ -n "$_NOTIFY_DISCORD_TARGET" ]; then
-        if "$OPENCLAW" message send --channel discord --target "user:$_NOTIFY_DISCORD_TARGET" --message "$msg" --json >/dev/null 2>&1; then
-            sent=$((sent + 1))
-        else
-            echo "[notify] WARN: Discord 发送失败" >&2
-            rc=1
+    # Discord（根据 topic 选择频道，无 topic 则 DM）
+    if echo "$channels" | grep -q "discord"; then
+        local discord_target=""
+        if [ -n "$topic" ]; then
+            local ch_id
+            ch_id=$(_notify_discord_target_for_topic "$topic")
+            [ -n "$ch_id" ] && discord_target="$ch_id"
+        fi
+        # fallback 到 DM
+        [ -z "$discord_target" ] && discord_target="user:$_NOTIFY_DISCORD_TARGET"
+
+        if [ -n "$discord_target" ] && [ "$discord_target" != "user:" ]; then
+            if "$OPENCLAW" message send --channel discord --target "$discord_target" --message "$msg" --json >/dev/null 2>&1; then
+                sent=$((sent + 1))
+            else
+                echo "[notify] WARN: Discord 发送失败 (target=$discord_target)" >&2
+                rc=1
+            fi
         fi
     fi
 
@@ -65,8 +101,7 @@ notify() {
     return $rc
 }
 
-# notify_file "filepath" [--channel whatsapp|discord]
-# 从文件读取消息内容发送（避免命令行参数过长）
+# notify_file "filepath" [--channel whatsapp|discord] [--topic ...]
 notify_file() {
     local file="$1"
     shift

--- a/run_hn_fixed.sh
+++ b/run_hn_fixed.sh
@@ -302,6 +302,7 @@ if [ "$SENT_COUNT" -gt 0 ]; then
     SEND_ERR=$(mktemp)
     if openclaw message send --channel whatsapp --target "$TO" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>"$SEND_ERR"; then
         log "已推送 ${SENT_COUNT} 条AI/Tech精选（单次批量LLM）。"
+        openclaw message send --channel discord --target "${DISCORD_CH_TECH:-}" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1 || true
         printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$SENT_COUNT" > "$STATUS_FILE"
     else
         # 过滤已知无害警告（feishu 插件 duplicate id、plugins.allow empty）
@@ -309,6 +310,7 @@ if [ "$SENT_COUNT" -gt 0 ]; then
         if [ -z "$REAL_ERR" ]; then
             # 只有无害警告，实际推送可能成功了
             log "已推送 ${SENT_COUNT} 条AI/Tech精选（单次批量LLM，忽略插件警告）。"
+            openclaw message send --channel discord --target "${DISCORD_CH_TECH:-}" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1 || true
             printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$SENT_COUNT" > "$STATUS_FILE"
         else
             log "ERROR: 推送失败（${SENT_COUNT} 条待发）: $(echo "$REAL_ERR" | head -3)"


### PR DESCRIPTION
## Summary

- `notify.sh` 新增 `--topic` 参数，按主题路由到 5 个 Discord 频道（papers/freight/alerts/daily/tech）
- 18 个 job 脚本在 WhatsApp 推送成功后追加 Discord 频道推送（双通道同时发）
- Discord 推送失败不影响脚本（`|| true`），WhatsApp 仍为主通道
- 环境变量 `DISCORD_CH_PAPERS/FREIGHT/ALERTS/DAILY/TECH` 控制频道 ID

## 影响范围

- 19 个文件修改（notify.sh + 18 个 job/运维脚本）
- 零破坏性：Discord 环境变量未设置时自动跳过，不影响现有 WhatsApp 推送

## 回滚方案

删除各脚本中的 `openclaw message send --channel discord` 行即可，或清空 `DISCORD_CH_*` 环境变量使 Discord 推送静默跳过。

## Mac Mini 部署后操作

```bash
# 设置频道 ID 环境变量（.zshrc + .bash_profile）
export DISCORD_CH_PAPERS="1489455703805530177"
export DISCORD_CH_FREIGHT="1489488679985614868"
export DISCORD_CH_ALERTS="1489488771572432917"
export DISCORD_CH_DAILY="1489488825188221038"
export DISCORD_CH_TECH="1489488870411206717"
```

## Test plan

- [x] notify.sh 语法检查 pass
- [x] 全部 19 个 .sh 文件 bash -n 语法检查 pass
- [x] proxy_filters 单测 70 pass
- [x] registry 单测 22 pass + 校验 33 jobs pass
- [x] 文档漂移检测 pass
- [x] Discord DM 推送 E2E 验证通过
- [x] WhatsApp + Discord 双通道 notify 验证通过
- [ ] Mac Mini: 设置 DISCORD_CH_* 环境变量
- [ ] Mac Mini: 等待下一轮 cron job 触发，验证分频道推送

https://claude.ai/code/session_01756S75KfsGm5oR2guy39Zo