### PR TITLE
fix ontology paper push to use Chinese instead of English

### DIFF
--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -398,7 +398,7 @@ fi
 ONTO_MSG_FILE="$CACHE/ontology_papers.txt"
 ONTO_FILTER="$(dirname "$0")/../ontology_filter.py"
 if [ -f "$ONTO_FILTER" ]; then
-    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" 2>/dev/null || true
+    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>/dev/null || true
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)

--- a/jobs/dblp/run_dblp.sh
+++ b/jobs/dblp/run_dblp.sh
@@ -394,7 +394,7 @@ fi
 ONTO_MSG_FILE="$CACHE/ontology_papers.txt"
 ONTO_FILTER="$(dirname "$0")/../ontology_filter.py"
 if [ -f "$ONTO_FILTER" ]; then
-    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" 2>/dev/null || true
+    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>/dev/null || true
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)

--- a/jobs/ontology_filter.py
+++ b/jobs/ontology_filter.py
@@ -3,15 +3,15 @@
 ontology_filter.py — 从论文 JSONL 中筛选 ontology 相关论文
 
 供 ArXiv/S2/DBLP 等论文监控脚本调用，检测标题/摘要命中 ontology 关键词。
-命中的论文输出为格式化消息，用于推送到 Discord #ontology 频道。
+命中的论文输出中文格式化消息，用于推送到 Discord #ontology 频道。
 
 用法：
-    python3 ontology_filter.py <papers.jsonl> <day> <output.txt>
+    python3 ontology_filter.py <papers.jsonl> <day> <output.txt> [chinese_msg.txt]
 
