### PR TITLE
V34: Provider Compatibility Layer + 导师战略指导嵌入治理体系

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — openclaw-model-bridge 项目背景
 
-> 每次新会话开始时自动读取。当前版本：v30.5（2026-03-31）
+> 每次新会话开始时自动读取。当前版本：v34（2026-04-03）
 
 ---
 
@@ -126,7 +126,11 @@
 | `ops_soul.md` | **V31新增** Ops Agent 运维助手 SOUL.md（系统健康检查/日志排查/cron诊断/维护操作，部署到 `~/.openclaw/SOUL.md`） |
 | `ops_health.sh` | **V31新增** Ops Agent 健康检查包装脚本（Qwen3 拒绝直接 curl localhost，通过脚本包装绕过） |
 | `status.json` | **V30.4新增（仓库副本）** 三方共享意识锚点（priorities/feedback/incidents/quality/operating_rules/session_context），Mac Mini 每小时 git push 同步 |
-| `adapter.py` | API适配层（认证 `$REMOTE_API_KEY`，Fallback降级 `$FALLBACK_PROVIDER`） |
+| `providers.py` | **V34新增** Provider Compatibility Layer（BaseProvider 抽象 + 4 个实现 + ProviderRegistry 动态注册 + 能力声明 + CLI 兼容性矩阵输出） |
+| `test_providers.py` | **V34新增** providers.py 单测（48个用例：能力声明/模型查找/认证头/注册表/向后兼容/CLI输出） |
+| `adapter.py` | API适配层（认证 `$REMOTE_API_KEY`，Fallback降级 `$FALLBACK_PROVIDER`）。V34: 从 `providers.py` 导入 PROVIDERS |
+| `docs/strategic_review_20260403.md` | **V34新增** 导师战略复盘文档（Stage判断/主战场定位/V1-V3路标/三个高价值模块/话语权输出/三块差距） |
+| `docs/compatibility_matrix.md` | **V34新增** Provider 兼容性矩阵（验证状态/降级路径/添加新 Provider 指南） |
 | `openclaw_backup.sh` | **V29.1新增** 每日Gateway state备份到外挂SSD（保留7天） |
 | `jobs_registry.yaml` | **V27新增** 统一任务注册表（system + openclaw 双 cron） |
 | `check_registry.py` | **V27新增** 注册表校验脚本 |
@@ -188,6 +192,7 @@
 
 | 版本 | 日期 | 关键变更 |
 |------|------|----------|
+| V34 | 2026-04-03 | **Stage2 启动** — Provider Compatibility Layer + 导师战略复盘嵌入治理体系 + V1/V2/V3 路标 + 461 测试 |
 | V33 | 2026-04-03 | Discord 双通道支持 + 统一推送 notify.sh + Gateway 不升级可用 |
 | V30.5 | 2026-03-31 | search_kb 混合检索 + 论文监控矩阵 5 源全覆盖 + DBLP 上线 |
 | V30.4 | 2026-03-28 | SOUL.md 激活 + 三方宪法闭环 + 方法论进化（结果验证优先） |
@@ -226,7 +231,7 @@ python3 check_registry.py
 # 一键 smoke test（单测+注册表+连通性）
 bash smoke_test.sh
 
-# 全量回归测试（393个用例，发布前必须100%通过）
+# 全量回归测试（461个用例，发布前必须100%通过）
 bash full_regression.sh
 
 # 安全评分（7维度100分）
@@ -271,6 +276,10 @@ python3 data_clean.py validate original.csv cleaned.csv  # 验证结果
 python3 data_clean.py list-ops                           # 可用操作
 python3 data_clean.py history data.xlsx                  # 版本历史
 curl http://localhost:5002/data_clean/help               # REST 端点帮助
+
+# Provider 兼容性矩阵
+python3 providers.py              # Markdown 表格
+python3 providers.py --json       # JSON 格式（供脚本调用）
 
 # 生成任务文档 / 检测文档漂移
 python3 gen_jobs_doc.py           # 输出 markdown 表格
@@ -327,7 +336,28 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 >
 > 共享状态：`~/.kb/status.json`（三方实时同步优先级、反馈、系统健康）
 
-### 🔴 每次必查（15条，优先级最高）
+### 🔴 战略定位（2026-04-03 导师评审确立）
+
+> **项目已跨过关键门槛：Stage 1 完成（系统构建者）→ 正在冲刺 Stage 2（被社区认可的系统作者）。**
+>
+> **主战场**：不再是抽象的"LLM推理系统"，已收敛为两条线：
+> 1. **Agent Runtime / Inference Gateway / Control Plane** — 模型接入 + 工具治理 + 可观测性 + 故障恢复
+> 2. **Agent Memory Plane / KB-RAG / Job-Orchestrated Intelligence** — 记忆系统 + 知识检索 + 作业编排
+>
+> **旗舰叙事**：`OpenClaw Runtime Control Plane for Tool-Calling Agents`
+>
+> **核心洞察**：项目最强的不是单独算法，而是把模型接入、工具治理、可观测性、故障恢复、记忆与作业系统编织成可运行的 agent runtime。顶级专家不是死守最初设想，而是顺着已证明的能力继续放大。
+>
+> **12 个月路线图**：
+> - **V1（0-4月）别人能跑**：安装稳定 / 配置清晰 / 文档闭环 / 最小 demo / golden test trace
+> - **V2（4-8月）别人敢用**：benchmark / SLO dashboard / incident drill / 兼容矩阵 / semver
+> - **V3（8-12月）别人会扩展**：provider plugin / tool policy plugin / memory plane plugin / SDK / extension guide
+>
+> **距离世界顶级的三块差距**：可迁移性（去硬编码场景依赖）/ 证据密度（benchmark+演练+案例）/ 话语权输出（代码+文档+评测+方法论=完整叙事）
+>
+> **详细战略文档**：`docs/strategic_review_20260403.md`
+
+### 🔴 每次必查（20条，优先级最高）
 
 | # | 原则 | 一句话 |
 |---|------|--------|
@@ -348,11 +378,14 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 | 15 | **🆕 测试必须全量：单测 + full_regression + WhatsApp 业务验证** | 每次变更后测试三层缺一不可：① `bash full_regression.sh`（394 单测 + 注册表 + 安全扫描 + 代码质量）② `bash preflight_check.sh --full` + `bash job_smoke_test.sh`（Mac Mini 部署验证）③ **WhatsApp 端实际业务测试**（用户视角发消息验证 PA 回复、search_kb 检索、图片理解等核心功能）。只跑单测不算测完——单测验证组件，WhatsApp 验证系统。（2026-04-01教训：394 单测全过但 preflight 8 项失败） |
 | 16 | **🆕 所有推送必须双通道（WhatsApp + Discord）** | 新增或修改任何消息推送时，**必须同时覆盖 WhatsApp 和 Discord 两个通道**，不允许遗留单通道发送。优先使用 `notify.sh`（`source notify.sh && notify "msg" --topic papers`）统一推送；若直接调用 `openclaw message send`，每个 WhatsApp 发送后必须紧跟对应的 Discord 发送（成功路径→对应 topic 频道，错误/告警→`DISCORD_CH_ALERTS`）。审计方法：`grep -c "message send.*whatsapp"` 与 `grep -c "message send.*discord"` 计数必须一致。（2026-04-03教训：货代客户画像推送遗漏 Discord，11 个脚本错误路径缺 Discord） |
 | 17 | **🆕 收工必须交叉校验待办状态** | 收工时不仅更新 `status.json`，还必须**扫描 CLAUDE.md 待办列表**，对照本次 session 的 commits 和 recent_changes，将已实现的任务标记 ✅。实现代码 + 更新待办 = 一个完整的交付，缺一不可。同时检查：① CLAUDE.md 待办 vs 实际代码一致 ② status.json priorities vs CLAUDE.md 待办一致 ③ 版本号/文件表/常用命令是否需要同步更新。（2026-04-03教训：V32 实现了 7 个 P0+P1 任务但 CLAUDE.md 全部未标记，直到 V33 审计才发现） |
+| 18 | **🆕 补证据而非补功能** | 下一阶段最该补的不是功能，而是**可对外复述的证据链**：A.兼容性矩阵（provider/模型/模态/工具模式验证 matrix+checklist）B.性能/SLO 实验结果（延迟/成功率/降级恢复时间）C.运维韧性证据（故障注入+恢复时间统计）D.可复现证据（一键启动+demo transcript）。新增功能前先问"这能产出什么证据？"（2026-04-03导师评审：系统已有但证据密度不足） |
+| 19 | **🆕 纵向做深不横向铺开** | 沿 `providers.py` 已证明的方向继续放大，不轻易开新战线。每个改动必须对应 V1/V2/V3 路标中的具体目标：V1=别人能跑，V2=别人敢用，V3=别人会扩展。对照 `docs/strategic_review_20260403.md` 和 status.json 路标检查。偏离路标的功能需要明确理由。（2026-04-03导师建议：不是再做更多功能，而是把已有能力做成证据链） |
+| 20 | **🆕 话语权输出是一等公民** | 代码只是第一步，真正的顶级专家把代码、文档、评测、方法论、复盘文章串成完整叙事。每个 milestone 完成后考虑：能否产出一篇架构型/证据型/立场型文章？README 里的方法论要持续扩写成观点体系。（2026-04-03导师建议：建立"话语权上层建筑"） |
 
 ### 🟡 按需查阅（操作 & 架构参考）
 
 <details>
