### PR TITLE
fix: add date filter (14d) and link-only filter to ai_leaders_x

### DIFF
--- a/jobs/ai_leaders_x/run_ai_leaders_x.sh
+++ b/jobs/ai_leaders_x/run_ai_leaders_x.sh
@@ -84,9 +84,25 @@ for leader_entry in "${LEADERS[@]}"; do
     $PYTHON3 - "$RAW_HTML" "$SEEN_FILE" "$HANDLE" "$DISPLAY_NAME" "$LABEL" "$MAX_PER_PERSON" << 'PYEOF' >> "$ALL_TWEETS"
 import sys, json, re
 from html import unescape
+from datetime import datetime, timedelta, timezone
 
 html_file, seen_file, handle, display_name, label, max_per = sys.argv[1:7]
 max_per = int(max_per)
+
+# 只保留 14 天内的推文
+CUTOFF = datetime.now(timezone.utc) - timedelta(days=14)
+
+def parse_twitter_date(s):
+    """解析 Twitter 的日期格式：'Wed Oct 10 20:19:24 +0000 2018'"""
+    try:
+        return datetime.strptime(s, "%a %b %d %H:%M:%S %z %Y")
+    except (ValueError, TypeError):
+        return None
+
+def is_link_only(text):
+    """检测是否为纯链接推文（无实质内容）"""
+    clean = re.sub(r'https?://\S+', '', text).strip()
+    return len(clean) < 15
 
 with open(seen_file) as f:
     seen_ids = set(line.strip() for line in f if line.strip())
@@ -130,6 +146,13 @@ if next_data_match:
             if text and len(text) > 20 and tweet_id not in seen_ids:
                 # 跳过纯 RT
                 if text.startswith("RT @"):
+                    continue
+                # 跳过纯链接推文
+                if is_link_only(text):
+                    continue
+                # 跳过超过 14 天的旧推文
+                tweet_date = parse_twitter_date(created_at)
+                if tweet_date and tweet_date < CUTOFF:
                     continue
                 tweets.append({
                     "id": tweet_id,


### PR DESCRIPTION
Syndication API returns full timeline including very old tweets for inactive accounts (e.g. Chollet 2018 tweets). Added:
- 14-day cutoff: skip tweets older than 2 weeks
- Link-only filter: skip tweets that are just URLs with <15 chars text
- Twitter date parser for "Wed Oct 10 20:19:24 +0000 2018" format

https://claude.ai/code/session_01Nyc651fAh2wWuCYdrdZziA

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
