### PR TITLE
Fix Chinese provider specs with verified data from official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 | SLO Benchmark | — | `slo_benchmark.py` | SLO compliance — 5 metrics, real production data reports (p95=459ms, 5/5 PASS) |
 | Notifications | — | `notify.sh` | **Dual-channel push**: WhatsApp + Discord (6 topic channels: papers/freight/alerts/daily/tech/DM) |
 | Local Embedding | — | `local_embed.py` | sentence-transformers (384-dim, 50+ languages), zero API calls |
-| Remote LLM | — | 7 providers | Qwen3-235B / GPT-4o / Gemini 2.5 / Claude Sonnet / Kimi 2.5 / MiniMax M2.7 / GLM-5 |
+| Remote LLM | — | 7 providers | Qwen3-235B / GPT-4o / Gemini 2.5 / Claude Sonnet / Kimi K2.5 / MiniMax M2.7 / GLM-5 |
 
 ## Supported Providers (7)
 
@@ -126,9 +126,9 @@
 | **OpenAI** | GPT-4o | 128K | built-in | Bearer | available |
 | **Google Gemini** | Gemini 2.5 Flash | 1M | built-in | Bearer | 2/5 (fallback) |
 | **Anthropic Claude** | Claude Sonnet 4.6 | 200K | built-in | x-api-key | available |
-| **Kimi** (Moonshot AI) | Kimi 2.5 | 131K | built-in | Bearer | available |
-| **MiniMax** | MiniMax M2.7 | 1M | built-in | Bearer | available |
-| **GLM** (Zhipu AI) | GLM-5 | 128K | GLM-5V | Bearer | available |
+| **Kimi** (Moonshot AI) | Kimi K2.5 (1T MoE) | 256K | built-in | Bearer | available |
+| **MiniMax** | MiniMax M2.7 | 200K | built-in | Bearer | available |
+| **GLM** (Zhipu AI) | GLM-5 (744B MoE) | 200K | GLM-5V-Turbo | Bearer | available |
 
 All providers use **OpenAI-compatible API** format. Adding a new provider: see [docs/compatibility_matrix.md](docs/compatibility_matrix.md).
 

