### PR TITLE
fix(notify): queue drain fails in zsh — for-loop doesn't word-split

### DIFF
--- a/notify.sh
+++ b/notify.sh
@@ -109,7 +109,8 @@ _notify_drain_queue() {
     echo "[notify] 发现 $count 条排队消息，尝试重放..." >&2
 
     local f channel target msg
-    for f in $qfiles; do
+    while IFS= read -r f; do
+        [ -f "$f" ] || continue
         channel=$(python3 -c "import json,sys; print(json.load(sys.stdin)['channel'])" < "$f" 2>/dev/null) || continue
         target=$(python3 -c "import json,sys; print(json.load(sys.stdin)['target'])" < "$f" 2>/dev/null) || continue
         msg=$(python3 -c "import json,sys; print(json.load(sys.stdin)['msg'])" < "$f" 2>/dev/null) || continue
@@ -121,7 +122,7 @@ _notify_drain_queue() {
             echo "[notify] REPLAY FAIL: $(basename "$f")，保留队列" >&2
             break  # 如果还是失败，停止重放（避免雪崩）
         fi
-    done
+    done <<< "$qfiles"
 }
 
 # notify "message" [--channel whatsapp|discord] [--topic papers|freight|alerts|daily|tech]


### PR DESCRIPTION
When notify.sh is sourced into zsh (user's interactive shell), `for f in $qfiles` treats the newline-separated file list as one string. Switch to `while read` which works in both bash and zsh.

https://claude.ai/code/session_01CHUYbEh7oe612yVWES1LwX

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
