### PR TITLE
feat: sub-agent PoC — sessions_spawn/send schema injection + SOUL.md …

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -48,11 +48,22 @@
    python3 ~/status_update.py --update-priority "任务名" status done --by pa
    ```
 
-8. **委派复杂任务** — 遇到需要多步骤的复杂请求时，我可以使用 `sessions_spawn` 创建子 agent：
-   - 数据分析任务 → spawn research agent 处理
-   - 系统检查任务 → spawn ops agent 处理
-   - 使用 `sessions_send` 与子 agent 通信，`sessions_history` 查看结果
-   - 汇总子 agent 结果后回复用户
+8. **委派复杂任务** — 遇到以下关键词时，我**必须**使用 `sessions_spawn` 创建子 agent 处理：
+
+   **触发词 → 动作：**
+   - "检查系统"/"系统状态"/"健康检查"/"服务状态" → `sessions_spawn(agent="ops", message="执行全面健康检查：bash ~/ops_health.sh")`
+   - "查日志"/"排查问题"/"为什么出错" → `sessions_spawn(agent="ops", message="检查最近日志，排查问题：<用户描述>")`
+   - "分析这个数据"/"帮我研究" → `sessions_spawn(agent="research", message="<用户的具体请求>")`
+   
+   **使用流程：**
+   1. 调用 `sessions_spawn`，传 `agent` 名和 `message` 指令
+   2. 记住返回的 `sessionId`
+   3. 等待片刻后用 `sessions_history(sessionId=...)` 获取子 agent 的结果
+   4. 汇总结果回复用户（不要让用户自己去看子 agent 的输出）
+   
+   **可用子 agent：**
+   - `ops` — 系统运维（健康检查、日志、进程、cron 诊断）
+   - `research` — 研究分析（数据分析、深度调研）
 
 ## 我的性格
 

--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -123,7 +123,38 @@ CLEAN_SCHEMAS = {
         "properties": {"text": {"type": "string", "description": "Text to convert to speech"}},
         "required": ["text"],
         "additionalProperties": False
-    }
+    },
+    "sessions_spawn": {
+        "type": "object",
+        "properties": {
+            "agent": {"type": "string", "description": "Agent name to spawn (e.g. 'ops', 'research')"},
+            "message": {"type": "string", "description": "Initial message/instruction to send to the spawned agent"},
+        },
+        "required": ["agent", "message"],
+        "additionalProperties": False
+    },
+    "sessions_send": {
+        "type": "object",
+        "properties": {
+            "sessionId": {"type": "string", "description": "Session ID of the target sub-agent (returned by sessions_spawn)"},
+            "message": {"type": "string", "description": "Message to send to the sub-agent"},
+        },
+        "required": ["sessionId", "message"],
+        "additionalProperties": False
+    },
+    "sessions_history": {
+        "type": "object",
+        "properties": {
+            "sessionId": {"type": "string", "description": "Session ID to retrieve history for"},
+        },
+        "required": ["sessionId"],
+        "additionalProperties": False
+    },
+    "agents_list": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False
+    },
 }
 
 # 每个工具的合法参数集（用于响应清理）
@@ -139,6 +170,10 @@ TOOL_PARAMS = {
     "cron": {"action", "schedule", "command", "id", "name", "sessionTarget", "payload", "job"},
     "message": {"to", "text"},
     "tts": {"text"},
+    "sessions_spawn": {"agent", "message"},
+    "sessions_send": {"sessionId", "message"},
+    "sessions_history": {"sessionId"},
+    "agents_list": set(),
     "browser_navigate": {"url", "profile", "target"},
     "browser_click": {"selector", "profile", "target"},
     "browser_type": {"selector", "text", "profile", "target"},

--- a/test_tool_proxy.py
+++ b/test_tool_proxy.py
@@ -669,5 +669,85 @@ class TestClassifyComplexity(unittest.TestCase):
         self.assertEqual(classify_complexity([], has_tools=False), "simple")
 
 
+class TestSessionToolSchemas(unittest.TestCase):
+    """V35 PoC: sessions_spawn/send/history/agents_list schema injection tests."""
+
+    def test_sessions_spawn_schema_injected(self):
+        """sessions_spawn should get CLEAN_SCHEMA with agent + message params."""
+        tools = [{"function": {"name": "sessions_spawn", "parameters": {"bloated": True}}}]
+        filtered, _, kept = filter_tools(tools)
+        self.assertIn("sessions_spawn", kept)
+        schema = filtered[0]["function"]["parameters"]
+        self.assertIn("agent", schema["properties"])
+        self.assertIn("message", schema["properties"])
+        self.assertEqual(schema["required"], ["agent", "message"])
+        self.assertTrue(schema.get("additionalProperties") is False)
+
+    def test_sessions_send_schema_injected(self):
+        """sessions_send should get CLEAN_SCHEMA with sessionId + message params."""
+        tools = [{"function": {"name": "sessions_send", "parameters": {"bloated": True}}}]
+        filtered, _, kept = filter_tools(tools)
+        self.assertIn("sessions_send", kept)
+        schema = filtered[0]["function"]["parameters"]
+        self.assertIn("sessionId", schema["properties"])
+        self.assertIn("message", schema["properties"])
+        self.assertEqual(schema["required"], ["sessionId", "message"])
+
+    def test_sessions_history_schema_injected(self):
+        """sessions_history should get CLEAN_SCHEMA with sessionId param."""
+        tools = [{"function": {"name": "sessions_history", "parameters": {}}}]
+        filtered, _, kept = filter_tools(tools)
+        self.assertIn("sessions_history", kept)
+        schema = filtered[0]["function"]["parameters"]
+        self.assertIn("sessionId", schema["properties"])
+        self.assertEqual(schema["required"], ["sessionId"])
+
+    def test_agents_list_schema_injected(self):
+        """agents_list should get CLEAN_SCHEMA with no required params."""
+        tools = [{"function": {"name": "agents_list", "parameters": {"junk": True}}}]
+        filtered, _, kept = filter_tools(tools)
+        self.assertIn("agents_list", kept)
+        schema = filtered[0]["function"]["parameters"]
+        self.assertEqual(schema["properties"], {})
+        self.assertTrue(schema.get("additionalProperties") is False)
+
+    def test_sessions_tools_in_allowed(self):
+        """All session tools must be in ALLOWED_TOOLS."""
+        for name in ("sessions_spawn", "sessions_send", "sessions_history", "agents_list"):
+            self.assertIn(name, ALLOWED_TOOLS)
+
+    def test_sessions_tools_in_tool_params(self):
+        """All session tools must have TOOL_PARAMS entries."""
+        self.assertEqual(TOOL_PARAMS["sessions_spawn"], {"agent", "message"})
+        self.assertEqual(TOOL_PARAMS["sessions_send"], {"sessionId", "message"})
+        self.assertEqual(TOOL_PARAMS["sessions_history"], {"sessionId"})
+        self.assertEqual(TOOL_PARAMS["agents_list"], set())
+
+    def test_spawn_args_cleaned(self):
+        """fix_tool_args should strip extra params from sessions_spawn."""
+        resp = make_response("sessions_spawn", {
+            "agent": "ops",
+            "message": "check health",
+            "bogus_param": "should be removed"
+        })
+        fix_tool_args(resp)
+        args = get_args(resp)
+        self.assertIn("agent", args)
+        self.assertIn("message", args)
+        self.assertNotIn("bogus_param", args)
+
+    def test_send_args_cleaned(self):
+        """fix_tool_args should strip extra params from sessions_send."""
+        resp = make_response("sessions_send", {
+            "sessionId": "abc-123",
+            "message": "hello",
+            "extra": "gone"
+        })
+        fix_tool_args(resp)
+        args = get_args(resp)
+        self.assertIn("sessionId", args)
+        self.assertNotIn("extra", args)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
…trigger patterns

Add CLEAN_SCHEMAS and TOOL_PARAMS for sessions_spawn, sessions_send, sessions_history, and agents_list to prevent Qwen3 parameter hallucination. Update SOUL.md with explicit trigger keywords (检查系统/查日志/分析数据) so Qwen3 knows when to spawn ops/research sub-agents. 8 new unit tests (578 total, all pass).

https://claude.ai/code/session_01HNBYCJdgjywijUu8oVUsFg

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
