### PR TITLE
fix: S2 论文监控 429 限流 — 增加间隔 + 指数退避双重重试

### DIFF
--- a/jobs/semantic_scholar/run_semantic_scholar.sh
+++ b/jobs/semantic_scholar/run_semantic_scholar.sh
@@ -47,8 +47,8 @@ for i in "${!KEYWORDS[@]}"; do
   OUTFILE="$RAW_DIR/search_${i}.json"
   ENCODED_KW=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$KW'))")
 
-  # Semantic Scholar 免费 API: 1 req/sec
-  sleep 1
+  # Semantic Scholar 免费 API: 严格限流，关键词间隔 5s
+  [ "$i" -gt 0 ] && sleep 5
 
   HTTP_CODE=$(curl -sSL --max-time 30 -w '%{http_code}' \
     -H "User-Agent: openclaw-s2-monitor/1.0" \
@@ -58,15 +58,21 @@ for i in "${!KEYWORDS[@]}"; do
   if [ "$HTTP_CODE" = "200" ]; then
     echo "[s2] 搜索 '$KW' 成功"
   elif [ "$HTTP_CODE" = "429" ]; then
-    log "WARN: S2 API 429 for '$KW'，等待 60s 重试"
-    sleep 60
-    HTTP_CODE=$(curl -sSL --max-time 30 -w '%{http_code}' \
-      -H "User-Agent: openclaw-s2-monitor/1.0" \
-      "${S2_API}?query=${ENCODED_KW}&fields=${FIELDS}&limit=20&publicationDateOrYear=${DATE_FROM}:${DATE_TO}&fieldsOfStudy=Computer+Science" \
-      -o "$OUTFILE" 2>"$CACHE/curl_s2.err") || HTTP_CODE="000"
+    # 指数退避重试：60s → 120s
+    for RETRY in 60 120; do
+      log "WARN: S2 API 429 for '$KW'，等待 ${RETRY}s 重试"
+      sleep "$RETRY"
+      HTTP_CODE=$(curl -sSL --max-time 30 -w '%{http_code}' \
+        -H "User-Agent: openclaw-s2-monitor/1.0" \
+        "${S2_API}?query=${ENCODED_KW}&fields=${FIELDS}&limit=20&publicationDateOrYear=${DATE_FROM}:${DATE_TO}&fieldsOfStudy=Computer+Science" \
+        -o "$OUTFILE" 2>"$CACHE/curl_s2.err") || HTTP_CODE="000"
+      [ "$HTTP_CODE" = "200" ] && break
+    done
     if [ "$HTTP_CODE" != "200" ]; then
       log "WARN: S2 重试仍失败 ($HTTP_CODE) for '$KW'"
       FETCH_ERRORS=$((FETCH_ERRORS + 1))
+    else
+      echo "[s2] 搜索 '$KW' 成功（重试后）"
     fi
   else
     log "WARN: S2 API 返回 HTTP $HTTP_CODE for '$KW'"


### PR DESCRIPTION
S2 免费 API 限流加严，连续 3 天 429 恶化（4/1: 2/5失败，4/2: 4/5，4/3: 5/5全失败）

修改：
- 关键词间隔 1s → 5s（减少触发限流窗口）
- 429 重试从 1 次（60s）改为 2 次指数退避（60s → 120s）
- 首个关键词不等待（节省 5s）

DBLP 推送失败根因：4/3 12:00 运行时尚未同步 PR #234（13:40 才合并同步）， --channel whatsapp 已在 PR #234 修复，明天 12:00 将自动恢复。

https://claude.ai/code/session_01756S75KfsGm5oR2guy39Zo

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
