### PR TITLE
Add auto-retry + failure queue to notify.sh, improve watchdog resilience

### DIFF
--- a/job_watchdog.sh
+++ b/job_watchdog.sh
@@ -198,11 +198,15 @@ scan_logs() {
     local job_name="$2"
     [ -f "$logfile" ] || return
 
-    # 检查日志文件最后修改时间（超过预期间隔的3倍 → 日志可能已停更）
+    # 跳过超过 24h 未修改的日志文件（避免告警已自愈的陈旧错误）
     if [ "$(uname)" = "Darwin" ]; then
         LOG_MOD=$(stat -f %m "$logfile" 2>/dev/null || echo "0")
     else
         LOG_MOD=$(stat -c %Y "$logfile" 2>/dev/null || echo "0")
+    fi
+    local LOG_AGE=$(( NOW_EPOCH - LOG_MOD ))
+    if [ "$LOG_AGE" -gt 86400 ]; then
+        return  # 日志超过24h未更新，跳过扫描
     fi
 
     # 扫描最后50行中的错误（比原来的20行覆盖更多）
@@ -585,15 +589,27 @@ if [ "$CRITICAL_COUNT" -gt 0 ] || [ "${#CORE_ALERTS[@]}" -gt 0 ]; then
     }
 fi
 
-# 推送 WhatsApp（失败时写本地告警文件，打破 WhatsApp↔Gateway 循环依赖）
+# 推送告警（使用 notify.sh 自动重试 + 失败队列）
 ALERT_LOG="$HOME/.openclaw_alerts.log"
-"$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ALERT_MSG" --json >/dev/null 2>&1 || {
-    echo "[$TS] watchdog: ⚠️ WhatsApp 推送失败，写入本地告警文件"
-    echo "=== UNDELIVERED ALERT [$TS] ===" >> "$ALERT_LOG"
-    echo "$ALERT_MSG" >> "$ALERT_LOG"
-    echo "================================" >> "$ALERT_LOG"
-}
-"$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ALERT_MSG" --json >/dev/null 2>&1 || true
+NOTIFY_SCRIPT="$(cd "$(dirname "$0")" && pwd)/notify.sh"
+if [ -f "$NOTIFY_SCRIPT" ]; then
+    source "$NOTIFY_SCRIPT"
+    notify "$ALERT_MSG" --topic alerts || {
+        echo "[$TS] watchdog: ⚠️ 推送失败（已入队待重放），写入本地告警文件"
+        echo "=== UNDELIVERED ALERT [$TS] ===" >> "$ALERT_LOG"
+        echo "$ALERT_MSG" >> "$ALERT_LOG"
+        echo "================================" >> "$ALERT_LOG"
+    }
+else
+    # fallback: 直接发送（notify.sh 不可用时）
+    "$OPENCLAW" message send --channel whatsapp --target "$TO" --message "$ALERT_MSG" --json >/dev/null 2>&1 || {
+        echo "[$TS] watchdog: ⚠️ WhatsApp 推送失败，写入本地告警文件"
+        echo "=== UNDELIVERED ALERT [$TS] ===" >> "$ALERT_LOG"
+        echo "$ALERT_MSG" >> "$ALERT_LOG"
+        echo "================================" >> "$ALERT_LOG"
+    }
+    "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ALERTS:-}" --message "$ALERT_MSG" --json >/dev/null 2>&1 || true
+fi
 
 # 本地告警文件始终写入（供 cron_doctor / SSH 检查时查看）
 echo "[$TS] ALERT: ${#ALERTS[@]} issues (${CRITICAL_COUNT} critical, ${WARNING_COUNT} warning)" >> "$ALERT_LOG"

--- a/notify.sh
+++ b/notify.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-# notify.sh — 统一消息推送（多通道 + 分频道支持）
+# notify.sh — 统一消息推送（多通道 + 分频道 + 自动重试 + 失败队列）
 # 用法：source ~/openclaw-model-bridge/notify.sh
 #       notify "消息内容"                             # WhatsApp + Discord DM
 #       notify "消息内容" --topic papers               # WhatsApp + Discord #论文
 #       notify "消息内容" --topic alerts               # WhatsApp + Discord #告警
 #       notify "消息内容" --channel discord --topic papers  # 只发 Discord #论文
 #       notify "消息内容" --channel whatsapp            # 只发 WhatsApp
