### PR TITLE
fix: auto-retry when LLM returns truncated dream (<4000 chars)

### DIFF
--- a/kb_dream.sh
+++ b/kb_dream.sh
@@ -503,14 +503,38 @@ $REDUCE_MATERIAL
     log "回退后 prompt: ${PROMPT_BYTES} bytes"
 fi
 
-DREAM_RESULT=$(llm_call "$REDUCE_PROMPT" 8000 0.85 300 || true)
+# Reduce 调用 + 短响应自动重试
+# LLM 响应不稳定：同样的 prompt 有时产出 17KB，有时只有 2KB
+# 如果响应 < 4000 字符（约 1000 字），大概率是被截断，值得重试
+MIN_DREAM_CHARS=4000
+MAX_RETRIES=2
+DREAM_RESULT=""
+
+for retry in $(seq 1 $MAX_RETRIES); do
+    DREAM_RESULT=$(llm_call "$REDUCE_PROMPT" 8000 0.85 300 || true)
+    DREAM_CHARS=$(echo "$DREAM_RESULT" | wc -c | tr -d ' ')
+
+    if [ -z "${DREAM_RESULT// }" ]; then
+        log "Reduce 尝试 $retry/$MAX_RETRIES: 空响应"
+    elif [ "$DREAM_CHARS" -lt "$MIN_DREAM_CHARS" ]; then
+        log "Reduce 尝试 $retry/$MAX_RETRIES: 响应过短 (${DREAM_CHARS} chars < ${MIN_DREAM_CHARS})，重试..."
+    else
+        log "Reduce 尝试 $retry/$MAX_RETRIES: 成功 (${DREAM_CHARS} chars)"
+        break
+    fi
+
+    [ "$retry" -lt "$MAX_RETRIES" ] && sleep 5
+done
 
 if [ -z "${DREAM_RESULT// }" ]; then
-    log "ERROR: Phase 2 LLM 返回空结果 (prompt was ${PROMPT_BYTES} bytes)"
+    log "ERROR: Phase 2 所有重试均失败 (prompt was ${PROMPT_BYTES} bytes)"
     printf '{"time":"%s","status":"llm_failed","phase":"reduce","map_count":%d,"reduce_chars":%d,"prompt_bytes":%d}\n' \
         "$TS" "$MAP_COUNT" "$REDUCE_CHARS" "$PROMPT_BYTES" > "$STATUS_FILE"
     exit 1
 fi
+
+DREAM_CHARS=$(echo "$DREAM_RESULT" | wc -c | tr -d ' ')
+log "最终梦境: ${DREAM_CHARS} chars"
 
 # ═══════════════════════════════════════════════════════════════════
 # 6. 输出"梦境"


### PR DESCRIPTION
LLM output is inconsistent: same 113KB prompt produces 17KB one run and 2KB the next. Add retry logic:
- If response < 4000 chars, log and retry (up to 2 attempts)
- 5s delay between retries
- Log attempt number and response size for diagnostics

Also fixed chunked push (previous commit): bash can't hold NULL bytes in variables, switched to temp file approach.

https://claude.ai/code/session_01DVZUZRMYu4LRCGqrgeHEJC

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
