### PR TITLE
V33: Discord 双通道支持 + 统一推送 notify.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,7 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 | 13 | **🆕 定期像用户一样使用系统** | 不是跑单测，而是在 WhatsApp 上实际问 PA 问题。每次涉及 PA 行为的变更后，必须清空 session（`echo '{"sessions":[]}' > sessions.json`）+ 重启 Gateway + WhatsApp 实测。单测验证组件内部，系统价值在组件之间的接缝处。 |
 | 14 | **🆕 PR 合并后立即同步 Mac Mini** | GitHub PR 合并到 main 后，**必须立即提醒用户在 Mac Mini 上同步**：`cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard origin/main`。不要等 auto_deploy 轮询（最长 2 分钟延迟）——合并后紧急同步是标准操作，确保运行时代码与仓库一致。同步后立即跑 `bash preflight_check.sh --full`。（2026-04-01教训：合并后 preflight 8 项失败全是部署漂移） |
 | 15 | **🆕 测试必须全量：单测 + full_regression + WhatsApp 业务验证** | 每次变更后测试三层缺一不可：① `bash full_regression.sh`（394 单测 + 注册表 + 安全扫描 + 代码质量）② `bash preflight_check.sh --full` + `bash job_smoke_test.sh`（Mac Mini 部署验证）③ **WhatsApp 端实际业务测试**（用户视角发消息验证 PA 回复、search_kb 检索、图片理解等核心功能）。只跑单测不算测完——单测验证组件，WhatsApp 验证系统。（2026-04-01教训：394 单测全过但 preflight 8 项失败） |
+| 16 | **🆕 所有推送必须双通道（WhatsApp + Discord）** | 新增或修改任何消息推送时，**必须同时覆盖 WhatsApp 和 Discord 两个通道**，不允许遗留单通道发送。优先使用 `notify.sh`（`source notify.sh && notify "msg" --topic papers`）统一推送；若直接调用 `openclaw message send`，每个 WhatsApp 发送后必须紧跟对应的 Discord 发送（成功路径→对应 topic 频道，错误/告警→`DISCORD_CH_ALERTS`）。审计方法：`grep -c "message send.*whatsapp"` 与 `grep -c "message send.*discord"` 计数必须一致。（2026-04-03教训：货代客户画像推送遗漏 Discord，11 个脚本错误路径缺 Discord） |
 
 ### 🟡 按需查阅（操作 & 架构参考）
 

--- a/diagnose.sh
+++ b/diagnose.sh
@@ -187,6 +187,10 @@ if command -v openclaw >/dev/null 2>&1 || [ -x "$OPENCLAW" ]; then
     echo "  正在发送测试消息..."
     SEND_RESULT=$("$OPENCLAW" message send --channel whatsapp --target "$PHONE" --message "🔧 诊断测试消息 ($TS)" --json 2>&1 || true)
     echo "  发送结果: $SEND_RESULT" | head -5 | sed 's/^/    /'
+    # Discord 诊断测试
+    if [ -n "${DISCORD_TARGET:-}" ]; then
+        "$OPENCLAW" message send --channel discord --target "user:${DISCORD_TARGET}" --message "🔧 诊断测试消息 ($TS)" --json >/dev/null 2>&1 || true
+    fi
 else
     echo "  🔴 openclaw 命令未找到！"
     FAIL=1

--- a/jobs/acl_anthology/run_acl_anthology.sh
+++ b/jobs/acl_anthology/run_acl_anthology.sh
@@ -245,6 +245,7 @@ if [ -z "${LLM_CONTENT// }" ]; then
     ERR_MSG="⚠️ ACL Anthology LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 

--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -233,6 +233,7 @@ if [ -z "${LLM_CONTENT// }" ]; then
     ERR_MSG="⚠️ ArXiv监控 LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -366,6 +367,7 @@ if [ -f "$ASSEMBLE_ERR" ] && grep -q "WARNING.*解析成功率过低" "$ASSEMBLE
     L2_MSG="⚠️ ArXiv监控 LLM解析异常（${DAY}）: $(grep 'WARNING' "$ASSEMBLE_ERR" | head -1)，请检查 $CACHE/llm_content.txt"
     log "$L2_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$L2_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$L2_MSG" --json >/dev/null 2>&1 || true
     printf '{"time":"%s","status":"parse_quality_low","new":%d}\n' "$TS" "$PAPER_COUNT" > "$STATUS_FILE"
     exit 2
 fi

--- a/jobs/dblp/run_dblp.sh
+++ b/jobs/dblp/run_dblp.sh
@@ -251,6 +251,7 @@ if [ -z "${LLM_CONTENT// }" ]; then
     ERR_MSG="⚠️ DBLP论文监控 LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 