-<summary>展开查看完整原则列表（13条）</summary>
+<summary>展开查看完整原则列表（16条）</summary>
 
 **操作类**
 - **故障先回滚** — 线上故障 → `git checkout v26-snapshot` 恢复服务 → 再排查根因
@@ -365,6 +398,11 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 - **分支合并由用户在GitHub操作** — 推送到 `claude/xxx` 分支 → 提醒用户创建 PR → **合并后立即同步 Mac Mini**（见必查 #14）
 - **Mac Mini 同步用 reset 不用 pull** — `git fetch origin main && git reset --hard origin/main`（Mac Mini 是纯消费端，无本地 commit；`git pull` 会因历史 merge commit 导致分叉失败）
 - **全量测试三层标准** — 单测通过 ≠ 测完，必须 full_regression + preflight + **WhatsApp 业务验证**（见必查 #15）
+
+**战略类（导师建议 2026-04-03）**
+- **不再是桥接器，是控制平面产品** — 项目已远超 "bridge"，实际是 agent runtime control plane。旗舰叙事：`OpenClaw Runtime Control Plane for Tool-Calling Agents`
+- **沿此仓库继续长 12 个月** — 不轻易切换去做完全不同的大项目，把这个仓库做成第一性代表作
+- **下次汇报准备 5 样东西** — 版本变化 + 1-2 个关键架构图 + benchmark 数据 + 一次真实故障案例 + 对下一阶段的取舍判断
 
 **架构类**
 - **进程管理单一主控** — Gateway 由 launchd 管理，禁止再加 cron watchdog（#95）
@@ -379,58 +417,103 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 
 ## 系统定位：三平面架构
 
-> 来源：2026-04-01 外部专业评审反馈，确立"控制平面先行"原则
+> 来源：2026-04-01 外部专业评审反馈 + 2026-04-03 导师战略复盘
 
 ```
 控制平面（先做强 → 60%→90%）：治理、限流、降级、观测、审计
+  → V34: Provider Compatibility Layer (providers.py) 已实现
 能力平面（持续演进 → 80%）    ：模型路由、工具编排、多模态能力
+  → V34: 兼容性矩阵 + 能力声明 (ProviderCapabilities) 已实现
 记忆平面（长期投入 → 60%）    ：知识沉淀、冲突消解、可信度评分
+  → V2 路标: Memory Plane v1 统一叙事（将 5 个散落组件统一）
 ```
 
 **核心原则：控制平面先行。否则能力越强，系统越难控。**
 
-## 当前待办
+### 导师确立的三个高价值模块（V34+）
 
-| 优先级 | 任务 |
-|--------|------|
-| ✅ | **SLO 最小集**：5 项 SLO 指标定义到 config.yaml + proxy_stats 实时采集 + slo_checker.py 检查 + watchdog 每小时告警（V32→V33 接入 watchdog） |
-| ✅ | **阈值中心化**：config.yaml 统一管理 9 大类阈值（SLO/Proxy/Token/Alert/Routing/Truncation/Watchdog/Incident/Fallback），config_loader.py 统一加载（V32） |
-| ✅ | **旅程级 E2E 进 CI**：wa_e2e_test.sh 覆盖三条主路径（基础对话 / search_kb 检索 / 图片理解），集成到 preflight 18/19（V33） |
-| ✅ | **故障快照机制**：故障时自动收集 proxy.log 尾部 + adapter.log + 最近请求 + 系统状态，写入 `~/.kb/incidents/`（V33: job_watchdog CORE告警自动触发） |
-| ✅ | **Job 分层治理**：registry tier 字段（core/auxiliary/experiment） + watchdog 按 tier 分级告警（V31-V32） |
-| ✅ | **Fallback Matrix 模板化**：config.yaml fallback 段 + adapter.py 断路器 + 自动降级（V32） |
-| ✅ | **变更影响评估**：`.github/PULL_REQUEST_TEMPLATE.md` 含 Impact Scope + Risk Assessment + Rollback Plan（V32） |
-| 中 | **数据清洗 Phase 2**：三 Agent 架构（Profiler/Planner/Executor，可用 `sessions_spawn` 实现）、语义去重、自定义清洗规则 |
-| 中 | **PA 长期记忆**：启用 `memory_search`/`memory_get`。⚠️ Qwen3不主动调用memory工具，等模型升级后重新验证 |
-| 中 | **PA 子 Agent 委派**：`sessions_spawn` + `sessions_send` 让 PA 自主创建子任务 |
-| ✅ | **配置中心化 + 变更审计**：config.yaml 统一配置 + config_loader.py 加载 + audit_log.py 链式哈希审计（V30.2-V32） |
-| ✅ | **GameDay 故障演练**：`gameday.sh` 5 场景（GPU超时/断路器/快照/SLO/Watchdog流水线），`--all` 一键演练（V33） |
-| **P2-低** | **记忆系统分层**：短期（session内）/ 长期（跨session偏好）/ 任务（项目上下文），含冲突消解和可信度评分 |
-| **P2-低** | **成本-质量-时延联动调度**：根据查询复杂度动态选择模型/参数组合 |
-| 低 | 知识图谱：AI大模型领域知识图谱构建（需6-12个月数据积累，暂缓） |
-| 低 | 货代Watcher V3：Bing News API替代GoogleNews |
-| 低 | 语音消息支持：WhatsApp语音→STT→LLM回复 |
-| 低 | **视频号内容转录分析**：firethinker张东普视频号监控，视频保存→STT转录（FunASR/Whisper）→LLM提炼观点+点评→KB沉淀（标签firethinker）→周趋势串联分析成长轨迹。当前方案：手动记笔记→PA写入KB；未来：半自动流水线（保存视频→自动转录分析） |
-| 低 | KB 静态加密：status.json / index.json 使用 age/gpg 加密存盘 |
-| ✅ | 依赖漏洞扫描：pip-audit 集成到 full_regression.sh 第三层安全扫描（V33） |
-| ✅ | **WhatsApp E2E 测试脚本**：`wa_e2e_test.sh` 端到端业务验证（基础对话/工具注入/KB索引/Proxy监控） |
-| ✅ | **pre-commit hook**：`.githooks/pre-commit` 安全扫描+语法检查（`git config core.hooksPath .githooks`） |
-| ✅ | **GitHub Actions CI**：`.github/workflows/ci.yml` PR 门禁（8套单测+注册表+文档漂移+安全扫描+bandit） |
-| ✅ | **search_kb 混合检索 + 数据复利闭环：语义搜索+关键词+LLM解读（V30.5）** |
-| ✅ | **论文监控矩阵：ArXiv+HF+S2+DBLP+ACL 5源全覆盖（V30.5）** |
-| ✅ | **三方宪法闭环验证：SOUL.md + status.json 实时同步 + PA 主动感知（V30.4）** |
-| ✅ | **数据清洗 Phase 1：CLI + 自定义工具注入 + WhatsApp E2E（V30.3）** |
-| ✅ | **安全评分体系 + 审计日志 + 持续安全机制（V30.2）** |
-| ✅ | **全量回归测试框架 393 用例（V30.1）** |
-| ✅ | **KB 周趋势报告 + 模型智能路由（V29.5）** |
-| ✅ | **多模态图片理解：Qwen2.5-VL-72B 自动路由（V29.4）** |
-| ✅ | Multimodal Memory：Gemini Embedding 2 索引图片/音频/视频/PDF（V29.1） |
-| ✅ | Model Fallback 降级链（V29.1） |
-| ✅ | 每日自动备份（V29.1） |
-| ✅ | Multi-Agent 专业化（V29.1） |
-| ✅ | Bootstrap KB 自动注入（V29.1） |
-| ✅ | Context Pruning 配置（V29.1） |
-| ✅ | KB三件套：搜索/LLM深度回顾/每日摘要注入（V29） |
+| 模块 | 目标 | 当前基础 | 路标 |
+|------|------|----------|------|
+| **Provider Compatibility Layer** | auth/chat/tool-calling/multimodal/streaming/fallback 标准接口 | `providers.py`+`adapter.py` 重构完成 | **V1 (in progress)** |
+| **Agent Reliability Bench** | 系统性可靠性评测（provider宕机/tool timeout/malformed args/kb miss-hit/cron drift） | `gameday.sh` 5 场景 | **V2 (backlog)** |
+| **Memory Plane v1** | 短期对话/KB语义/多媒体/用户偏好/运维状态 统一成一个平面 | local_embed+kb_rag+mm_index+preference_learner+status_sync | **V2 (backlog)** |
+
+## 当前待办（按导师 V1/V2/V3 路标组织）
+
+> 来源：2026-04-03 导师战略复盘。路标 = 时间窗口 + 成功标准。详见 `docs/strategic_review_20260403.md`
+
+### V1 路标（0-4 个月）：别人能跑
+
+| 优先级 | 任务 | 状态 |
+|--------|------|------|
+| **V1-P0** | **Provider Compatibility Layer**：`providers.py` BaseProvider 抽象 + 4 个实现 + ProviderRegistry + 能力声明 + CLI 兼容性矩阵（V34 已实现，生产验证中） | 🔄 运行验证中 |
+| **V1-P0** | **兼容性矩阵 + SLO Benchmark 证据**：`docs/compatibility_matrix.md` 已生成。下一步把 SLO 从规则变成实验结果（延迟 p95 / 成功率 / 降级恢复时间 / 超时率） | 🔄 矩阵完成，benchmark 待做 |
+| **V1-P1** | **一键启动 + 最小 demo + golden test trace**：别人 10 分钟能跑起来 = 传播效率翻倍 | 待启动 |
+| **V1-P1** | **可复现证据**：Quick Start 完善 + 一键 smoke test demo + demo transcript | 待启动 |
+
+### V2 路标（4-8 个月）：别人敢用
+
+| 优先级 | 任务 | 状态 |
+|--------|------|------|
+| **V2-P0** | **Agent Reliability Bench**（导师建议模块二）：provider 宕机 / tool timeout / malformed args / oversized request / kb miss-hit / cron drift / state corruption 系统性评测。基于 `gameday.sh` 扩展 | 待启动 |
+| **V2-P0** | **Memory Plane v1 统一叙事**（导师建议模块三）：把 local_embed / kb_rag / mm_index / preference_learner / status_sync 统一成一个 memory plane（短期对话 / KB 语义 / 多媒体 / 用户偏好 / 运维状态） | 待启动 |
+| **V2-P1** | **运维韧性证据**：故障注入实验 + 演练脚本 + 恢复时间统计 → 从"工程做得挺全"升级成"有 SRE 味道的 agent infra" | 待启动 |
+| **V2-P1** | **SLO Dashboard + semver 版本治理** | 待启动 |
+| **V2-P1** | **安全边界说明文档** | 待启动 |
+
+### V3 路标（8-12 个月）：别人会扩展
+
+| 优先级 | 任务 | 状态 |
+|--------|------|------|
+| **V3** | **Provider Plugin Interface**：auth / chat / tool-calling / multimodal normalization / streaming / fallback contract 标准接口 | 待启动 |
+| **V3** | **Tool Policy Plugin + Memory Plane Plugin**：可插拔的工具策略和记忆平面扩展 | 待启动 |
+| **V3** | **Job Template/Registry SDK + Extension Guide**：让别人能基于框架扩展 | 待启动 |
+
+### 话语权输出（持续推进）
+
+| 类型 | 任务 | 状态 |
+|------|------|------|
+| 架构型 | **Why Agent Systems Need a Control Plane** / **From Model Bridge to Runtime Governance** | 待写 |
+| 证据型 | **Benchmark Report** / **Failure Injection Report** / **Lessons from 461-test Regression** | 待写 |
+| 立场型 | **为什么 agent 系统首先是治理问题** / **为什么 control plane 必须先于 capability plane** | 待写 |
+
+### 现有功能任务（V1 稳定后继续推进）
+
+| 优先级 | 任务 | 状态 |
+|--------|------|------|
+| 中 | **数据清洗 Phase 2**：三 Agent 架构（Profiler/Planner/Executor，用 `sessions_spawn`）、语义去重、自定义规则 | active |
+| 中 | **PA 子 Agent 委派**：`sessions_spawn` + `sessions_send` 让 PA 自主创建子任务 | active |
+| deferred | **PA 长期记忆**：Qwen3 不主动调用 memory 工具，等模型升级后重新验证 | blocked |
+| 低 | **可迁移性抽象**：去除个人/场景定制痕迹，抽象成别人也能迁移的框架（导师指出三块差距之一） | V2-V3 |
+| 低 | **记忆系统分层**：短期/长期/任务，含冲突消解和可信度评分 → 纳入 Memory Plane v1 | V2 |
+| 低 | **成本-质量-时延联动调度**：根据查询复杂度动态选择模型/参数组合 | V2+ |
+| 低 | 知识图谱：AI 大模型领域知识图谱构建（需 6-12 个月数据积累） | V3 |
+| 低 | 货代 Watcher V3：Bing News API 替代 GoogleNews | 按需 |
+| 低 | 语音消息支持：WhatsApp 语音→STT→LLM 回复 | 按需 |
+| 低 | **视频号内容转录分析**：firethinker 视频号监控 → STT 转录 → LLM 提炼 → KB 沉淀 | 按需 |
+| 低 | KB 静态加密：status.json / index.json 使用 age/gpg 加密存盘 | 按需 |
+
+### 已完成里程碑（V27-V33）
+
+<details>
+<summary>展开查看 25+ 项已完成任务</summary>
+
+| 版本 | 任务 |
+|------|------|
+| V34 | **Provider Compatibility Layer**：providers.py + 48 单测 + 兼容性矩阵 + adapter.py 重构 |
+| V33 | SLO 最小集 + 阈值中心化 + 旅程级 E2E 进 CI + 故障快照机制 + Job 分层治理 + Fallback Matrix + 变更影响评估 + GameDay 故障演练 + Discord 双通道 + notify.sh + pip-audit |
+| V32 | 配置中心化 + 变更审计 + config_loader.py |
+| V30.5 | search_kb 混合检索 + 论文监控矩阵 5 源全覆盖 + DBLP |
+| V30.4 | SOUL.md 激活 + 三方宪法闭环 + 方法论进化 |
+| V30.3 | 数据清洗 Phase 1 + 自定义工具注入 + WhatsApp E2E |
+| V30.2 | 安全评分体系 + 审计日志 + 持续安全机制 |
+| V30.1 | status.json 实时刷新 + KB 完整性 + 全量回归 374→461 测试 |
+| V30 | crontab 事故修复 + cron 安全三层保护 |
+| V29.x | KB 搜索/RAG/趋势/MM 索引/Fallback/备份/Multi-Agent |
+| V28.x | preflight 体检 + WhatsApp 保活 + CI + pre-commit |
+| V27.x | Proxy 拆层 + 任务注册表 + auto_deploy + 回滚机制 |
+
+</details>
 
 ## 远程连接（本机）
 

