### PR TITLE
fix ontology filter stderr redirect: /dev/null → log file

### DIFF
--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -398,11 +398,11 @@ fi
 ONTO_MSG_FILE="$CACHE/ontology_papers.txt"
 ONTO_FILTER="$(dirname "$0")/../ontology_filter.py"
 if [ -f "$ONTO_FILTER" ]; then
-    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>/dev/null || true
+    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>"$CACHE/onto_filter.err" || true
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)
-        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json >/dev/null 2>&1 || true
+        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json 2>"$CACHE/onto_discord.err" || true
         log "Ontology论文推送到Discord #ontology: ${ONTO_COUNT} 篇"
     fi
 fi

--- a/jobs/dblp/run_dblp.sh
+++ b/jobs/dblp/run_dblp.sh
@@ -394,11 +394,11 @@ fi
 ONTO_MSG_FILE="$CACHE/ontology_papers.txt"
 ONTO_FILTER="$(dirname "$0")/../ontology_filter.py"
 if [ -f "$ONTO_FILTER" ]; then
-    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>/dev/null || true
+    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>"$CACHE/onto_filter.err" || true
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)
-        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json >/dev/null 2>&1 || true
+        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json 2>"$CACHE/onto_discord.err" || true
         log "Ontology论文推送到Discord #ontology: ${ONTO_COUNT} 篇"
     fi
 fi

--- a/jobs/semantic_scholar/run_semantic_scholar.sh
+++ b/jobs/semantic_scholar/run_semantic_scholar.sh
@@ -374,11 +374,11 @@ fi
 ONTO_MSG_FILE="$CACHE/ontology_papers.txt"
 ONTO_FILTER="$(dirname "$0")/../ontology_filter.py"
 if [ -f "$ONTO_FILTER" ]; then
-    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>/dev/null || true
+    python3 "$ONTO_FILTER" "$PAPERS_FILE" "$DAY" "$ONTO_MSG_FILE" "$MSG_FILE" 2>"$CACHE/onto_filter.err" || true
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)
-        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json >/dev/null 2>&1 || true
+        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json 2>"$CACHE/onto_discord.err" || true
         log "Ontology论文推送到Discord #ontology: ${ONTO_COUNT} 篇"
     fi
 fi


### PR DESCRIPTION
Problem: 2>/dev/null caused silent failures on Mac — ontology filter ran but Discord push was swallowed. Manual execution confirmed both filter (3 papers, Chinese) and Discord push work correctly.

Fix: redirect stderr to $CACHE/onto_filter.err and onto_discord.err for all 3 scripts (ArXiv, S2, DBLP). Errors are now logged for debugging instead of silently discarded.

Verified: manual run produced correct Chinese output + Discord push
succeeded (messageId: 1490723949904924722).

https://claude.ai/code/session_01BocKQqGAunm9cc61Zp97Rj

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
