### PR TITLE
revert: back to Qwen3 via Adapter — Gemini quality unacceptable

### DIFF
--- a/jobs_registry.yaml
+++ b/jobs_registry.yaml
@@ -347,9 +347,9 @@ jobs:
   - id: kb_dream
     scheduler: system
     entry: kb_dream.sh
-    interval: "0 3 * * *"           # 每天 03:00（凌晨系统空闲时"做梦"）
+    interval: "30 4 * * *"          # 每天 04:30（GPU 低负载时段，避开其他 cron 集中期）
     log: ~/kb_dream.log
-    needs_api_key: false             # 通过 proxy:5002 调 LLM
+    needs_api_key: false             # 通过 Adapter:5001 调 LLM（绕过 Proxy）
     enabled: true
     tier: experiment                 # 实验性：Agent 跨领域探索
     description: "Agent 做梦引擎 — 跨领域关联发现 + 趋势推演 + 被忽视信号挖掘（每日凌晨，输出 ~/.kb/dreams/）"

--- a/kb_dream.sh
+++ b/kb_dream.sh
@@ -22,26 +22,12 @@ LOCK="/tmp/kb_dream.lockdir"
 mkdir "$LOCK" 2>/dev/null || { echo "[dream] Already running, skip"; exit 0; }
 trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
-# Dream 专用 LLM：直接调 Gemini API，完全独立于 WhatsApp 的 Qwen3
-# 原因：
-# ① 资源隔离：Qwen3 远端 GPU 高峰时段常截断响应（2KB vs 17KB）
-# ② Gemini 2.5 Flash：1M context（113KB prompt 轻松容纳）+ 8192 max_output_tokens
-# ③ 免费/低成本，且和 Qwen3 不共享任何资源
-# 回退：如果 GEMINI_API_KEY 未设置，仍用 Adapter(:5001)
-GEMINI_API_KEY="${GEMINI_API_KEY:-}"
-if [ -n "$GEMINI_API_KEY" ]; then
-    LLM_URL="https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
-    LLM_AUTH="Bearer $GEMINI_API_KEY"
-    LLM_MODEL="gemini-2.5-flash"
-    LLM_SOURCE="gemini"
-    log "LLM: Gemini 2.5 Flash (独立资源，不与 WhatsApp 竞争)"
-else
-    LLM_URL="http://localhost:5001/v1/chat/completions"
-    LLM_AUTH=""
-    LLM_MODEL="any"
-    LLM_SOURCE="adapter"
-    log "LLM: Adapter(:5001) (GEMINI_API_KEY 未设置，回退)"
-fi
+# Dream LLM 配置：直接调 Adapter(:5001)，绕过 Proxy
+# 资源竞争缓解策略：cron 调度到凌晨 4:00（GPU 低负载时段）+ 短响应自动重试
+# Gemini 2.5 Flash 已验证不适合（中文质量差、免费 tier 限速、输出极短）
+LLM_URL="http://localhost:5001/v1/chat/completions"
+LLM_AUTH=""
+LLM_MODEL="any"
 DAY="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d')"
 TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
 DRY_RUN=false
@@ -85,15 +71,10 @@ llm_call() {
     local err_file=$(mktemp)
 
     while [ $attempt -lt 2 ]; do
-        # 构建 auth header（Gemini 需要 Bearer token，Adapter 不需要）
-        local auth_args=()
-        [ -n "$LLM_AUTH" ] && auth_args=(-H "Authorization: $LLM_AUTH")
-
         raw=$(curl -sS --max-time "$timeout" "$LLM_URL" \
             -H 'Content-Type: application/json' \
-            "${auth_args[@]}" \
-            -d "$(jq -nc --arg p "$prompt" --arg m "$LLM_MODEL" --argjson mt "$max_tokens" --argjson t "$temp" \
-                '{model:$m,messages:[{role:"user",content:$p}],max_tokens:$mt,temperature:$t,stream:false}')" \
+            -d "$(jq -nc --arg p "$prompt" --argjson mt "$max_tokens" --argjson t "$temp" \
+                '{model:"any",messages:[{role:"user",content:$p}],max_tokens:$mt,temperature:$t,stream:false}')" \
             2>"$err_file" || true)
 
         # 尝试从标准 JSON 提取


### PR DESCRIPTION
Gemini 2.5 Flash tested in production:
- Chinese analytical writing quality far below Qwen3
- Free tier rate limiting: 3/14 Map sources returned empty
- Reduce output consistently < 1300 chars (vs Qwen3's 17KB)
- macOS `log` command conflict with our log() function

Strategy change: keep Qwen3 (proven 17KB quality output) + mitigate GPU contention via scheduling:
- Cron moved from 03:00 → 04:30 (lowest GPU load window)
- Retry logic retained (short response < 4000 chars → auto-retry)
- Direct Adapter(:5001) call retained (bypass Proxy overhead)

https://claude.ai/code/session_01DVZUZRMYu4LRCGqrgeHEJC

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