--- a/adapter.py
+++ b/adapter.py
@@ -17,35 +17,42 @@ except Exception:
     pass  # config_loader 不可用时使用默认值
 
 # ---------------------------------------------------------------------------
-# Provider registry — add new providers here, no other code changes needed
+# Provider registry — V34: 从 providers.py 加载（Provider Compatibility Layer）
+# 向后兼容：PROVIDERS 仍是 dict，provider 对象可通过 get_provider() 获取能力声明
 # ---------------------------------------------------------------------------
-PROVIDERS = {
-    "qwen": {
-        "base_url":    "https://hkagentx.hkopenlab.com/v1",
-        "api_key_env": "REMOTE_API_KEY",
-        "model_id":    "Qwen3-235B-A22B-Instruct-2507-W8A8",
-        "vl_model_id": "Qwen2.5-VL-72B-Instruct",   # Vision-Language model on same endpoint
-        "auth_style":  "bearer",      # Authorization: Bearer <key>
-    },
-    "openai": {
-        "base_url":    "https://api.openai.com/v1",
-        "api_key_env": "OPENAI_API_KEY",
-        "model_id":    "gpt-4o",
-        "auth_style":  "bearer",
-    },
-    "gemini": {
-        "base_url":    "https://generativelanguage.googleapis.com/v1beta/openai",
-        "api_key_env": "GEMINI_API_KEY",
-        "model_id":    "gemini-2.5-flash",
-        "auth_style":  "bearer",
-    },
-    "claude": {
-        "base_url":    "https://api.anthropic.com/v1",
-        "api_key_env": "ANTHROPIC_API_KEY",
-        "model_id":    "claude-sonnet-4-6",
-        "auth_style":  "x-api-key",   # x-api-key: <key> + anthropic-version header
-    },
-}
+try:
+    from providers import PROVIDERS, get_provider as _get_provider, get_registry as _get_registry
+except ImportError:
+    # providers.py 不可用时回退到内联定义
+    _get_provider = None
+    _get_registry = None
+    PROVIDERS = {
+        "qwen": {
+            "base_url":    "https://hkagentx.hkopenlab.com/v1",
+            "api_key_env": "REMOTE_API_KEY",
+            "model_id":    "Qwen3-235B-A22B-Instruct-2507-W8A8",
+            "vl_model_id": "Qwen2.5-VL-72B-Instruct",
+            "auth_style":  "bearer",
+        },
+        "openai": {
+            "base_url":    "https://api.openai.com/v1",
+            "api_key_env": "OPENAI_API_KEY",
+            "model_id":    "gpt-4o",
+            "auth_style":  "bearer",
+        },
+        "gemini": {
+            "base_url":    "https://generativelanguage.googleapis.com/v1beta/openai",
+            "api_key_env": "GEMINI_API_KEY",
+            "model_id":    "gemini-2.5-flash",
+            "auth_style":  "bearer",
+        },
+        "claude": {
+            "base_url":    "https://api.anthropic.com/v1",
+            "api_key_env": "ANTHROPIC_API_KEY",
+            "model_id":    "claude-sonnet-4-6",
+            "auth_style":  "x-api-key",
+        },
+    }
 
 # ---------------------------------------------------------------------------
 # Load active provider from environment (default: qwen for backward compat)