+#       notify_queue_status                            # 查看失败队列
+#       notify_queue_flush                             # 手动重放队列
+#
+# 自动重试机制：
+#   - 每次发送失败自动重试 3 次（指数退避：2s/4s/8s）
+#   - 3 次全部失败 → 消息写入 ~/.kb/notify_queue/ 队列
+#   - 下次 notify() 调用时自动尝试重放队列
+#   - notify_queue_flush 可手动触发重放
 #
 # Topic 频道映射（Discord Server 频道）：
 #   papers  → #论文（arxiv/hf/s2/dblp/acl）
@@ -24,6 +32,8 @@
 #   DISCORD_CH_DAILY    — Discord #日报 频道ID
 #   DISCORD_CH_TECH     — Discord #技术 频道ID
 #   NOTIFY_CHANNELS     — 启用的通道，逗号分隔（默认 "whatsapp,discord"）
+#   NOTIFY_MAX_RETRIES  — 最大重试次数（默认 3）
+#   NOTIFY_QUEUE_DIR    — 失败队列目录（默认 ~/.kb/notify_queue）
 #   OPENCLAW            — openclaw 二进制路径
 
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
@@ -32,6 +42,8 @@ OPENCLAW="${OPENCLAW:-/opt/homebrew/bin/openclaw}"
 _NOTIFY_WA_TARGET="${OPENCLAW_PHONE:-+85200000000}"
 _NOTIFY_DISCORD_TARGET="${DISCORD_TARGET:-}"
 _NOTIFY_CHANNELS="${NOTIFY_CHANNELS:-whatsapp,discord}"
+_NOTIFY_MAX_RETRIES="${NOTIFY_MAX_RETRIES:-3}"
+_NOTIFY_QUEUE_DIR="${NOTIFY_QUEUE_DIR:-$HOME/.kb/notify_queue}"
 
 # topic → Discord channel ID 映射
 _notify_discord_target_for_topic() {
@@ -43,6 +55,70 @@ _notify_discord_target_for_topic() {
         tech)    echo "${DISCORD_CH_TECH:-}" ;;
         *)       echo "" ;;
     esac
+}
+
+# _notify_send_with_retry — 带指数退避重试的发送
+# 用法：_notify_send_with_retry <channel> <target> <message>
+# 返回：0=成功，1=全部重试失败
+_notify_send_with_retry() {
+    local channel="$1" target="$2" msg="$3"
+    local attempt=0 delay=2
+
+    while [ "$attempt" -lt "$_NOTIFY_MAX_RETRIES" ]; do
+        if "$OPENCLAW" message send --channel "$channel" --target "$target" --message "$msg" --json >/dev/null 2>&1; then
+            [ "$attempt" -gt 0 ] && echo "[notify] OK: $channel 第$((attempt+1))次重试成功" >&2
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        if [ "$attempt" -lt "$_NOTIFY_MAX_RETRIES" ]; then
+            echo "[notify] WARN: $channel 发送失败，${delay}s 后第$((attempt+1))次重试..." >&2
+            sleep "$delay"
+            delay=$((delay * 2))
+        fi
+    done
+    return 1
+}
+
+# _notify_queue_failed — 将失败消息写入队列
+# 用法：_notify_queue_failed <channel> <target> <topic> <message>
+_notify_queue_failed() {
+    local channel="$1" target="$2" topic="$3" msg="$4"
+    mkdir -p "$_NOTIFY_QUEUE_DIR"
+    local ts
+    ts=$(date +%Y%m%d_%H%M%S)
+    local qfile="$_NOTIFY_QUEUE_DIR/${ts}_${channel}_$$.json"
+    cat > "$qfile" <<QEOF
+{"ts":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","channel":"$channel","target":"$target","topic":"$topic","msg":$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" <<< "$msg")}
+QEOF
+    echo "[notify] QUEUED: $channel 消息已入队 → $qfile" >&2
+}
+
+# _notify_drain_queue — 重放队列中的失败消息
+# 在每次 notify() 开头调用，成功发送则删除队列文件
+_notify_drain_queue() {
+    [ -d "$_NOTIFY_QUEUE_DIR" ] || return 0
+    local qfiles
+    qfiles=$(find "$_NOTIFY_QUEUE_DIR" -name "*.json" -type f 2>/dev/null | sort)
+    [ -z "$qfiles" ] && return 0
+
+    local count
+    count=$(echo "$qfiles" | wc -l | tr -d ' ')
+    echo "[notify] 发现 $count 条排队消息，尝试重放..." >&2
+
+    local f channel target msg
+    for f in $qfiles; do
+        channel=$(python3 -c "import json,sys; print(json.load(sys.stdin)['channel'])" < "$f" 2>/dev/null) || continue
+        target=$(python3 -c "import json,sys; print(json.load(sys.stdin)['target'])" < "$f" 2>/dev/null) || continue
+        msg=$(python3 -c "import json,sys; print(json.load(sys.stdin)['msg'])" < "$f" 2>/dev/null) || continue
+
+        if "$OPENCLAW" message send --channel "$channel" --target "$target" --message "$msg" --json >/dev/null 2>&1; then
+            echo "[notify] REPLAY OK: $(basename "$f")" >&2
+            rm -f "$f"
+        else
+            echo "[notify] REPLAY FAIL: $(basename "$f")，保留队列" >&2
+            break  # 如果还是失败，停止重放（避免雪崩）
+        fi
+    done
 }
 
 # notify "message" [--channel whatsapp|discord] [--topic papers|freight|alerts|daily|tech]
