### PR TITLE
docs: V36.1 — status.json + CLAUDE.md full update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — openclaw-model-bridge 项目背景
 
-> 每次新会话开始时自动读取。当前版本：v36 / 0.36.0（2026-04-05）
+> 每次新会话开始时自动读取。当前版本：v36.1 / 0.36.1（2026-04-06）
 
 ---
 
@@ -190,6 +190,8 @@
 | `docs/memory_plane.md` | **V36新增** Memory Plane 架构文档（分层设计/API/数据流/CLI） |
 | `docs/security_boundaries.md` | **V36新增** 安全边界文档（8节：认证/网络/输入验证/数据保护/LLM安全/运维/评分/已知风险+Checklist） |
 | `docs/resilience_report.md` | **V36新增** 运维韧性实验报告（7场景故障注入+Recovery Time+GameDay对比+改进建议） |
+| `docs/ontology/` | **V36新增** Ontology KB — 本体论驱动的企业智能架构知识库（7文件：三角架构论述/核心概念/AI治理/OpenClaw本体审视/文献/人物/README） |
+| `kb_dream.sh` | **V36新增→升级** Agent Dream v2 MapReduce 全量 KB 探索引擎（Phase1 Map 14源+226笔记逐一提取信号 → Phase2 Reduce 跨域深度分析，一个主题×全部分析维���，绕过Proxy直调Adapter，分段WhatsApp推送，短响应自动重试，04:30错峰执行） |
 | `gameday.sh` | **V33新增** GameDay 故障演练（5场景：GPU超时/断路器/快照/SLO/Watchdog，`bash gameday.sh --all`） |
 | `jobs/dblp/run_dblp.sh` | **V30.5新增** DBLP CS论文监控（多关键词搜索、免费API、每日12:00推送+KB写入） |
 | `jobs/hf_papers/run_hf_papers.sh` | **V30.5新增** HuggingFace Daily Papers 监控（热门AI论文、每日10:00推送+KB写入） |
@@ -207,6 +209,7 @@
 
 | 版本 | 日期 | 关键变更 |
 |------|------|----------|
+| V36.1 | 2026-04-06 | **Agent Dream v2 + Ontology KB** — MapReduce 全量 KB 探索（14源+226笔记）+ Notes 一等信号 + Ontology KB 创建（7文件）+ 论文监控加 ontology 关键词 + X 监控 9→15 人（+Palantir）+ Cron 调度优化（~55→30 次/天）+ 凌晨 GPU 黄金窗口 |
 | V36 | 2026-04-05 | **V2 路标双P0完成** — Agent Reliability Bench（7场景47检查） + Memory Plane v1（4层统一接口+45单测+架构文档） + 560 测试 |
 | V35 | 2026-04-05 | **V1 路标冲刺** — SLO Benchmark 实验报告 + Quick Start 一键 demo + Golden Test Trace + Sub-agent PoC（链路通，deferred 等模型升级）+ 605 测试 |
 | V34 | 2026-04-03 | **Stage2 启动** — Provider Compatibility Layer + 导师战略复盘嵌入治理体系 + V1/V2/V3 路标 + 461 测试 |
@@ -305,6 +308,12 @@ python3 memory_plane.py stats                     # 各层统计
 python3 memory_plane.py query "Qwen3"             # 统一搜索
 python3 memory_plane.py query --context "AI论文"   # LLM可注入格式
 python3 memory_plane.py query --layers kb "RAG"    # 仅搜索KB层
+
+# Agent Dream v2（MapReduce 全量 KB 探索）
+bash kb_dream.sh              # 完整 MapReduce 做梦（~15 分钟）
+bash kb_dream.sh --dry-run    # 素材统计（不调 LLM）
+bash kb_dream.sh --fast       # 跳过 Map，直接采样做梦（旧模式）
+cat ~/.kb/dreams/2026-04-06.md  # 查看梦境结果
 
 # Agent Reliability Bench（7场景故障评测）
 python3 reliability_bench.py            # Markdown 报告
@@ -518,6 +527,19 @@ grep -r "BSA[A-Za-z0-9]\{15,\}" . --include="*.py" --include="*.sh" --include="*
 | 架构型 | **Why Agent Systems Need a Control Plane** — `docs/articles/why_control_plane.md`（问题→三平面架构→7场景证据→5条教训→立场） | ✅ V36 完成 |
 | 证据型 | **Benchmark Report** / **Failure Injection Report** / **Lessons from 461-test Regression** | 待写 |
 | 立场型 | **为什么 agent 系统首先是治理问题** / **为什么 control plane 必须先于 capability plane** | 待写 |
+| 立场型 | **Why Enterprise AI Needs Ontology Before It Needs More Models** — Ontology+LLM+Agent 三角架构论述 | 待写 |
+
+### Ontology KB（新方向，持续推进）
+
+| 优先级 | 任务 | 状态 |
+|--------|------|------|
+| **P0** | Ontology KB 目录结构 + 初始文件（7 文件） | ✅ V36.1 完成 |
+| **P0** | 论文监控加 ontology 关键词（ArXiv/S2/DBLP） | ✅ V36.1 完成 |
+| **P0** | X 监控加 ontology 人物（Marcus/Leskovec/Witbrock/Palantir×3） | ✅ V36.1 完成 |
+| **P1** | 丰富 Ontology KB 内容：BFO/DOLCE/UFO 流派对比、Neuro-Symbolic 技术、供应链本体 | 待写 |
+| **P1** | 用本体论视角重新审视 OpenClaw（深度版，含工具语义本体实验） | 待写 |
+| **P1** | 第一篇立场文章：**Why Enterprise AI Needs Ontology Before It Needs More Models** | 待写 |
+| **P2** | 在 OpenClaw 中实验性引入本体约束（工具调用前置条件检查） | 待启动 |
 
 ### 现有功能任务（V1 稳定后继续推进）
 