--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -206,6 +206,7 @@ if [ -z "${LLM_OUT// }" ]; then
     ERR_MSG="⚠️ 货代Watcher LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -215,6 +216,7 @@ if [ "$PARSE_OK" -lt $(( NEW_COUNT / 2 )) ] && [ "$NEW_COUNT" -gt 2 ]; then
     WARN_MSG="⚠️ 货代Watcher解析成功率低 ${PARSE_OK}/${NEW_COUNT}（${DAY}），请查 $LLM_RAW"
     echo "$WARN_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$WARN_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$WARN_MSG" --json >/dev/null 2>&1 || true
     exit 2
 fi
 

--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -483,6 +483,12 @@ ${PROFILE_OUT}
 💡 数据来源：ImportYeti美国海关提单 + 行业新闻
 ⚠ 预算为运价推算值，仅供参考" --json >/dev/null 2>&1; then
                 log "已推送客户画像"
+                "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_FREIGHT:-}" --message "📊 货代客户画像 (${DAY})
+
+${PROFILE_OUT}
+
+💡 数据来源：ImportYeti美国海关提单 + 行业新闻
+⚠ 预算为运价推算值，仅供参考" --json >/dev/null 2>&1 || true
             else
                 log "ERROR: 客户画像推送失败，请检查 gateway。"
             fi

--- a/jobs/github_trending/run_github_trending.sh
+++ b/jobs/github_trending/run_github_trending.sh
@@ -224,6 +224,7 @@ if [ -z "${LLM_CONTENT// }" ]; then
     ERR_MSG="⚠️ GitHub Trending LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 

--- a/jobs/hf_papers/run_hf_papers.sh
+++ b/jobs/hf_papers/run_hf_papers.sh
@@ -266,6 +266,7 @@ if [ -z "${LLM_CONTENT// }" ]; then
     ERR_MSG="⚠️ HF Papers LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 

--- a/jobs/openclaw_official/run.sh
+++ b/jobs/openclaw_official/run.sh
@@ -45,6 +45,7 @@ if ! ATOM_PATH="$("$FETCH" 2>"$CACHE_DIR/fetch_releases.err")"; then
   log "ERROR: $ERR_MSG"
   TO="${OPENCLAW_PHONE:-+85200000000}"
   openclaw message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+  openclaw message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
   printf '{"time":"%s","status":"fetch_failed","new":0}\n' "$TS" > "$STATUS_FILE"
   exit 1
 fi

--- a/jobs/openclaw_official/run_discussions.sh
+++ b/jobs/openclaw_official/run_discussions.sh
@@ -53,6 +53,7 @@ if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
   ERR_MSG="⚠️ Issues Watcher API 请求失败 HTTP ${HTTP_CODE}（$(TZ=Asia/Hong_Kong date '+%H:%M')）: $(head -1 "$CACHE/curl_issues_api.err" 2>/dev/null)"
   log "ERROR: $ERR_MSG"
   openclaw message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+  openclaw message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
   printf '{"time":"%s","status":"fetch_failed","http":%s,"new":0}\n' "$TS" "$HTTP_CODE" > "$STATUS_FILE"
   exit 1
 fi
@@ -84,6 +85,7 @@ print(f'[issues] 解析完成: {count} 条 issues', file=sys.stderr)
   ERR_MSG="⚠️ Issues Watcher 解析失败（$(TZ=Asia/Hong_Kong date '+%H:%M')）: $(head -1 "$CACHE/parse_issues.err" 2>/dev/null)"
   log "ERROR: $ERR_MSG"
   openclaw message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+  openclaw message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
   printf '{"time":"%s","status":"parse_failed","new":0}\n' "$TS" > "$STATUS_FILE"
   exit 1
 fi

--- a/jobs/openreview/run_openreview.sh
+++ b/jobs/openreview/run_openreview.sh
@@ -282,6 +282,7 @@ if [ -z "${LLM_CONTENT// }" ]; then
     ERR_MSG="⚠️ OpenReview LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -403,6 +404,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${PAPER_COUNT} 篇论文"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_PAPERS:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     if [ -f "$NEW_IDS_FILE" ]; then
         cat "$NEW_IDS_FILE" >> "$SEEN_FILE"
     fi

--- a/jobs/pwc/run_pwc.sh
+++ b/jobs/pwc/run_pwc.sh
@@ -285,6 +285,7 @@ if [ -z "${LLM_CONTENT// }" ]; then
     ERR_MSG="⚠️ PwC Monitor LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -420,6 +421,7 @@ MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
 SEND_ERR=$(mktemp)
 if "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$MSG_CONTENT" --json >/dev/null 2>"$SEND_ERR"; then
     log "已推送 ${PAPER_COUNT} 篇论文"
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_PAPERS:-}" --message "$MSG_CONTENT" --json >/dev/null 2>&1 || true
     if [ -f "$NEW_IDS_FILE" ]; then
         cat "$NEW_IDS_FILE" >> "$SEEN_FILE"
         log "已标记 ${PAPER_COUNT} 篇为已发送"