@@ -63,15 +139,19 @@ notify() {
 
     [ -z "$msg" ] && return 1
 
+    # 先尝试重放队列中的失败消息
+    _notify_drain_queue
+
     local rc=0
     local sent=0
 
     # WhatsApp（所有 topic 都发到同一个号码）
     if echo "$channels" | grep -q "whatsapp" && [ -n "$_NOTIFY_WA_TARGET" ]; then
-        if "$OPENCLAW" message send --channel whatsapp --target "$_NOTIFY_WA_TARGET" --message "$msg" --json >/dev/null 2>&1; then
+        if _notify_send_with_retry whatsapp "$_NOTIFY_WA_TARGET" "$msg"; then
             sent=$((sent + 1))
         else
-            echo "[notify] WARN: WhatsApp 发送失败" >&2
+            echo "[notify] FAIL: WhatsApp 3次重试均失败，入队" >&2
+            _notify_queue_failed whatsapp "$_NOTIFY_WA_TARGET" "$topic" "$msg"
             rc=1
         fi
     fi
@@ -88,10 +168,11 @@ notify() {
         [ -z "$discord_target" ] && discord_target="user:$_NOTIFY_DISCORD_TARGET"
 
         if [ -n "$discord_target" ] && [ "$discord_target" != "user:" ]; then
-            if "$OPENCLAW" message send --channel discord --target "$discord_target" --message "$msg" --json >/dev/null 2>&1; then
+            if _notify_send_with_retry discord "$discord_target" "$msg"; then
                 sent=$((sent + 1))
             else
-                echo "[notify] WARN: Discord 发送失败 (target=$discord_target)" >&2
+                echo "[notify] FAIL: Discord 3次重试均失败，入队" >&2
+                _notify_queue_failed discord "$discord_target" "$topic" "$msg"
                 rc=1
             fi
         fi
@@ -107,4 +188,26 @@ notify_file() {
     shift
     [ -f "$file" ] || return 1
     notify "$(cat "$file")" "$@"
+}
+
+# notify_queue_status — 显示队列状态
+notify_queue_status() {
+    if [ ! -d "$_NOTIFY_QUEUE_DIR" ]; then
+        echo "队列为空（目录不存在）"
+        return 0
+    fi
+    local count
+    count=$(find "$_NOTIFY_QUEUE_DIR" -name "*.json" -type f 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$count" -eq 0 ]; then
+        echo "队列为空"
+    else
+        echo "队列中有 $count 条待发送消息："
+        find "$_NOTIFY_QUEUE_DIR" -name "*.json" -type f -exec basename {} \; | sort
+    fi
+}
+
+# notify_queue_flush — 强制重放全部队列
+notify_queue_flush() {
+    _notify_drain_queue
+    notify_queue_status
 }


### PR DESCRIPTION
- notify.sh: 3 retries with exponential backoff (2s/4s/8s) before giving up
- Failed messages queued to ~/.kb/notify_queue/ as JSON for later replay
- Queue auto-drained on next successful notify() call
- New helpers: notify_queue_status, notify_queue_flush
- job_watchdog.sh: use notify.sh for alert push (gets retry+queue)
- job_watchdog.sh: skip log scanning for files >24h old (reduce stale noise)

https://claude.ai/code/session_01HNBYCJdgjywijUu8oVUsFg

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