--- a/status.json
+++ b/status.json
@@ -103,6 +103,16 @@
       "note": "导师指出的三块差距之一：去除个人/场景定制痕迹，抽象成别人也能迁移的框架。V2-V3阶段推进"
     },
     {
+      "task": "【新方向】Ontology KB — 本体论驱动的企业智能架构",
+      "status": "active",
+      "note": "核心论点：Ontology(语义骨架)+LLM(大脑)+Agent(执行)=未来企业智能架构。已创建docs/ontology/(7文件)，论文监控已加ontology关键词，X监控已加Marcus/Leskovec/Witbrock/Palantir。下一步：丰富内容+第一篇立场文章"
+    },
+    {
+      "task": "【优化】Agent Dream v2 MapReduce",
+      "status": "active",
+      "note": "MapReduce全量KB探索(14 sources+226 notes)，Notes走Map阶段，一个主题×全部分析维度，绕过Proxy直调Adapter，04:30错峰执行。待验收：明早04:30自动运行结果"
+    },
+    {
       "task": "Provider Compatibility Layer",
       "status": "completed"
     },
@@ -120,6 +130,11 @@
     }
   ],
   "recent_changes": [
+    {
+      "date": "2026-04-06",
+      "what": "Agent Dream v2 MapReduce全量KB探索(14 sources+226 notes全覆盖) + Notes走Map阶段(用户交互=一等信号) + 一个主题×全部分析维度(隐藏关联+趋势推演+被忽视信号+行动建议) + 绕过Proxy直调Adapter + 分段推送完整梦境 + 短响应自动重试 + Ontology KB创建(7文件571行:三角架构+核心概念+AI治理+OpenClaw本体审视+文献+人物) + Discord #ontology频道 + 论文监控加ontology关键词(ArXiv/S2/DBLP) + X监控9→15人(+Marcus/Leskovec/Witbrock/Palantir×3) + Cron调度优化(~55次/天→~30次/天,08:00并发4→2) + 凌晨04:00-06:00 GPU黄金窗口规划 + CLAUDE.md规则#14硬卡点",
+      "by": "claude_code"
+    },
     {
       "date": "2026-04-05",
       "what": "V36/0.36.0: V2路标7/7全部完成 — Reliability Bench(7场景47检查)+Memory Plane v1+v2(4层统一+去重+置信度+冲突消解,64单测)+SLO Dashboard(历史追踪+sparkline)+安全边界文档+semver版本治理+运维韧性报告+第一篇架构文章(dev.to+知乎+Twitter发布)+610测试23套件全过+Mac Mini生产验证通过",
@@ -238,8 +253,8 @@
     "text_index": "14198 chunks, 257/257 files (100%), 257 stale, 0h ago, 21297KB"
   },
   "session_context": {
-    "last_session": "2026-04-05",
-    "unfinished": "",
+    "last_session": "2026-04-06",
+    "unfinished": "明早验收Dream v2 04:30自动运行结果(期望>10KB+Notes信号)",
     "open_prs": "",
     "blocked_on": ""
   },
@@ -309,7 +324,7 @@
     "stage": "Stage2: 从系统构建者升级为被社区认可的系统作者",
     "mentor_review": "2026-04-03: 确认Stage1完成，主战场=Agent Runtime Control Plane + Memory Plane，下一步补证据而非功能"
   },
-  "focus": "Stage2:被社区认可的系统作者。P0:Provider Compatibility Layer抽象+Agent Reliability Bench+Memory Plane v1统一+兼容矩阵&SLO benchmark证据。P1:一键demo+第一篇架构文章。详见docs/strategic_review_20260403.md",
+  "focus": "Stage2:被社区认可的系统作者。双线并进：① Control Plane(V1-V2完成,V3 Plugin待启动) ② Ontology KB(新方向:Ontology+LLM+Agent企业架构,docs/ontology/已创建)。Dream v2 MapReduce全量KB探索已部署。详见docs/strategic_review_20260403.md + docs/ontology/README.md",
   "notes": "",
   "preferences": [
     "[auto] 活跃时段 00:00-08:00（2天数据）",


### PR DESCRIPTION
## Summary

V36.1 文档和状态全面更新，反映今日所有工作成果。

- **status.json**: 新增 2026-04-06 变更记录、Ontology KB 和 Dream v2 加入 priorities、focus 更新为双线并进、session_context 标注明早验收项
- **CLAUDE.md**: 版本 v36→v36.1、关键文件表加 `docs/ontology/` 和 `kb_dream.sh`、版本历史加 V36.1、Ontology KB 待办列表、Dream v2 常用命令、新增立场文章待写项
- 610 测试全过

## Test plan
- [x] `bash full_regression.sh` 610 测试通过
- [x] status.json JSON 格式合法
- [x] CLAUDE.md 内容与实际代码一致

https://claude.ai/code/session_01DVZUZRMYu4LRCGqrgeHEJC