--- a/adapter.py
+++ b/adapter.py
@@ -53,13 +53,13 @@ except ImportError:
             "auth_style":  "x-api-key",
         },
         "kimi": {
-            "base_url":    "https://api.moonshot.cn/v1",
+            "base_url":    "https://api.moonshot.ai/v1",
             "api_key_env": "MOONSHOT_API_KEY",
-            "model_id":    "kimi-2.5",
+            "model_id":    "kimi-k2.5",
             "auth_style":  "bearer",
         },
         "minimax": {
-            "base_url":    "https://api.minimax.chat/v1",
+            "base_url":    "https://api.minimaxi.com/v1",
             "api_key_env": "MINIMAX_API_KEY",
             "model_id":    "MiniMax-M2.7",
             "auth_style":  "bearer",

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -11,9 +11,9 @@
 | | Qwen2.5-VL-72B | 图片理解，自动路由 | 检测 image_url 自动切换 |
 | | Gemini Flash (降级) | 主力不可用时自动切换 | FALLBACK_PROVIDER |
 | | OpenAI / Claude | 手动切换备选 | 环境变量 PROVIDER= |
-| | Kimi 2.5 (Moonshot) | 视觉+长上下文 131K | MOONSHOT_API_KEY |
-| | MiniMax M2.7 | 百万 token 上下文+视觉 | MINIMAX_API_KEY |
-| | GLM-5 (Zhipu) | 含 GLM-5V 视觉 | GLM_API_KEY |
+| | Kimi K2.5 (Moonshot) | 1T MoE 视觉+256K | MOONSHOT_API_KEY |
+| | MiniMax M2.7 | 视觉+200K+131K输出 | MINIMAX_API_KEY |
+| | GLM-5 (Zhipu) | 744B MoE + GLM-5V-Turbo | GLM_API_KEY |
 | **自定义工具** | search_kb | 混合检索：语义搜索(embedding) + 关键词补充 + source/时间过滤 → followup LLM 解读 | `proxy_filters.py` 注入 |
 | | data_clean | 数据清洗：7 种操作(dedup/trim/fix_dates 等)、5 种格式(CSV/JSON/Excel 等) | `data_clean.py` |
 | **本地 AI** | KB RAG 语义搜索 | sentence-transformers 384 维 50+ 语言，零 API 调用 | `local_embed.py` + `kb_embed.py` + `kb_rag.py` |

--- a/docs/articles/zhihu_provider_compatibility.md
+++ b/docs/articles/zhihu_provider_compatibility.md
@@ -91,9 +91,9 @@ capabilities = ProviderCapabilities(
 | **OpenAI** | GPT-4o | 128K | 多模态（文本+视觉+音频） |
 | **Google Gemini** | Gemini 2.5 Flash | 1M | 百万级上下文，已验证 Fallback |
 | **Anthropic Claude** | Claude Sonnet 4.6 | 200K | x-api-key 认证 |
-| **Kimi (Moonshot AI)** | Kimi 2.5 | 131K | 视觉理解 + 长上下文标杆 |
-| **MiniMax** | MiniMax M2.7 | 1M | 百万 token 上下文 + 视觉理解 |
-| **GLM (Zhipu AI)** | GLM-5 + GLM-5V | 128K | 视觉模型 + JSON mode |
+| **Kimi (Moonshot AI)** | Kimi K2.5 (1T MoE, 32B active) | 256K | 视觉理解 + 32K 输出 |
+| **MiniMax** | MiniMax M2.7 | 200K | 视觉理解 + 131K 超长输出 |
+| **GLM (Zhipu AI)** | GLM-5 (744B MoE) + GLM-5V-Turbo | 200K | 视觉模型 + 128K 输出 |
 
 **添加新 Provider 只需 3 步**：
 
@@ -139,7 +139,7 @@ export PROVIDER=my_provider && export MY_API_KEY=... && bash restart.sh
 # 你有什么 API key，就用什么模型。零配置。
 export OPENAI_API_KEY='sk-...'    # 有 OpenAI key？用 GPT-4o
 export GEMINI_API_KEY='...'       # 有 Gemini key？用 Gemini
-export MOONSHOT_API_KEY='...'     # 有 Kimi key？用 Kimi 2.5
+export MOONSHOT_API_KEY='...'     # 有 Kimi key？用 Kimi K2.5
 export GLM_API_KEY='...'          # 有 GLM key？用 GLM-4
 # 或者显式指定：
 export PROVIDER=minimax

--- a/docs/compatibility_matrix.md
+++ b/docs/compatibility_matrix.md
@@ -13,9 +13,9 @@
 | OpenAI | gpt-4o | — | Bearer | api.openai.com |
 | Google Gemini | gemini-2.5-flash | — | Bearer | generativelanguage.googleapis.com |
 | Anthropic Claude | claude-sonnet-4-6 | — | x-api-key | api.anthropic.com |
-| Kimi (Moonshot AI) | kimi-2.5 | — | Bearer | api.moonshot.cn |
-| MiniMax | MiniMax-M2.7 | — | Bearer | api.minimax.chat |
-| GLM (Zhipu AI) | glm-5 | glm-5v | Bearer | open.bigmodel.cn |
+| Kimi (Moonshot AI) | kimi-k2.5 | built-in | Bearer | api.moonshot.ai |
+| MiniMax | MiniMax-M2.7 | built-in | Bearer | api.minimaxi.com |
+| GLM (Zhipu AI) | glm-5 | glm-5v-turbo | Bearer | open.bigmodel.cn |
 
 ## 能力矩阵
 
@@ -25,9 +25,9 @@
 | OpenAI | Yes | Yes | Yes | — | Yes | Yes | Yes | 128K |
 | Google Gemini | Yes | Yes | — | — | Yes | Yes | Yes | 1048K |
 | Anthropic Claude | Yes | Yes | — | — | Yes | Yes | — | 200K |
-| Kimi (Moonshot AI) | Yes | Yes | — | — | Yes | Yes | Yes | 131K |
-| MiniMax | Yes | Yes | — | — | Yes | Yes | Yes | 1000K |
-| GLM (Zhipu AI) | Yes | Yes | — | — | Yes | Yes | Yes | 128K |
+| Kimi (Moonshot AI) | Yes | Yes | — | — | Yes | Yes | Yes | 256K |
+| MiniMax | Yes | Yes | — | — | Yes | Yes | Yes | 200K |
+| GLM (Zhipu AI) | Yes | Yes | — | — | Yes | Yes | Yes | 200K |
 
 ## 验证状态
 

--- a/providers.py
+++ b/providers.py
@@ -316,27 +316,20 @@ class ClaudeProvider(BaseProvider):
 # Chinese Providers — 国内主流大模型
 # ---------------------------------------------------------------------------
 class KimiProvider(BaseProvider):
-    """Moonshot AI (Kimi) — https://platform.moonshot.cn"""
+    """Moonshot AI (Kimi) — https://platform.moonshot.ai"""
     name = "kimi"
     display_name = "Kimi (Moonshot AI)"
-    base_url = "https://api.moonshot.cn/v1"
+    base_url = "https://api.moonshot.ai/v1"
     api_key_env = "MOONSHOT_API_KEY"
     auth_style = "bearer"
     models = [
         ModelInfo(
-            model_id="kimi-2.5",
-            display_name="Kimi 2.5",
+            model_id="kimi-k2.5",
+            display_name="Kimi K2.5 (1T MoE, 32B active)",
             modalities=["text", "vision"],
-            context_window=131072,
-            max_output_tokens=8192,
+            context_window=262144,
+            max_output_tokens=32768,
             is_default=True,
-        ),
-        ModelInfo(
-            model_id="moonshot-v1-128k",
-            display_name="Moonshot v1 128K",
-            modalities=["text"],
-            context_window=131072,
-            max_output_tokens=8192,
         ),
     ]
     capabilities = ProviderCapabilities(
@@ -347,8 +340,8 @@ class KimiProvider(BaseProvider):
         tool_calling=True,
         streaming=True,
         json_mode=True,
-        context_window=131072,
-        max_output_tokens=8192,
+        context_window=262144,
+        max_output_tokens=32768,
         verified_text=False,
         verified_vision=False,
         verified_tool_calling=False,
@@ -358,10 +351,10 @@ class KimiProvider(BaseProvider):
 
 
 class MiniMaxProvider(BaseProvider):
-    """MiniMax — https://platform.minimaxi.com"""
+    """MiniMax — https://www.minimax.io"""
     name = "minimax"
     display_name = "MiniMax"
-    base_url = "https://api.minimax.chat/v1"
+    base_url = "https://api.minimaxi.com/v1"
     api_key_env = "MINIMAX_API_KEY"
     auth_style = "bearer"
     models = [
@@ -369,8 +362,8 @@ class MiniMaxProvider(BaseProvider):
             model_id="MiniMax-M2.7",
             display_name="MiniMax M2.7",
             modalities=["text", "vision"],
-            context_window=1000000,
-            max_output_tokens=8192,
+            context_window=204800,
+            max_output_tokens=131072,
             is_default=True,
         ),
     ]
@@ -382,8 +375,8 @@ class MiniMaxProvider(BaseProvider):
         tool_calling=True,
         streaming=True,
         json_mode=True,
-        context_window=1000000,
-        max_output_tokens=8192,
+        context_window=204800,
+        max_output_tokens=131072,
         verified_text=False,
         verified_vision=False,
         verified_tool_calling=False,
@@ -402,18 +395,18 @@ class GLMProvider(BaseProvider):
     models = [
         ModelInfo(
             model_id="glm-5",
-            display_name="GLM-5",
+            display_name="GLM-5 (744B MoE, ~40B active)",
             modalities=["text"],
-            context_window=128000,
-            max_output_tokens=16384,
+            context_window=202752,
+            max_output_tokens=128000,
             is_default=True,
         ),
         ModelInfo(
-            model_id="glm-5v",
-            display_name="GLM-5V (Vision)",
+            model_id="glm-5v-turbo",
+            display_name="GLM-5V-Turbo (Vision)",
             modalities=["text", "vision"],
-            context_window=128000,
-            max_output_tokens=16384,
+            context_window=202752,
+            max_output_tokens=128000,
             is_vision=True,
         ),
     ]
@@ -425,8 +418,8 @@ class GLMProvider(BaseProvider):
         tool_calling=True,
         streaming=True,
         json_mode=True,
-        context_window=128000,
-        max_output_tokens=16384,
+        context_window=202752,
+        max_output_tokens=128000,
         verified_text=False,
         verified_vision=False,
         verified_tool_calling=False,

--- a/test_providers.py
+++ b/test_providers.py
@@ -422,30 +422,31 @@ class TestChineseProviders(unittest.TestCase):
         p = KimiProvider()
         self.assertEqual(p.name, "kimi")
         self.assertEqual(p.auth_style, "bearer")
-        self.assertIn("moonshot.cn", p.base_url)
+        self.assertIn("moonshot.ai", p.base_url)
         self.assertEqual(p.api_key_env, "MOONSHOT_API_KEY")
-        self.assertEqual(len(p.models), 2)
+        self.assertEqual(len(p.models), 1)
         self.assertTrue(p.capabilities.tool_calling)
         self.assertTrue(p.capabilities.vision)
+        self.assertEqual(p.capabilities.context_window, 262144)
 
     def test_kimi_default_model(self):
         from providers import KimiProvider
         p = KimiProvider()
         dm = p.default_model()
         self.assertIsNotNone(dm)
-        self.assertEqual(dm.model_id, "kimi-2.5")
+        self.assertEqual(dm.model_id, "kimi-k2.5")
 
     def test_minimax_provider(self):
         from providers import MiniMaxProvider
         p = MiniMaxProvider()
         self.assertEqual(p.name, "minimax")
         self.assertEqual(p.auth_style, "bearer")
-        self.assertIn("minimax.chat", p.base_url)
+        self.assertIn("minimaxi.com", p.base_url)
         self.assertEqual(p.api_key_env, "MINIMAX_API_KEY")
         self.assertEqual(len(p.models), 1)
         self.assertTrue(p.capabilities.tool_calling)
         self.assertTrue(p.capabilities.vision)
-        self.assertEqual(p.capabilities.context_window, 1000000)
+        self.assertEqual(p.capabilities.context_window, 204800)
 
     def test_minimax_default_model(self):
         from providers import MiniMaxProvider
@@ -470,7 +471,7 @@ class TestChineseProviders(unittest.TestCase):
         p = GLMProvider()
         vm = p.vision_model()
         self.assertIsNotNone(vm)
-        self.assertIn("5v", vm.model_id)
+        self.assertEqual(vm.model_id, "glm-5v-turbo")
 
     def test_glm_default_model(self):
         from providers import GLMProvider
@@ -484,7 +485,7 @@ class TestChineseProviders(unittest.TestCase):
         p = GLMProvider()
         d = p.to_legacy_dict()
         self.assertIn("vl_model_id", d)
-        self.assertIn("5v", d["vl_model_id"])
+        self.assertEqual(d["vl_model_id"], "glm-5v-turbo")
 
     def test_chinese_providers_in_legacy_dict(self):
         from providers import PROVIDERS


### PR DESCRIPTION
Research-backed corrections:
- Kimi: model_id kimi-k2.5 (not kimi-2.5), 1T MoE/32B active, 256K context, 32K output, base_url api.moonshot.ai (not .cn), vision built-in
- MiniMax: 200K context (not 1M), 131K output, base_url api.minimaxi.com (not minimax.chat)
- GLM: vision model glm-5v-turbo (not glm-5v), 744B MoE/~40B active, 200K context, 128K output, JSON mode supported

Sources: platform.moonshot.ai, minimax.io, open.bigmodel.cn official docs

https://claude.ai/code/session_01HNBYCJdgjywijUu8oVUsFg

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