--- a/jobs/semantic_scholar/run_semantic_scholar.sh
+++ b/jobs/semantic_scholar/run_semantic_scholar.sh
@@ -233,6 +233,7 @@ if [ -z "${LLM_CONTENT// }" ]; then
     ERR_MSG="⚠️ S2论文监控 LLM调用失败（${DAY}），请检查 $LLM_RAW"
     echo "$ERR_MSG"
     "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ERR_MSG" --json >/dev/null 2>&1 || true
     exit 1
 fi
 

--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -657,6 +657,21 @@ if $FULL_MODE; then
     else
         fail "WhatsApp 推送失败（退出码 $PUSH_RC）: $(echo "$PUSH_STDERR" | head -2)"
     fi
+
+    # Discord 推送通道 E2E
+    if [ -n "${DISCORD_TARGET:-}" ]; then
+        DC_ERR=$(mktemp)
+        openclaw message send --channel discord --target "user:${DISCORD_TARGET}" --message "🔧 preflight push test $(date '+%H:%M')" --json 2>"$DC_ERR" && DC_RC=0 || DC_RC=$?
+        DC_STDERR=$(cat "$DC_ERR" 2>/dev/null)
+        rm -f "$DC_ERR"
+        if [ $DC_RC -eq 0 ]; then
+            pass "Discord 推送通道正常（openclaw message send 退出码 0）"
+        else
+            warn "Discord 推送失败（退出码 $DC_RC）: $(echo "$DC_STDERR" | head -2)"
+        fi
+    else
+        skip "Discord 推送通道（DISCORD_TARGET 未设置）"
+    fi
 else
     skip "推送通道 smoke test（需在 Mac Mini 上验证）"
 fi

--- a/upgrade_openclaw.sh
+++ b/upgrade_openclaw.sh
@@ -64,6 +64,8 @@ if [ "$GW" = "UP" ]; then
     # 推送通知
     $OPENCLAW message send --channel whatsapp -t "$PHONE" \
         -m "✅ OpenClaw 升级完成: $OLD_VER → $NEW_VER" 2>/dev/null || true
+    $OPENCLAW message send --channel discord -t "${DISCORD_CH_ALERTS:-}" \
+        -m "✅ OpenClaw 升级完成: $OLD_VER → $NEW_VER" 2>/dev/null || true
 else
     echo ""
     echo "⚠️ Gateway 未启动，请检查日志: /tmp/openclaw/openclaw-$(date +%Y-%m-%d).log"


### PR DESCRIPTION
## Summary

- **Discord 双通道集成**：Gateway 新增 Discord Bot 通道，与 WhatsApp 并行推送，降低单一 IM 依赖
- **统一推送抽象层 `notify.sh`**：`source notify.sh && notify "msg" --topic papers` 一行代码同时推送 WhatsApp + Discord，支持 5 个主题频道（papers/freight/alerts/daily/tech）
- **全量双通道覆盖**：审计 24 个脚本，所有 `openclaw message send` 调用 WhatsApp/Discord 发送数量 100% 对齐
- **新增工作原则 #16**：所有推送必须双通道，不允许遗留单通道发送

### 变更明细（7 commits）

| Commit | 说明 |
|--------|------|
| `8d5b329` | feat: V33 Discord 双通道 + notify.sh + docs/config.md 更新 |
| `4d270d9` | fix: config drift — 补齐 kb_dream 条目 |
| `0afeb6d` | fix: Discord target 需要 `user:` 前缀 |
| `ed91952` | fix(critical): 22 个脚本加 `--channel whatsapp` 适配多通道环境 |
| `7f8aa12` | feat: 5 个 Discord 主题频道 + notify.sh --topic 路由 |
| `749405f` | fix: 货代客户画像补加 Discord 推送 |
| `ec03089` | fix: 全量补齐 13 个脚本错误/告警路径 Discord 推送 + 工作原则 #16 |

### 涉及文件（30+）

- **新增**: `notify.sh`（统一推送抽象层）
- **核心修改**: 22 个 job/ops 脚本全部加 `--channel whatsapp` + Discord 对应推送
- **文档**: `CLAUDE.md`（V33 + 工作原则 #16）、`docs/config.md`（Discord 配置章节 11.2）
- **体检**: `preflight_check.sh`（Discord 环境变量检查 + E2E 推送测试）

## Test plan

- [ ] Mac Mini: `bash preflight_check.sh --full`（含 Discord E2E 推送测试）
- [ ] Mac Mini: `bash job_smoke_test.sh`（全量 job 健康检查）
- [ ] 手动触发一个 job（如 arxiv），确认 WhatsApp + Discord 双通道均收到
- [ ] 手动触发 freight_watcher，确认主推送 + 客户画像 + 错误路径均有 Discord
- [ ] 验证 `source notify.sh && notify "test" --topic papers` 发送到 Discord #论文
- [ ] 重置 Discord Bot Token（本次会话中曾暴露）

https://claude.ai/code/session_01756S75KfsGm5oR2guy39Zo