-输入 JSONL 格式（每行一个 JSON）：
-    {"title": "...", "abstract": "...", "first_author": "...", "date": "...", "arxiv_id": "..." }
-    或
-    {"title": "...", "abstract": "...", "first_author": "...", "date": "...", "url": "..." }
+    papers.jsonl    — 原始论文数据（英文，用于关键词匹配）
+    day             — 日期字符串
+    output.txt      — 输出文件
+    chinese_msg.txt — 可选，主流程生成的中文消息文件（有则提取中文内容，无则回退英文）
 
 如果无命中，输出文件为空。
 """
@@ -21,7 +21,6 @@ import re
 import sys
 
 # Ontology 关键词（标题或摘要命中任一即可）
-# 宽泛匹配：覆盖 ontology 及其关联领域
 ONTO_KEYWORDS = [
     r'\bontolog',              # ontology, ontological, ontologies
     r'\bknowledge.graph',      # knowledge graph(s)
@@ -41,13 +40,63 @@ ONTO_KEYWORDS = [
 PATTERN = re.compile('|'.join(ONTO_KEYWORDS), re.IGNORECASE)
 
 
+def _parse_chinese_blocks(chinese_msg_file):
+    """解析中文消息文件，按论文分块。
+
+    主流程消息格式（每篇论文 5 行 + 1 空行）：
+        *中文标题*
+        作者：XXX 等 | 日期：YYYY-MM-DD
+        链接：https://arxiv.org/abs/XXXX
+        贡献：...
+        价值：⭐⭐⭐
+        （空行）
+
+    返回 list[str]，每个元素是一篇论文的完整中文文本块。
+    """
+    try:
+        with open(chinese_msg_file, encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, IOError):
+        return []
+
+    blocks = []
+    current = []
+    in_paper = False
+
+    for line in content.split("\n"):
+        # 论文标题行以 * 开头
+        if line.startswith("*") and line.endswith("*"):
+            if current and in_paper:
+                blocks.append("\n".join(current))
+            current = [line]
+            in_paper = True
+        elif in_paper:
+            if line.strip() == "" and current:
+                blocks.append("\n".join(current))
+                current = []
+                in_paper = False
+            else:
+                current.append(line)
+
+    # 最后一个 block
+    if current and in_paper:
+        blocks.append("\n".join(current))
+
+    return blocks
+
+
 def main():
     if len(sys.argv) < 4:
-        print(f"Usage: {sys.argv[0]} <papers.jsonl> <day> <output.txt>", file=sys.stderr)
+        print(f"Usage: {sys.argv[0]} <papers.jsonl> <day> <output.txt> [chinese_msg.txt]",
+              file=sys.stderr)
         sys.exit(1)
 
-    papers_file, day, output_file = sys.argv[1], sys.argv[2], sys.argv[3]
+    papers_file = sys.argv[1]
+    day = sys.argv[2]
+    output_file = sys.argv[3]
+    chinese_msg_file = sys.argv[4] if len(sys.argv) > 4 else None
 
+    # 加载原始论文数据（英文，用于关键词匹配）
     papers = []
     with open(papers_file) as f:
         for line in f:
@@ -58,37 +107,46 @@ def main():
                 except json.JSONDecodeError:
                     continue
 
-    # 检测命中
-    onto_papers = []
-    for p in papers:
+    # 加载中文消息块（如有）
+    cn_blocks = []
+    if chinese_msg_file:
+        cn_blocks = _parse_chinese_blocks(chinese_msg_file)
+
+    # 检测命中（记录索引）
+    matches = []  # (index, paper)
+    for i, p in enumerate(papers):
         text = p.get("title", "") + " " + p.get("abstract", "")
         if PATTERN.search(text):
-            onto_papers.append(p)
+            matches.append((i, p))
 
-    if not onto_papers:
+    if not matches:
         with open(output_file, "w") as f:
             pass
         sys.exit(0)
 
     # 组装消息
     lines = [f"\U0001F9E0 Ontology 相关论文 ({day})", ""]
-    for p in onto_papers:
-        lines.append(f"*{p.get('title', 'Untitled')}*")
-        lines.append(f"作者：{p.get('first_author', '?')} 等 | 日期：{p.get('date', '?')}")
-        # 优先 arxiv_id，其次 url
-        if p.get("arxiv_id"):
-            lines.append(f"链接：https://arxiv.org/abs/{p['arxiv_id']}")
-        elif p.get("url"):
-            lines.append(f"链接：{p['url']}")
-        abstract = p.get("abstract", "")
-        if abstract:
-            lines.append(f"摘要：{abstract[:200]}...")
+
+    for idx, p in matches:
+        # 优先使用中文内容（按索引对应）
+        if idx < len(cn_blocks):
+            lines.append(cn_blocks[idx])
+        else:
+            # 回退英文
+            lines.append(f"*{p.get('title', 'Untitled')}*")
+            lines.append(f"作者：{p.get('first_author', '?')} 等 | 日期：{p.get('date', '?')}")
+            if p.get("arxiv_id"):
+                lines.append(f"链接：https://arxiv.org/abs/{p['arxiv_id']}")
+            elif p.get("url"):
+                lines.append(f"链接：{p['url']}")
         lines.append("")
 
     with open(output_file, "w") as f:
         f.write("\n".join(lines))
 
-    print(f"[ontology_filter] 命中 {len(onto_papers)}/{len(papers)} 篇", file=sys.stderr)
+    print(f"[ontology_filter] 命中 {len(matches)}/{len(papers)} 篇"
+          f"{'（中文）' if cn_blocks else '（英文回退）'}",
+          file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/jobs/semantic_scholar/run_semantic_scholar.sh
+++ b/jobs/semantic_scholar/run_semantic_scholar.sh
@@ -374,7 +374,7 @@ fi
 ONTO_MSG_FILE="$CACHE/ontology_papers.txt"
 ONTO_FILTER="$(dirname "$0")/../ontology_filter.py"
 if [ -f "$ONTO_FILTER" ]; then
-    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" 2>/dev/null || true
+    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>/dev/null || true
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)


### PR DESCRIPTION
Problem: ontology_filter.py output English titles/abstracts, but project rule requires all pushes in Chinese.

Fix: ontology_filter.py now accepts optional 4th arg (chinese_msg.txt) — the main pipeline's already-translated Chinese message file. When provided, matching papers extract Chinese content by index mapping. When missing, falls back to English (backward compatible).

ArXiv/S2/DBLP scripts updated to pass $MSG_FILE as the Chinese source.

Tested: 2/3 papers correctly matched with full Chinese output (title + author + link + contribution + rating all in Chinese).

https://claude.ai/code/session_01BocKQqGAunm9cc61Zp97Rj

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
