### PR TITLE
feat: kb_dream.sh v2 — MapReduce full-KB exploration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,7 +414,7 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 | 11 | **🆕 结果验证优先于功能建设** | 先定义"从用户视角，成功长什么样"，再写代码。status.json 的成功标准不是"能写入"，而是"PA 能正确回答项目进展"。（2026-03-28教训：393个单测通过但 PA 说"没有项目"） |
 | 12 | **🆕 上下文工程是一等公民** | SOUL.md = 宪法级（身份+关键状态，LLM 注意力最高），CLAUDE.md = 手册级（工具+详情）；信息放哪里、占多少 token、LLM 能否注意到——都是架构决策，和 API 设计同等严肃。（2026-03-28教训：SOUL.md 空置数月，17KB CLAUDE.md 信息被"lost in the middle"） |
 | 13 | **🆕 定期像用户一样使用系统** | 不是跑单测，而是在 WhatsApp 上实际问 PA 问题。每次涉及 PA 行为的变更后，必须清空 session（`echo '{"sessions":[]}' > sessions.json`）+ 重启 Gateway + WhatsApp 实测。单测验证组件内部，系统价值在组件之间的接缝处。 |
-| 14 | **🆕 PR 合并后立即同步 Mac Mini** | GitHub PR 合并到 main 后，**必须立即提醒用户在 Mac Mini 上同步**：`cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard origin/main`。不要等 auto_deploy 轮询（最长 2 分钟延迟）——合并后紧急同步是标准操作，确保运行时代码与仓库一致。同步后立即跑 `bash preflight_check.sh --full`。（2026-04-01教训：合并后 preflight 8 项失败全是部署漂移） |
+| 14 | **🔴 合并 PR 后下一步首先同步 Mac Mini** | **这是卡点，不是提醒。** GitHub PR 合并到 main 后，**下一步必须是 Mac Mini 同步，不做任何其他操作**。同步命令：`cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard origin/main`。同步后立即验证：`bash preflight_check.sh --full`。**不要在 Mac Mini 上测试未同步的代码**——多次返工都是因为合并后没同步就直接跑旧代码。不要等 auto_deploy 轮询。（2026-04-01教训：合并后 preflight 8 项失败全是部署漂移；2026-04-06教训：合并后直接测试跑的是旧代码，浪费时间排查不存在的 bug） |
 | 15 | **🆕 测试必须全量：单测 + full_regression + WhatsApp 业务验证** | 每次变更后测试三层缺一不可：① `bash full_regression.sh`（394 单测 + 注册表 + 安全扫描 + 代码质量）② `bash preflight_check.sh --full` + `bash job_smoke_test.sh`（Mac Mini 部署验证）③ **WhatsApp 端实际业务测试**（用户视角发消息验证 PA 回复、search_kb 检索、图片理解等核心功能）。只跑单测不算测完——单测验证组件，WhatsApp 验证系统。（2026-04-01教训：394 单测全过但 preflight 8 项失败） |
 | 16 | **🆕 所有推送必须双通道（WhatsApp + Discord）** | 新增或修改任何消息推送时，**必须同时覆盖 WhatsApp 和 Discord 两个通道**，不允许遗留单通道发送。优先使用 `notify.sh`（`source notify.sh && notify "msg" --topic papers`）统一推送；若直接调用 `openclaw message send`，每个 WhatsApp 发送后必须紧跟对应的 Discord 发送（成功路径→对应 topic 频道，错误/告警→`DISCORD_CH_ALERTS`）。审计方法：`grep -c "message send.*whatsapp"` 与 `grep -c "message send.*discord"` 计数必须一致。（2026-04-03教训：货代客户画像推送遗漏 Discord，11 个脚本错误路径缺 Discord） |
 | 17 | **🆕 收工必须交叉校验待办状态** | 收工时不仅更新 `status.json`，还必须**扫描 CLAUDE.md 待办列表**，对照本次 session 的 commits 和 recent_changes，将已实现的任务标记 ✅。实现代码 + 更新待办 = 一个完整的交付，缺一不可。同时检查：① CLAUDE.md 待办 vs 实际代码一致 ② status.json priorities vs CLAUDE.md 待办一致 ③ 版本号/文件表/常用命令是否需要同步更新。（2026-04-03教训：V32 实现了 7 个 P0+P1 任务但 CLAUDE.md 全部未标记，直到 V33 审计才发现） |
@@ -435,7 +435,7 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 - **macOS sed禁用OR语法** — `\|` 在 BSD sed 不支持，用 Python 替代
 - **禁用交互式编辑器** — git merge 用 `--no-edit`，commit 用 `-m`
 - **crontab 安全操作** — **严禁 `echo ... | crontab -`**（2026-03-25事故：清空全部 cron），必须用 `bash crontab_safe.sh add '<行>'`
-- **分支合并由用户在GitHub操作** — 推送到 `claude/xxx` 分支 → 提醒用户创建 PR → **合并后立即同步 Mac Mini**（见必查 #14）
+- **分支合并由用户在GitHub操作** — 推送到 `claude/xxx` 分支 → 用户合并 PR → **⚠️ 合并后下一步首先同步 Mac Mini，不做任何其他操作**（`git fetch origin main && git reset --hard origin/main`）→ 同步后再测试（见必查 #14，2026-04-06 再次踩坑）
 - **Mac Mini 同步用 reset 不用 pull** — `git fetch origin main && git reset --hard origin/main`（Mac Mini 是纯消费端，无本地 commit；`git pull` 会因历史 merge commit 导致分叉失败）
 - **全量测试三层标准** — 单测通过 ≠ 测完，必须 full_regression + preflight + **WhatsApp 业务验证**（见必查 #15）
 


### PR DESCRIPTION
## Summary

- **kb_dream.sh v2 重写为 MapReduce 两阶段全量 KB 探索**
  - Phase 1 (Map): 每个 source 文件独立发送 LLM 提取 5-8 个关键信号（15K chars/file，100% 覆盖）
  - Phase 2 (Reduce): 所有信号 + notes + 状态汇总到 80K context 做跨域发现
  - `--fast` 回退到单次 80K 采样（旧模式加强版）
  - Map 缓存（同一天同文件不重复调用，3 天自动清理）

- **Prompt 反幻觉优化**
  - Map: 只提取本数据源事实，不做跨域联想
  - Reduce: 明确允许"没发现跨域关联"，拒绝硬凑不相关领域
  - "质量 > 数量：一个有扎实证据链的发现，胜过三个牵强附会的关联"

- **5 项 bugfix**（首次提交）
  - Bug: status.json 字段 `title` → `task`
  - UTF-8 安全截断（修复 `Agent�` 乱码）
  - 推送改用 notify.sh 双通道
  - 随机采样偏移 + 加权最近数据
  - 去重：3 次梦境主题提取

- **CLAUDE.md 规则 #14 升级为硬卡点**
  - 从"提醒同步"升级为"合并后下一步首先同步，不做任何其他操作"
  - 2026-04-06 教训：合并后直接测试跑的是旧代码

## Test plan

- [x] `bash -n kb_dream.sh` 语法通过
- [x] `bash full_regression.sh` 610 测试全过
- [ ] Mac Mini 同步后 `bash kb_dream.sh --dry-run` 验证素材统计
- [ ] Mac Mini 同步后 `bash kb_dream.sh` 完整 MapReduce 运行
- [ ] 对比新旧梦境输出质量（是否减少硬关联、增加真实信号）

https://claude.ai/code/session_01DVZUZRMYu4LRCGqrgeHEJC