@@ -211,6 +218,12 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 info["circuit_breaker"] = _circuit_breaker.state()
             if FAST_ROUTE:
                 info["fast_route"] = f"{FAST_ROUTE['name']}/{FAST_ROUTE['model_id']}"
+            # V34: capabilities from Provider Compatibility Layer
+            if _get_provider:
+                p = _get_provider(PROVIDER_NAME)
+                if p:
+                    info["capabilities"] = p.capabilities.supported_modalities()
+                    info["verified"] = p.capabilities.verified_features()
             resp = json.dumps(info).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -85,6 +85,7 @@ declare -a FILE_MAP=(
     "proxy_filters.py|$HOME/proxy_filters.py"
     "tool_proxy.py|$HOME/tool_proxy.py"
     "adapter.py|$HOME/adapter.py"
+    "providers.py|$HOME/providers.py"
 
     # 运维脚本
     "restart.sh|$HOME/restart.sh"

--- a/docs/compatibility_matrix.md
+++ b/docs/compatibility_matrix.md
@@ -1,0 +1,147 @@
+# Provider Compatibility Matrix
+
+> 自动生成：`python3 providers.py` | 最后更新：2026-04-03
+> 数据来源：`providers.py` — Provider Compatibility Layer (V34)
+
+---
+
+## 支持的 Provider
+
+| Provider | Default Model | VL Model | Auth | Base URL |
+|----------|--------------|----------|------|----------|
+| Qwen (Remote GPU) | Qwen3-235B-A22B-Instruct-2507-W8A8 | Qwen2.5-VL-72B-Instruct | Bearer | hkagentx.hkopenlab.com |
+| OpenAI | gpt-4o | — | Bearer | api.openai.com |
+| Google Gemini | gemini-2.5-flash | — | Bearer | generativelanguage.googleapis.com |
+| Anthropic Claude | claude-sonnet-4-6 | — | x-api-key | api.anthropic.com |
+
+## 能力矩阵
+
+| Provider | Text | Vision | Audio | Video | Tool Calling | Streaming | JSON Mode | Context Window |
+|----------|------|--------|-------|-------|-------------|-----------|-----------|---------------|
+| Qwen (Remote GPU) | Yes | Yes | — | — | Yes | Yes | — | 262K |
+| OpenAI | Yes | Yes | Yes | — | Yes | Yes | Yes | 128K |
+| Google Gemini | Yes | Yes | — | — | Yes | Yes | Yes | 1048K |
+| Anthropic Claude | Yes | Yes | — | — | Yes | Yes | — | 200K |
+
+## 验证状态
+
+> "Verified" = 在生产环境中实际测试并确认功能正常
+
+| Provider | 角色 | Text | Vision | Tool Calling | Streaming | Fallback |
+|----------|------|------|--------|-------------|-----------|----------|
+| **Qwen** | Primary | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **Gemini** | Fallback | :white_check_mark: | — | — | — | :white_check_mark: |
+| OpenAI | Available | — | — | — | — | — |
+| Claude | Available | — | — | — | — | — |
+
+### 验证详情
+
+**Qwen (Primary Provider)** — 5/5 verified
+- Text: 日常 WhatsApp 对话，262K context 稳定运行
+- Vision: Qwen2.5-VL-72B 图片理解，自动路由
+- Tool Calling: 12 工具 + 2 自定义工具（data_clean, search_kb）
+- Streaming: SSE 转换，非流式→流式
+- Fallback: 作为 primary 被 Gemini fallback，电路断路器验证
+
+**Gemini (Fallback Provider)** — 2/5 verified
+- Text: 作为 fallback 处理降级请求
+- Fallback: 在 Qwen 超时/故障时自动接管，60s 超时
+
+**OpenAI / Claude** — 0/5 verified
+- 注册表中已配置，但未在生产环境验证
+- 可通过 `PROVIDER=openai` 或 `PROVIDER=claude` 环境变量切换
+
+## 部署配置
+
+### 当前生产配置
+
+```bash
+# Primary
+PROVIDER=qwen
+MODEL_ID=Qwen3-235B-A22B-Instruct-2507-W8A8
+VL_MODEL_ID=Qwen2.5-VL-72B-Instruct
+
+# Fallback
+FALLBACK_PROVIDER=gemini
+FALLBACK_MODEL_ID=gemini-2.5-flash
+
+# Smart Routing (目前禁用)
+FAST_PROVIDER=    # 空 = 禁用
+```
+
+### 切换 Provider
+
+```bash
+# 切换到 OpenAI
+export PROVIDER=openai
+export OPENAI_API_KEY=sk-...
+
+# 切换到 Claude
+export PROVIDER=claude
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# 重启 adapter
+bash restart.sh
+```
+
+## 降级路径
+
+```
+Qwen3-235B (Primary, 5min timeout)
+    ↓ 失败 / 超时 / 电路断路
+Gemini 2.5 Flash (Fallback, 1min timeout)
+    ↓ 也失败
+502 Error (两个错误信息一起返回)
+```
+
+**电路断路器**：连续 5 次失败后自动短路，直接走 Fallback。300 秒后半开尝试恢复。
+
+## 添加新 Provider
+
+```python
+# 在 providers.py 中添加：
+class MyProvider(BaseProvider):
+    name = "my_provider"
+    display_name = "My Custom Provider"
+    base_url = "https://api.example.com/v1"
+    api_key_env = "MY_API_KEY"
+    auth_style = "bearer"  # 或 "x-api-key"
+    models = [
+        ModelInfo(
+            model_id="my-model-v1",
+            display_name="My Model v1",
+            modalities=["text"],
+            context_window=32768,
+            is_default=True,
+        ),
+    ]
+    capabilities = ProviderCapabilities(
+        text=True,
+        tool_calling=True,
+        streaming=True,
+    )
+
+# 注册到默认注册表
+_default_registry.register(MyProvider())
+```
+
+然后：
+```bash
+export PROVIDER=my_provider
+export MY_API_KEY=...
+bash restart.sh
+```
+
+## 工具模式验证
+
+| 模式 | Qwen | Gemini | OpenAI | Claude |
+|------|------|--------|--------|--------|
+| 单工具调用 | :white_check_mark: | — | — | — |
+| 多工具并行 | :white_check_mark: | — | — | — |
+| 自定义工具拦截 | :white_check_mark: | — | — | — |
+| Schema 简化 | :white_check_mark: | — | — | — |
+| 参数修复/别名映射 | :white_check_mark: | — | — | — |
+
+---
+
+*此文档由 `providers.py` 的能力声明驱动，`python3 providers.py --json` 可获取机器可读版本。*

--- a/full_regression.sh
+++ b/full_regression.sh
@@ -49,6 +49,7 @@ run_suite "check_registry (注册表校验器)" "python3 test_check_registry.py"
 run_suite "cron_health (锁/心跳/告警/完整性)" "python3 test_cron_health.py"
 run_suite "status_update (三方状态CRUD)" "python3 test_status_update.py"
 run_suite "adapter (路由/Fallback/认证)" "python3 test_adapter.py"
+run_suite "providers (Provider Compatibility Layer)" "python3 test_providers.py"
 run_suite "kb_business (KB全业务逻辑)" "python3 test_kb_business.py"
 run_suite "audit_log (审计日志/链式哈希)" "python3 test_audit_log.py"
 
@@ -163,8 +164,8 @@ echo "📋 第四层：代码质量（参考项）"
 # 代码覆盖率
 echo -n "  📊 代码覆盖率 ... "
 if command -v coverage &>/dev/null || python3 -c "import coverage" 2>/dev/null; then
-    COV_OUTPUT=$(python3 -m coverage run --source=. --omit="test_*,*/site-packages/*" -m pytest test_tool_proxy.py test_check_registry.py test_status_update.py test_adapter.py -q 2>&1 || \
-                 python3 -m coverage run --source=proxy_filters,status_update,adapter,audit_log --omit="test_*" -m unittest test_tool_proxy test_status_update test_adapter 2>&1)
+    COV_OUTPUT=$(python3 -m coverage run --source=. --omit="test_*,*/site-packages/*" -m pytest test_tool_proxy.py test_check_registry.py test_status_update.py test_adapter.py test_providers.py -q 2>&1 || \
+                 python3 -m coverage run --source=proxy_filters,status_update,adapter,providers,audit_log --omit="test_*" -m unittest test_tool_proxy test_status_update test_adapter test_providers 2>&1)
     COV_REPORT=$(python3 -m coverage report --format=total 2>/dev/null || python3 -m coverage report 2>/dev/null | tail -1 | awk '{print $NF}')
     echo "📈 $COV_REPORT"
 else

--- a/providers.py
+++ b/providers.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+providers.py — Provider Compatibility Layer (V34: Stage2)
+
+统一的 Provider 抽象层，将硬编码的 provider 字典升级为可插拔的接口。
+每个 Provider 声明自己的能力（capabilities）、认证方式、模型列表和限制，
+为兼容性矩阵和自动化评测提供基础。
+
+设计原则：
+- 向后兼容：导出 PROVIDERS dict，adapter.py 无感知切换
+- 单文件：适配 auto_deploy FILE_MAP 同步，无需目录结构
+- 能力声明：每个 Provider 显式声明支持的功能，而非运行时探测
+- 可扩展：新 Provider 只需继承 BaseProvider 并注册
+"""
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+
+# ---------------------------------------------------------------------------
+# Capability declarations — 每个 Provider 显式声明支持的能力
+# ---------------------------------------------------------------------------
+@dataclass
+class ProviderCapabilities:
+    """Provider 能力声明，用于兼容性矩阵和路由决策。"""
+    # 模态支持
+    text: bool = True
+    vision: bool = False
+    audio: bool = False
+    video: bool = False
+
+    # 功能支持
+    tool_calling: bool = False
+    streaming: bool = False
+    json_mode: bool = False
+
+    # 限制
+    context_window: int = 0          # 最大上下文窗口 (tokens)
+    max_output_tokens: int = 0       # 最大输出 tokens
+    rate_limit_rpm: int = 0          # 每分钟请求限制 (0 = unknown)
+
+    # 验证状态（实际测试过的才标 True）
+    verified_text: bool = False
+    verified_vision: bool = False
+    verified_tool_calling: bool = False
+    verified_streaming: bool = False
+    verified_fallback: bool = False
+
+    def supported_modalities(self) -> List[str]:
+        """返回支持的模态列表。"""
+        mods = []
+        if self.text: mods.append("text")
+        if self.vision: mods.append("vision")
+        if self.audio: mods.append("audio")
+        if self.video: mods.append("video")
+        return mods
+
+    def verified_features(self) -> List[str]:
+        """返回已验证的功能列表。"""
+        features = []
+        if self.verified_text: features.append("text")
+        if self.verified_vision: features.append("vision")
+        if self.verified_tool_calling: features.append("tool_calling")
+        if self.verified_streaming: features.append("streaming")
+        if self.verified_fallback: features.append("fallback")
+        return features
+
+
+@dataclass
+class ModelInfo:
+    """单个模型的信息。"""
+    model_id: str
+    display_name: str = ""
+    modalities: List[str] = field(default_factory=lambda: ["text"])
+    context_window: int = 0
+    max_output_tokens: int = 0
+    is_default: bool = False
+    is_vision: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Base Provider — 所有 Provider 的抽象基类
+# ---------------------------------------------------------------------------
+class BaseProvider:
+    """Provider 基类，定义标准接口。
+
+    子类必须实现:
+    - name: str
+    - display_name: str
+    - base_url: str
+    - api_key_env: str
+    - auth_style: str ("bearer" | "x-api-key")
+    - models: List[ModelInfo]
+    - capabilities: ProviderCapabilities
+    """
+    name: str = ""
+    display_name: str = ""
+    base_url: str = ""
+    api_key_env: str = ""
+    auth_style: str = "bearer"
+    models: List[ModelInfo] = []
+    capabilities: ProviderCapabilities = ProviderCapabilities()
+
+    def default_model(self) -> Optional[ModelInfo]:
+        """返回默认模型。"""
+        for m in self.models:
+            if m.is_default:
+                return m
+        return self.models[0] if self.models else None
+
+    def vision_model(self) -> Optional[ModelInfo]:
+        """返回视觉模型（如果有）。"""
+        for m in self.models:
+            if m.is_vision:
+                return m
+        return None
+
+    @property
+    def model_id(self) -> str:
+        """默认模型 ID（兼容旧 PROVIDERS dict）。"""
+        dm = self.default_model()
+        return dm.model_id if dm else ""
+
+    @property
+    def vl_model_id(self) -> str:
+        """视觉模型 ID（兼容旧 PROVIDERS dict）。"""
+        vm = self.vision_model()
+        return vm.model_id if vm else ""
+
+    def make_auth_headers(self, api_key: str) -> Dict[str, str]:
+        """生成认证头。子类可覆写以支持特殊认证。"""
+        if self.auth_style == "x-api-key":
+            return {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
+        return {"Authorization": f"Bearer {api_key}"}
+
+    def to_legacy_dict(self) -> dict:
+        """转换为旧格式 PROVIDERS dict entry（向后兼容）。"""
+        d = {
+            "base_url": self.base_url,
+            "api_key_env": self.api_key_env,
+            "model_id": self.model_id,
+            "auth_style": self.auth_style,
+        }
+        if self.vl_model_id:
+            d["vl_model_id"] = self.vl_model_id
+        return d
+
+    def to_matrix_row(self) -> dict:
+        """生成兼容性矩阵行。"""
+        caps = self.capabilities
+        return {
+            "provider": self.display_name or self.name,
+            "models": [m.model_id for m in self.models],
+            "modalities": caps.supported_modalities(),
+            "tool_calling": caps.tool_calling,
+            "streaming": caps.streaming,
+            "context_window": caps.context_window,
+            "max_output_tokens": caps.max_output_tokens,
+            "auth_style": self.auth_style,
+            "verified": caps.verified_features(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Concrete Providers
+# ---------------------------------------------------------------------------
+class QwenProvider(BaseProvider):
+    name = "qwen"
+    display_name = "Qwen (Remote GPU)"
+    base_url = "https://hkagentx.hkopenlab.com/v1"
+    api_key_env = "REMOTE_API_KEY"
+    auth_style = "bearer"
+    models = [
+        ModelInfo(
+            model_id="Qwen3-235B-A22B-Instruct-2507-W8A8",
+            display_name="Qwen3-235B (MoE, 22B active)",
+            modalities=["text"],
+            context_window=262144,
+            max_output_tokens=8192,
+            is_default=True,
+        ),
+        ModelInfo(
+            model_id="Qwen2.5-VL-72B-Instruct",
+            display_name="Qwen2.5-VL-72B (Vision)",
+            modalities=["text", "vision"],
+            context_window=32768,
+            max_output_tokens=4096,
+            is_vision=True,
+        ),
+    ]
+    capabilities = ProviderCapabilities(
+        text=True,
+        vision=True,
+        audio=False,
+        video=False,
+        tool_calling=True,
+        streaming=True,
+        json_mode=False,
+        context_window=262144,
+        max_output_tokens=8192,
+        # 已验证的功能
+        verified_text=True,
+        verified_vision=True,
+        verified_tool_calling=True,
+        verified_streaming=True,
+        verified_fallback=True,   # 作为 primary 被 fallback 过
+    )
+
+
+class OpenAIProvider(BaseProvider):
+    name = "openai"
+    display_name = "OpenAI"
+    base_url = "https://api.openai.com/v1"
+    api_key_env = "OPENAI_API_KEY"
+    auth_style = "bearer"
+    models = [
+        ModelInfo(
+            model_id="gpt-4o",
+            display_name="GPT-4o",
+            modalities=["text", "vision", "audio"],
+            context_window=128000,
+            max_output_tokens=16384,
+            is_default=True,
+        ),
+    ]
+    capabilities = ProviderCapabilities(
+        text=True,
+        vision=True,
+        audio=True,
+        video=False,
+        tool_calling=True,
+        streaming=True,
+        json_mode=True,
+        context_window=128000,
+        max_output_tokens=16384,
+        # 未在生产中验证
+        verified_text=False,
+        verified_vision=False,
+        verified_tool_calling=False,
+        verified_streaming=False,
+        verified_fallback=False,
+    )
+
+
+class GeminiProvider(BaseProvider):
+    name = "gemini"
+    display_name = "Google Gemini"
+    base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+    api_key_env = "GEMINI_API_KEY"
+    auth_style = "bearer"
+    models = [
+        ModelInfo(
+            model_id="gemini-2.5-flash",
+            display_name="Gemini 2.5 Flash",
+            modalities=["text", "vision"],
+            context_window=1048576,
+            max_output_tokens=8192,
+            is_default=True,
+        ),
+    ]
+    capabilities = ProviderCapabilities(
+        text=True,
+        vision=True,
+        audio=False,
+        video=False,
+        tool_calling=True,
+        streaming=True,
+        json_mode=True,
+        context_window=1048576,
+        max_output_tokens=8192,
+        # 作为 fallback 验证过
+        verified_text=True,
+        verified_vision=False,
+        verified_tool_calling=False,
+        verified_streaming=False,
+        verified_fallback=True,    # 作为 fallback provider 验证过
+    )
+
+
+class ClaudeProvider(BaseProvider):
+    name = "claude"
+    display_name = "Anthropic Claude"
+    base_url = "https://api.anthropic.com/v1"
+    api_key_env = "ANTHROPIC_API_KEY"
+    auth_style = "x-api-key"
+    models = [
+        ModelInfo(
+            model_id="claude-sonnet-4-6",
+            display_name="Claude Sonnet 4.6",
+            modalities=["text", "vision"],
+            context_window=200000,
+            max_output_tokens=64000,
+            is_default=True,
+        ),
+    ]
+    capabilities = ProviderCapabilities(
+        text=True,
+        vision=True,
+        audio=False,
+        video=False,
+        tool_calling=True,
+        streaming=True,
+        json_mode=False,
+        context_window=200000,
+        max_output_tokens=64000,
+        # 未在生产中验证
+        verified_text=False,
+        verified_vision=False,
+        verified_tool_calling=False,
+        verified_streaming=False,
+        verified_fallback=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider Registry — 动态注册 + 发现
+# ---------------------------------------------------------------------------
+class ProviderRegistry:
+    """Provider 注册表，支持动态注册和按名查找。"""
+
+    def __init__(self):
+        self._providers: Dict[str, BaseProvider] = {}
+
+    def register(self, provider: BaseProvider):
+        """注册一个 Provider。"""
+        self._providers[provider.name] = provider
+
+    def get(self, name: str) -> Optional[BaseProvider]:
+        """按名获取 Provider。"""
+        return self._providers.get(name)
+
+    def list_names(self) -> List[str]:
+        """返回所有已注册 Provider 名。"""
+        return list(self._providers.keys())
+
+    def all(self) -> List[BaseProvider]:
+        """返回所有已注册 Provider。"""
+        return list(self._providers.values())
+
+    def to_legacy_dict(self) -> Dict[str, dict]:
+        """转换为旧格式 PROVIDERS dict（向后兼容 adapter.py）。"""
+        return {name: p.to_legacy_dict() for name, p in self._providers.items()}
+
+    def compatibility_matrix(self) -> List[dict]:
+        """生成完整兼容性矩阵。"""
+        return [p.to_matrix_row() for p in self._providers.values()]
+
+    def print_matrix(self):
+        """打印兼容性矩阵（Markdown 格式）。"""
+        matrix = self.compatibility_matrix()
+        if not matrix:
+            print("No providers registered.")
+            return
+
+        print("| Provider | Models | Modalities | Tool Calling | Streaming | Context | Verified |")
+        print("|----------|--------|------------|-------------|-----------|---------|----------|")
+        for row in matrix:
+            models = ", ".join(row["models"][:2])
+            if len(row["models"]) > 2:
+                models += f" (+{len(row['models'])-2})"
+            mods = ", ".join(row["modalities"])
+            verified = ", ".join(row["verified"]) if row["verified"] else "none"
+            ctx = f"{row['context_window']//1000}K" if row['context_window'] else "?"
+            print(f"| {row['provider']} | {models} | {mods} | "
+                  f"{'Yes' if row['tool_calling'] else 'No'} | "
+                  f"{'Yes' if row['streaming'] else 'No'} | {ctx} | {verified} |")
+
+
+# ---------------------------------------------------------------------------
+# Default registry — 内置 4 个 Provider
+# ---------------------------------------------------------------------------
+_default_registry = ProviderRegistry()
+_default_registry.register(QwenProvider())
+_default_registry.register(OpenAIProvider())
+_default_registry.register(GeminiProvider())
+_default_registry.register(ClaudeProvider())
+
+
+def get_registry() -> ProviderRegistry:
+    """获取默认 Provider 注册表。"""
+    return _default_registry
+
+
+def get_provider(name: str) -> Optional[BaseProvider]:
+    """按名获取 Provider（快捷方法）。"""
+    return _default_registry.get(name)
+
+
+# ---------------------------------------------------------------------------
+# 向后兼容 — 导出 PROVIDERS dict，adapter.py 可直接 from providers import PROVIDERS
+# ---------------------------------------------------------------------------
+PROVIDERS = _default_registry.to_legacy_dict()
+
+
+# ---------------------------------------------------------------------------
+# CLI: python3 providers.py → 打印兼容性矩阵
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys
+    if "--json" in sys.argv:
+        import json
+        print(json.dumps(_default_registry.compatibility_matrix(), indent=2, ensure_ascii=False))
+    else:
+        print("# Provider Compatibility Matrix\n")
+        _default_registry.print_matrix()
+        print(f"\nTotal: {len(_default_registry.list_names())} providers registered")
+        print(f"Names: {', '.join(_default_registry.list_names())}")
+
+        # 验证摘要
+        print("\n## Verification Status\n")
+        for p in _default_registry.all():
+            verified = p.capabilities.verified_features()
+            total = len(p.capabilities.supported_modalities()) + \
+                    sum([p.capabilities.tool_calling, p.capabilities.streaming])
+            status = f"{len(verified)}/{total} verified" if total else "N/A"
+            print(f"- **{p.display_name}**: {status} — {', '.join(verified) if verified else 'not yet tested'}")

--- a/status.json
+++ b/status.json
@@ -3,14 +3,84 @@
   "updated_by": "claude_code",
   "priorities": [
     {
-      "task": "数据清洗 Phase 2",
+      "task": "【战略】Stage2: 从系统构建者升级为被社区认可的系统作者",
       "status": "active",
-      "note": "三Agent架构（用sessions_spawn）、语义去重、自定义规则、模板积累、文件回传"
+      "note": "导师评审确认 Stage1 完成。路线：bridge→runtime→control plane→方法论与生态。详见 docs/strategic_review_20260403.md"
     },
     {
-      "task": "PA长期记忆",
-      "status": "deferred",
-      "note": "Qwen3不主动调用memory工具+无法读取SOUL.md偏好数据，等模型升级后重新验证；基础设施已就绪"
+      "task": "【V1-P0】Provider Compatibility Layer",
+      "status": "in_progress",
+      "note": "V34已实现: providers.py(BaseProvider+4实现+ProviderRegistry+能力声明+CLI矩阵)+48单测。需生产运行验证后固化"
+    },
+    {
+      "task": "【V1-P0】兼容性矩阵 + SLO Benchmark 证据",
+      "status": "in_progress",
+      "note": "矩阵文档已生成(docs/compatibility_matrix.md)。下一步：把SLO从规则变成实验结果（延迟/成功率/降级恢复时间/超时率）"
+    },
+    {
+      "task": "【V1-P1】一键启动 + 最小 demo + golden test trace",
+      "status": "backlog",
+      "note": "导师建议：别人10分钟能跑起来，传播效率翻倍。需要：安装稳定/配置清晰/文档闭环/demo transcript"
+    },
+    {
+      "task": "【V1-P1】可复现证据：Quick Start 完善 + smoke test demo",
+      "status": "backlog",
+      "note": "已有 Quick Start/GUIDE/CI/测试，再加一键 demo transcript / golden trace"
+    },
+    {
+      "task": "【V2-P0】Agent Reliability Bench",
+      "status": "backlog",
+      "note": "导师建议模块二：provider宕机/tool timeout/malformed args/oversized request/kb miss-hit/cron drift/state corruption评测。基于gameday.sh扩展"
+    },
+    {
+      "task": "【V2-P0】Memory Plane v1 统一叙事",
+      "status": "backlog",
+      "note": "导师建议模块三：把 local_embed/kb_rag/mm_index/preference_learner/status_sync 统一成一个 memory plane（短期对话/KB语义/多媒体/用户偏好/运维状态）"
+    },
+    {
+      "task": "【V2-P1】运维韧性证据：故障注入 + 恢复时间统计",
+      "status": "backlog",
+      "note": "已有 incident_snapshot/watchdog/preflight/gameday。下一步：系统性故障注入实验+演练脚本+恢复时间统计"
+    },
+    {
+      "task": "【V2-P1】SLO Dashboard + 版本治理 semver",
+      "status": "backlog",
+      "note": "SLO指标已定义(config.yaml)，需要可视化dashboard和语义化版本管理"
+    },
+    {
+      "task": "【V3】Provider Plugin Interface",
+      "status": "backlog",
+      "note": "导师建议：auth/chat/tool-calling/multimodal normalization/streaming/fallback contract 标准接口"
+    },
+    {
+      "task": "【V3】Tool Policy Plugin + Memory Plane Plugin",
+      "status": "backlog",
+      "note": "可插拔的工具策略和记忆平面扩展接口"
+    },
+    {
+      "task": "【V3】Job Template/Registry SDK + Extension Guide",
+      "status": "backlog",
+      "note": "让别人能基于框架扩展自己的 job 和 agent"
+    },
+    {
+      "task": "【输出】第一篇架构型文章",
+      "status": "backlog",
+      "note": "导师建议题目：Why Agent Systems Need a Control Plane / From Model Bridge to Runtime Governance"
+    },
+    {
+      "task": "【输出】证据型文章（Benchmark/故障案例/Lessons Learned）",
+      "status": "backlog",
+      "note": "424+ tests, 9组CI, 26条教训 — 都适合转化为文章"
+    },
+    {
+      "task": "【输出】立场型文章（为什么agent首先是治理问题）",
+      "status": "backlog",
+      "note": "Control Plane First 方法论已在README写出，需扩写成完整观点体系"
+    },
+    {
+      "task": "数据清洗 Phase 2",
+      "status": "active",
+      "note": "三Agent架构（用sessions_spawn）、语义去重、自定义规则。V1稳定后继续推进"
     },
     {
       "task": "PA子Agent委派",
@@ -18,59 +88,14 @@
       "note": "sessions_spawn+sessions_send，PA自主创建子任务"
     },
     {
-      "task": "ops agent激活",
-      "status": "done",
-      "note": "V31: ops_soul.md运维身份+工具白名单(exec/read/write/message/web_fetch)+auto_deploy部署"
-    },
-    {
-      "task": "趋势报告优化",
-      "status": "active",
-      "note": "反馈闭环已上线"
-    },
-    {
-      "task": "模型智能路由",
+      "task": "PA长期记忆",
       "status": "deferred",
-      "note": "Gemini Flash临时免费API有额度限制，暂不启用FAST_PROVIDER；等有稳定的快速模型再评估"
+      "note": "Qwen3不主动调用memory工具，等模型升级后重新验证"
     },
     {
-      "task": "安全加固",
-      "status": "done",
-      "note": "sandbox.mode+redactSensitive限制PA写入范围和日志脱敏"
-    },
-    {
-      "task": "紧急告警中断",
+      "task": "可迁移性抽象",
       "status": "backlog",
-      "note": "queue interrupt模式，watchdog告警可中断当前对话"
-    },
-    {
-      "task": "知识图谱",
-      "status": "backlog",
-      "note": "需6-12个月数据积累"
-    },
-    {
-      "task": "论文源扩展: Papers with Code",
-      "status": "done",
-      "note": "V31: 论文+代码监控上线，免费API，每日13:00推送，优先展示有代码的论文"
-    },
-    {
-      "task": "论文源扩展: OpenReview",
-      "status": "done",
-      "note": "ICLR/NeurIPS/ICML顶会投稿+评审，可过滤高分论文"
-    },
-    {
-      "task": "论文源扩展: ACL Anthology",
-      "status": "done",
-      "note": "NLP顶会（ACL/EMNLP/NAACL）完整收录，按会议周期更新"
-    },
-    {
-      "task": "论文源扩展: DBLP",
-      "status": "done",
-      "note": "V30.5: DBLP CS论文监控上线，多关键词搜索，免费API，每日12:00推送"
-    },
-    {
-      "task": "search_kb 混合检索工具",
-      "status": "done",
-      "note": "V30.5: 语义搜索(embedding)+关键词补充+followup LLM解读，PA数据复利闭环"
+      "note": "导师指出的三块差距之一：去除个人/场景定制痕迹，抽象成别人也能迁移的框架。V2-V3阶段推进"
     }
   ],
   "recent_changes": [

--- a/test_providers.py
+++ b/test_providers.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""test_providers.py — Provider Compatibility Layer 单测 (V34)
+
+覆盖：BaseProvider / ProviderCapabilities / ProviderRegistry /
+      向后兼容 / 兼容性矩阵 / 模型查找 / 认证头生成 / 自定义 Provider
+"""
+import json
+import os
+import sys
+import unittest
+
+
+class TestProviderCapabilities(unittest.TestCase):
+    """能力声明测试"""
+
+    def test_supported_modalities_text_only(self):
+        from providers import ProviderCapabilities
+        caps = ProviderCapabilities(text=True, vision=False)
+        self.assertEqual(caps.supported_modalities(), ["text"])
+
+    def test_supported_modalities_multimodal(self):
+        from providers import ProviderCapabilities
+        caps = ProviderCapabilities(text=True, vision=True, audio=True, video=False)
+        self.assertEqual(caps.supported_modalities(), ["text", "vision", "audio"])
+
+    def test_verified_features_empty(self):
+        from providers import ProviderCapabilities
+        caps = ProviderCapabilities()
+        self.assertEqual(caps.verified_features(), [])
+
+    def test_verified_features_partial(self):
+        from providers import ProviderCapabilities
+        caps = ProviderCapabilities(verified_text=True, verified_fallback=True)
+        self.assertEqual(caps.verified_features(), ["text", "fallback"])
+
+
+class TestModelInfo(unittest.TestCase):
+    """模型信息测试"""
+
+    def test_model_info_fields(self):
+        from providers import ModelInfo
+        m = ModelInfo(model_id="test-model", display_name="Test", context_window=4096)
+        self.assertEqual(m.model_id, "test-model")
+        self.assertEqual(m.context_window, 4096)
+
+    def test_model_default_modalities(self):
+        from providers import ModelInfo
+        m = ModelInfo(model_id="test")
+        self.assertEqual(m.modalities, ["text"])
+
+
+class TestBaseProvider(unittest.TestCase):
+    """基类接口测试"""
+
+    def test_default_model(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        dm = p.default_model()
+        self.assertIsNotNone(dm)
+        self.assertIn("Qwen3", dm.model_id)
+
+    def test_vision_model(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        vm = p.vision_model()
+        self.assertIsNotNone(vm)
+        self.assertIn("VL", vm.model_id)
+
+    def test_no_vision_model(self):
+        from providers import OpenAIProvider
+        p = OpenAIProvider()
+        # OpenAI gpt-4o supports vision but is not a separate VL model
+        # is_vision=False by default, so vision_model() returns None
+        vm = p.vision_model()
+        self.assertIsNone(vm)
+
+    def test_model_id_property(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        self.assertEqual(p.model_id, "Qwen3-235B-A22B-Instruct-2507-W8A8")
+
+    def test_vl_model_id_property(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        self.assertEqual(p.vl_model_id, "Qwen2.5-VL-72B-Instruct")
+
+    def test_vl_model_id_empty_when_none(self):
+        from providers import OpenAIProvider
+        p = OpenAIProvider()
+        self.assertEqual(p.vl_model_id, "")
+
+    def test_bearer_auth_headers(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        headers = p.make_auth_headers("test-key")
+        self.assertEqual(headers, {"Authorization": "Bearer test-key"})
+
+    def test_x_api_key_auth_headers(self):
+        from providers import ClaudeProvider
+        p = ClaudeProvider()
+        headers = p.make_auth_headers("test-key")
+        self.assertIn("x-api-key", headers)
+        self.assertEqual(headers["x-api-key"], "test-key")
+        self.assertIn("anthropic-version", headers)
+
+    def test_to_legacy_dict_has_required_fields(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        d = p.to_legacy_dict()
+        required = {"base_url", "api_key_env", "model_id", "auth_style"}
+        self.assertTrue(required.issubset(set(d.keys())))
+
+    def test_to_legacy_dict_includes_vl(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        d = p.to_legacy_dict()
+        self.assertIn("vl_model_id", d)
+
+    def test_to_legacy_dict_no_vl_when_absent(self):
+        from providers import GeminiProvider
+        p = GeminiProvider()
+        d = p.to_legacy_dict()
+        self.assertNotIn("vl_model_id", d)
+
+    def test_to_matrix_row(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        row = p.to_matrix_row()
+        self.assertEqual(row["provider"], "Qwen (Remote GPU)")
+        self.assertIn("text", row["modalities"])
+        self.assertTrue(row["tool_calling"])
+        self.assertGreater(row["context_window"], 0)
+        self.assertIsInstance(row["verified"], list)
+
+
+class TestConcreteProviders(unittest.TestCase):
+    """具体 Provider 实现测试"""
+
+    def test_qwen_provider(self):
+        from providers import QwenProvider
+        p = QwenProvider()
+        self.assertEqual(p.name, "qwen")
+        self.assertEqual(p.auth_style, "bearer")
+        self.assertTrue(p.capabilities.vision)
+        self.assertTrue(p.capabilities.verified_text)
+        self.assertEqual(len(p.models), 2)
+
+    def test_openai_provider(self):
+        from providers import OpenAIProvider
+        p = OpenAIProvider()
+        self.assertEqual(p.name, "openai")
+        self.assertTrue(p.capabilities.audio)
+        self.assertTrue(p.capabilities.json_mode)
+        self.assertFalse(p.capabilities.verified_text)  # 未在生产验证
+
+    def test_gemini_provider(self):
+        from providers import GeminiProvider
+        p = GeminiProvider()
+        self.assertEqual(p.name, "gemini")
+        self.assertTrue(p.capabilities.verified_fallback)
+        self.assertGreater(p.capabilities.context_window, 1000000)
+
+    def test_claude_provider(self):
+        from providers import ClaudeProvider
+        p = ClaudeProvider()
+        self.assertEqual(p.name, "claude")
+        self.assertEqual(p.auth_style, "x-api-key")
+        self.assertFalse(p.capabilities.verified_text)
+
+    def test_all_providers_have_name(self):
+        from providers import get_registry
+        for p in get_registry().all():
+            self.assertTrue(p.name, f"Provider missing name")
+            self.assertTrue(p.display_name, f"{p.name} missing display_name")
+
+    def test_all_providers_have_base_url(self):
+        from providers import get_registry
+        for p in get_registry().all():
+            self.assertTrue(p.base_url.startswith("https://"), f"{p.name}: base_url not HTTPS")
+
+    def test_all_providers_have_api_key_env(self):
+        from providers import get_registry
+        for p in get_registry().all():
+            self.assertTrue(p.api_key_env.endswith("_KEY") or p.api_key_env.endswith("_API_KEY"),
+                            f"{p.name}: api_key_env doesn't look like env var")
+
+    def test_all_providers_valid_auth_style(self):
+        from providers import get_registry
+        valid = {"bearer", "x-api-key"}
+        for p in get_registry().all():
+            self.assertIn(p.auth_style, valid, f"{p.name}: invalid auth_style")
+
+    def test_all_providers_have_models(self):
+        from providers import get_registry
+        for p in get_registry().all():
+            self.assertGreater(len(p.models), 0, f"{p.name}: no models")
+
+    def test_all_providers_have_default_model(self):
+        from providers import get_registry
+        for p in get_registry().all():
+            self.assertIsNotNone(p.default_model(), f"{p.name}: no default model")
+
+
+class TestProviderRegistry(unittest.TestCase):
+    """注册表测试"""
+
+    def test_default_registry_has_4_providers(self):
+        from providers import get_registry
+        reg = get_registry()
+        self.assertEqual(len(reg.list_names()), 4)
+
+    def test_get_existing_provider(self):
+        from providers import get_registry
+        reg = get_registry()
+        p = reg.get("qwen")
+        self.assertIsNotNone(p)
+        self.assertEqual(p.name, "qwen")
+
+    def test_get_nonexistent_returns_none(self):
+        from providers import get_registry
+        reg = get_registry()
+        self.assertIsNone(reg.get("nonexistent"))
+
+    def test_list_names(self):
+        from providers import get_registry
+        names = get_registry().list_names()
+        self.assertIn("qwen", names)
+        self.assertIn("gemini", names)
+        self.assertIn("openai", names)
+        self.assertIn("claude", names)
+
+    def test_to_legacy_dict(self):
+        from providers import get_registry
+        legacy = get_registry().to_legacy_dict()
+        self.assertIsInstance(legacy, dict)
+        self.assertIn("qwen", legacy)
+        # 验证旧格式字段
+        for name, cfg in legacy.items():
+            self.assertIn("base_url", cfg)
+            self.assertIn("model_id", cfg)
+
+    def test_compatibility_matrix(self):
+        from providers import get_registry
+        matrix = get_registry().compatibility_matrix()
+        self.assertEqual(len(matrix), 4)
+        for row in matrix:
+            self.assertIn("provider", row)
+            self.assertIn("models", row)
+            self.assertIn("modalities", row)
+            self.assertIn("verified", row)
+
+    def test_register_custom_provider(self):
+        from providers import ProviderRegistry, BaseProvider, ProviderCapabilities, ModelInfo
+        reg = ProviderRegistry()
+        custom = BaseProvider()
+        custom.name = "custom"
+        custom.display_name = "Custom LLM"
+        custom.base_url = "https://custom.example.com/v1"
+        custom.api_key_env = "CUSTOM_API_KEY"
+        custom.auth_style = "bearer"
+        custom.models = [ModelInfo(model_id="custom-v1", is_default=True)]
+        custom.capabilities = ProviderCapabilities(text=True)
+        reg.register(custom)
+        self.assertEqual(len(reg.list_names()), 1)
+        self.assertIsNotNone(reg.get("custom"))
+
+    def test_custom_provider_in_matrix(self):
+        from providers import ProviderRegistry, BaseProvider, ProviderCapabilities, ModelInfo
+        reg = ProviderRegistry()
+        custom = BaseProvider()
+        custom.name = "test"
+        custom.display_name = "Test"
+        custom.base_url = "https://test.example.com/v1"
+        custom.api_key_env = "TEST_KEY"
+        custom.models = [ModelInfo(model_id="test-v1", is_default=True)]
+        custom.capabilities = ProviderCapabilities(text=True, verified_text=True)
+        reg.register(custom)
+        matrix = reg.compatibility_matrix()
+        self.assertEqual(len(matrix), 1)
+        self.assertEqual(matrix[0]["provider"], "Test")
+        self.assertIn("text", matrix[0]["verified"])
+
+
+class TestBackwardCompatibility(unittest.TestCase):
+    """向后兼容性测试 — 确保 adapter.py 无缝切换"""
+
+    def test_providers_dict_exported(self):
+        from providers import PROVIDERS
+        self.assertIsInstance(PROVIDERS, dict)
+        self.assertEqual(len(PROVIDERS), 4)
+
+    def test_providers_dict_matches_old_format(self):
+        """PROVIDERS dict 的格式与旧版 adapter.py 完全一致"""
+        from providers import PROVIDERS
+        for name, cfg in PROVIDERS.items():
+            self.assertIn("base_url", cfg)
+            self.assertIn("api_key_env", cfg)
+            self.assertIn("model_id", cfg)
+            self.assertIn("auth_style", cfg)
+            # 值类型检查
+            self.assertIsInstance(cfg["base_url"], str)
+            self.assertIsInstance(cfg["model_id"], str)
+
+    def test_qwen_vl_model_in_legacy(self):
+        """旧格式 qwen 包含 vl_model_id"""
+        from providers import PROVIDERS
+        self.assertIn("vl_model_id", PROVIDERS["qwen"])
+        self.assertIn("VL", PROVIDERS["qwen"]["vl_model_id"])
+
+    def test_claude_auth_style_in_legacy(self):
+        """旧格式 claude 使用 x-api-key"""
+        from providers import PROVIDERS
+        self.assertEqual(PROVIDERS["claude"]["auth_style"], "x-api-key")
+
+    def test_adapter_imports_providers(self):
+        """adapter.py 能从 providers.py 导入 PROVIDERS"""
+        import ast
+        with open("adapter.py") as f:
+            content = f.read()
+        self.assertIn("from providers import PROVIDERS", content)
+
+    def test_adapter_has_fallback_inline(self):
+        """adapter.py 有内联回退定义（providers.py 不可用时）"""
+        import ast
+        with open("adapter.py") as f:
+            content = f.read()
+        self.assertIn("ImportError", content)
+        # 回退中仍有旧定义
+        self.assertIn('"qwen":', content)
+
+
+class TestAdapterIntegration(unittest.TestCase):
+    """adapter.py 集成验证"""
+
+    def _load_adapter_providers(self):
+        """从 adapter.py 提取 PROVIDERS（兼容新旧两种方式）"""
+        import ast
+        with open("adapter.py") as f:
+            content = f.read()
+        tree = ast.parse(content)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "PROVIDERS":
+                        try:
+                            return ast.literal_eval(node.value)
+                        except ValueError:
+                            pass  # 新版是 import，不是 literal
+        return None
+
+    def test_adapter_syntax_valid(self):
+        """adapter.py 语法正确"""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "-c", "import ast; ast.parse(open('adapter.py').read())"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, f"Syntax error: {result.stderr}")
+
+    def test_providers_syntax_valid(self):
+        """providers.py 语法正确"""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "-c", "import ast; ast.parse(open('providers.py').read())"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, f"Syntax error: {result.stderr}")
+
+    def test_providers_importable(self):
+        """providers.py 可以 import"""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "-c", "from providers import PROVIDERS, get_provider, get_registry"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, f"Import error: {result.stderr}")
+
+    def test_health_endpoint_has_capabilities(self):
+        """adapter.py 健康端点包含 capabilities 信息"""
+        with open("adapter.py") as f:
+            content = f.read()
+        self.assertIn("capabilities", content)
+        self.assertIn("verified", content)
+
+
+class TestCLIOutput(unittest.TestCase):
+    """CLI 输出测试"""
+
+    def test_matrix_output(self):
+        """python3 providers.py 输出 Markdown 表格"""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "providers.py"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Provider Compatibility Matrix", result.stdout)
+        self.assertIn("Qwen", result.stdout)
+        self.assertIn("Verification Status", result.stdout)
+
+    def test_json_output(self):
+        """python3 providers.py --json 输出合法 JSON"""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "providers.py", "--json"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        data = json.loads(result.stdout)
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Provider Compatibility Layer** (`providers.py`): BaseProvider 抽象基类 + 4 个实现 (Qwen/OpenAI/Gemini/Claude) + ProviderRegistry 动态注册 + ProviderCapabilities 能力声明 + CLI 兼容性矩阵输出
- **adapter.py 重构**: 从 providers.py 导入 PROVIDERS（含 ImportError 回退），/health 端点新增 capabilities 和 verified 字段
- **导师战略指导全面嵌入治理体系**: CLAUDE.md 新增「战略定位」宪法段 + 必查原则 #18-#20 + V1/V2/V3 路标待办重排 + 话语权输出计划
- **48 新单测** (`test_providers.py`)，全量回归 461 测试 100% 通过

### 导师核心指导（已写入工作宪法）

> Stage 1 完成（系统构建者）→ Stage 2（被社区认可的系统作者）
> 路线：bridge → runtime → control plane → 方法论与生态
> 下一步补**证据**而非功能（兼容矩阵/SLO benchmark/故障演练/可复现demo）

### 文件变更

| 文件 | 变更 |
|------|------|
| `providers.py` | 🆕 Provider Compatibility Layer |
| `test_providers.py` | 🆕 48 个单测 |
| `docs/compatibility_matrix.md` | 🆕 兼容性矩阵文档 |
| `docs/strategic_review_20260403.md` | 🆕 导师战略复盘完整记录 |
| `adapter.py` | 重构：从 providers.py 导入 + /health 增强 |
| `CLAUDE.md` | 战略定位 + 必查 #18-#20 + 待办按 V1/V2/V3 重排 |
| `status.json` | priorities 按路标重排 + methodology 升级 |
| `auto_deploy.sh` | FILE_MAP 加入 providers.py |
| `full_regression.sh` | 加入 test_providers.py |

## Test plan

- [x] `python3 test_providers.py` — 48 tests pass
- [x] `python3 test_adapter.py` — 43 tests pass (零回归)
- [x] `bash full_regression.sh` — 461 tests, 20/20 suites pass
- [x] 安全扫描 clean
- [ ] Mac Mini 部署后运行 `bash preflight_check.sh --full`
- [ ] 验证 `/health` 端点包含 capabilities 和 verified 字段

https://claude.ai/code/session_011X1Cz9VY6nnzt9c31Mem3R