### PR TITLE
fix: Reduce output truncated — SSE response handling + stale Map cache

### DIFF
--- a/kb_dream.sh
+++ b/kb_dream.sh
@@ -69,11 +69,18 @@ llm_call() {
         raw=$(curl -sS --max-time "$timeout" "$PROXY_URL" \
             -H 'Content-Type: application/json' \
             -d "$(jq -nc --arg p "$prompt" --argjson mt "$max_tokens" --argjson t "$temp" \
-                '{model:"any",messages:[{role:"user",content:$p}],max_tokens:$mt,temperature:$t}')" \
+                '{model:"any",messages:[{role:"user",content:$p}],max_tokens:$mt,temperature:$t,stream:false}')" \
             2>"$err_file" || true)
 
-        # 尝试提取内容
+        # 尝试从标准 JSON 提取
         result=$(echo "$raw" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)
+
+        # 如果标准 JSON 失败，尝试解析 SSE 格式（data: {...}\n\n）
+        if [ -z "${result// }" ] && echo "$raw" | grep -q '^data: ' 2>/dev/null; then
+            log "  检测到 SSE 响应，解析中..."
+            result=$(echo "$raw" | grep '^data: ' | grep -v '\[DONE\]' | sed 's/^data: //' \
+                | jq -rs '[.[].choices[0].delta.content // empty] | join("")' 2>/dev/null || true)
+        fi
 
         if [ -n "${result// }" ]; then
             rm -f "$err_file"
@@ -230,7 +237,9 @@ if [ "$FAST_MODE" = false ] && [ "$SRC_COUNT" -gt 0 ]; then
 
         # 检查 map 缓存（同一天同一文件大小不重复提取）
         file_size=$(wc -c < "$src" 2>/dev/null | tr -d ' ')
-        cache_key="${name}_${file_size}"
+        # 缓存 key 含 prompt 版本哈希，prompt 变化时自动重新提取
+        prompt_hash=$(echo "$MAP_PROMPT_TPL" | md5sum 2>/dev/null | cut -c1-8 || echo "v2")
+        cache_key="${name}_${file_size}_${prompt_hash}"
         cache_file="$MAP_DIR/${DAY}_${cache_key}.txt"
 
         if [ -f "$cache_file" ]; then
@@ -544,4 +553,4 @@ find "$MAP_DIR" -name "*.txt" -mtime +3 -delete 2>/dev/null || true
 # rsync 备份
 rsync -a --quiet "$KB_BASE/dreams/" "/Volumes/MOVESPEED/KB/dreams/" 2>/dev/null || true
 
-log "完成。今夜的梦境已记录（$MODE_DESC）。"
+log "完成。模式=$MODE_DESC"


### PR DESCRIPTION
Two issues found in production test (Mac Mini, 14 sources):

1. Reduce output truncated to ~500 chars (should be 1500-2500 words) Root cause: Proxy returns SSE format (data: {...}\n) but curl+jq only parsed standard JSON, getting just the first chunk. Fix: add stream:false to request body + SSE fallback parser that concatenates all delta.content chunks.

2. Map used stale cache (old 5-8 signal prompt, not new 10-15) Root cause: cache key was name_filesize, didn't include prompt version. Fix: cache key now includes md5 hash of MAP_PROMPT_TPL, so prompt changes automatically invalidate cache.

Also: fixed MODE_DESC UTF-8 truncation in log output.

https://claude.ai/code/session_01DVZUZRMYu4LRCGqrgeHEJC

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
