### PR TITLE
feat(ontology): runtime governance + shadow mode + semantic observation

### DIFF
--- a/ontology/engine.py
+++ b/ontology/engine.py
@@ -436,6 +436,72 @@ class ToolOntology:
                 filters[key] = value
         return filters
 
+    # ── 语义分类（从观察到决策的桥梁）──
+
+    def classify_tool_call(self, tool_name: str) -> dict:
+        """对工具调用进行语义分类 — 从存在推导本质。
+
+        不是查表（"这个工具名在列表里吗"），
+        而是推理（"这个工具是什么类别、有什么副作用、操作什么资源"）。
+
+        用于 proxy_filters 的语义观察模式：
+        - 每次工具调用时，ontology 提供语义元数据
+        - proxy 记录这些信号，为未来的语义策略决策积累数据
+
+        Returns:
+            {
+                "name": "write",
+                "known": True,           # ontology 认识这个工具吗
+                "category": "file_operation",
+                "side_effects": True,
+                "resource_type": "File",
+                "risk_level": "high",    # 推理出的风险等级
+                "policy_tags": ["night_blockable", "audit_required"],
+            }
+        """
+        meta = self.get_tool_metadata(tool_name)
+        if not meta:
+            return {
+                "name": tool_name,
+                "known": False,
+                "category": None,
+                "side_effects": None,
+                "resource_type": None,
+                "risk_level": "unknown",
+                "policy_tags": ["unknown_tool"],
+            }
+
+        side_fx = meta.get("side_effects", False)
+        category = meta.get("category")
+
+        # 从属性推理风险等级和策略标签
+        risk = "low"
+        tags = []
+
+        if side_fx:
+            risk = "high"
+            tags.append("night_blockable")
+            tags.append("audit_required")
+        else:
+            tags.append("audit_exempt")
+
+        if category == "file_operation" and side_fx:
+            tags.append("approval_required")
+        if meta.get("resource_type") == "WebPage":
+            tags.append("rate_limited")
+            if risk == "low":
+                risk = "medium"
+
+        return {
+            "name": tool_name,
+            "known": True,
+            "category": category,
+            "side_effects": side_fx,
+            "resource_type": meta.get("resource_type"),
+            "risk_level": risk,
+            "policy_tags": sorted(tags),
+        }
+
     # ── Phase 1: 生成 proxy_filters 兼容数据 ──
 
     def generate_proxy_data(self):

--- a/ontology/governance_checker.py
+++ b/ontology/governance_checker.py
@@ -258,6 +258,11 @@ def run_meta_discovery(data):
             result = _discover_uncovered_topics(severity)
             discovery_results.append({"id": disc_id, "name": name, **result})
 
+        elif disc_id == "MRD-LAYER-001":
+            # 扫描 critical 不变式的验证深度
+            result = _discover_shallow_critical(data, severity)
+            discovery_results.append({"id": disc_id, "name": name, **result})
+
     return discovery_results
 
 
@@ -372,6 +377,37 @@ def _discover_uncovered_topics(severity):
     }
 
 
+def _discover_shallow_critical(data, severity):
+    """MRD-LAYER-001: severity=critical 的不变式应有 ≥2 层验证深度。"""
+    invariants = data.get("invariants", [])
+    shallow = []
+    deep = []
+
+    for inv in invariants:
+        if inv.get("severity") != "critical":
+            continue
+        layers = inv.get("verification_layer", [])
+        inv_id = inv.get("id", "?")
+        if len(layers) < 2:
+            shallow.append(f"{inv_id} ({','.join(layers) if layers else 'none'})")
+        else:
+            deep.append(inv_id)
+
+    if shallow:
+        return {
+            "status": "warn",
+            "severity": severity,
+            "message": f"{len(shallow)} 个 critical 不变式仅有单层验证: {', '.join(shallow[:5])}{'...' if len(shallow) > 5 else ''}",
+            "shallow": shallow,
+            "deep": deep,
+        }
+    return {
+        "status": "pass",
+        "severity": severity,
+        "message": f"所有 {len(deep)} 个 critical 不变式都有 ≥2 层验证深度",
+    }
+
+
 def print_results(results):
     if JSON_MODE:
         print(json.dumps(results, indent=2, ensure_ascii=False))
@@ -419,7 +455,7 @@ def print_results(results):
     print()
     print("─" * 70)
     print(f"  不变式: {len(results)} | 检查: {executed} 执行, {skipped} 跳过")
-    print(f"  通过: {passed_checks}/{executed} checks | 元规则: {len(mr_used)}/5")
+    print(f"  通过: {passed_checks}/{executed} checks | 元规则: {len(mr_used)}/6")
 
     if failed_invs:
         print(f"\n  ❌ {failed_invs} 个不变式被违反")

--- a/ontology/governance_ontology.yaml
+++ b/ontology/governance_ontology.yaml
@@ -1,10 +1,32 @@
-# governance_ontology.yaml — 系统治理不变式本体 v2（可执行声明式规则）
+# governance_ontology.yaml — 系统治理不变式本体 v3（验证深度分层）
 #
 # 核心问题："什么东西坏了我们会发现不了？"
 #
-# v1 → v2 升级：从"描述性三元组"升级为"可执行三元组"。
-# 每个不变式的 checks 字段包含真正可运行的断言，
-# governance_checker.py 直接执行这些断言，不再只是 grep 字符串。
+# v1 → v2: 从"描述性三元组"升级为"可执行三元组"
+# v2 → v3: 从"平面检查"升级为"验证深度三层模型"
+#   - 2026-04-07 教训：22 个声明-实际断裂，全在声明层
+#   - 2026-04-08 教训：声明层 12/12 全过，WhatsApp 推送却静默失败 3 天
+#     根因：只查"代码写了什么"(声明层)，不查"运行时环境对不对"(运行时层)
+#
+# 验证深度三层模型（Verification Depth Model）：
+#   Layer 1 — Declaration（声明层）："代码/配置说了 X 吗？"
+#     file_contains, file_not_contains, python_assert(静态)
+#     能查：代码级不一致
+#     盲区：代码正确但从未被执行
+#
+#   Layer 2 — Runtime（运行时层）："X 在执行时真的发生了吗？"
+#     env_var_exists, command_succeeds, python_assert(subprocess)
+#     能查：环境和执行时不一致
+#     盲区：执行正确但结果错误
+#
+#   Layer 3 — Effect（效果层）："X 达到了预期目的吗？"
+#     E2E验证：消息真的到达？数据不只新鲜还正确？
+#     能查：端到端失败（组件各自正常但整体不工作）
+#     盲区：未来的探索方向
+#
+# 每个不变式标注 verification_layer，让 governance 自我意识盲区深度。
+# MR-6 要求关键不变式覆盖 ≥2 层。
+# MRD-LAYER-001 自动发现只有单层覆盖的不变式。
 #
 # 检查类型（check_type）：
 #   python_assert  — 执行 Python 代码，assert 不抛异常 = pass
@@ -12,14 +34,15 @@
 #   file_not_contains — 检查文件不包含指定 pattern
 #   env_var_exists — 检查环境变量非空（需 --full 模式，bash -lc）
 #   command_succeeds — 执行 shell 命令，exit code 0 = pass
-#   json_field      — 检查 JSON 文件中某字段存在且满足条件
 #
 # 使用方式：
 #   python3 ontology/governance_checker.py              # dev 模式
 #   python3 ontology/governance_checker.py --full        # Mac Mini（含 env/crontab）
 #   python3 ontology/governance_checker.py --json        # JSON 输出
 #
-# 教训来源：2026-04-07 对抗审计 — 22 个声明 vs 实际断裂点
+# 教训来源：
+#   2026-04-07 对抗审计 — 22 个声明-实际断裂点
+#   2026-04-08 运行时层发现 — 声明全过但推送失败 3 天
 
 # ═══════════════════════════════════════════════════════════════════════
 # 1. 元概念（Meta-Concepts）
@@ -34,6 +57,34 @@ meta_concepts:
 
   Verification:
     description: "证明声明和执行一致的可执行检查"
+
+  # v3 新增：验证深度分层
+  VerificationDepth:
+    description: "检查在哪个深度层工作 — 越深越接近真实"
+    layers:
+      declaration:
+        depth: 1
+        question: "代码/配置说了 X 吗？"
+        check_types: [file_contains, file_not_contains, python_assert]
+        catches: "代码级不一致（pattern 缺失、字段缺失、导入缺失）"
+        blind_spot: "代码正确但从未被执行（cron 环境不同、PATH 不同）"
+        lesson: "2026-04-07: 12/12 声明检查全过"
+
+      runtime:
+        depth: 2
+        question: "X 在执行环境中真的发生了吗？"
+        check_types: [env_var_exists, command_succeeds]
+        catches: "执行环境不一致（env vars 缺失、python3 损坏、crontab 漂移）"
+        blind_spot: "执行正确但结果错误（发送成功但目标号码是占位号）"
+        lesson: "2026-04-08: bash -lc 缺失导致 OPENCLAW_PHONE 为占位号，推送 3 天失败"
+
+      effect:
+        depth: 3
+        question: "X 达到了预期目的吗？"
+        check_types: []  # 待建设
+        catches: "端到端失败（各组件正常但整体不工作）"
+        blind_spot: "需要外部反馈（用户确认收到消息）"
+        lesson: "待积累 — 每个真实 bug 驱动一个新 effect 检查"
 
 # ═══════════════════════════════════════════════════════════════════════
 # 2. 元规则（Meta-Rules）
@@ -63,6 +114,11 @@ meta_rules:
     description: "每个健康状态字段必须有刷新机制和陈旧度检测"
     lesson: "2026-04-07: security_score 无时间戳，从不自动刷新"
 
+  - id: MR-6
+    name: critical-invariants-need-depth
+    description: "severity=critical 的不变式必须有 ≥2 层验证深度（声明层+运行时层）"
+    lesson: "2026-04-08: 声明层 12/12 全过但 DBLP/Dream WhatsApp 推送连续失败 3 天。单层检查给出虚假的安全感。"
+
 # ═══════════════════════════════════════════════════════════════════════
 # 3. 不变式（Invariants）— 可执行的声明-执行-验证三元组
 # ═══════════════════════════════════════════════════════════════════════
@@ -73,6 +129,7 @@ invariants:
   - id: INV-TOOL-001
     name: tool-count-limit
     meta_rule: MR-1
+    verification_layer: [declaration]
     severity: critical
     declaration: "Agent 单次请求工具数 ≤ 12（CLAUDE.md）"
     checks:
@@ -91,6 +148,7 @@ invariants:
   - id: INV-TOOL-002
     name: max-tools-config-imported
     meta_rule: MR-1
+    verification_layer: [declaration]
     severity: critical
     declaration: "MAX_TOOLS = 12 定义在 config_loader → proxy_filters 必须导入使用"
     checks:
@@ -107,6 +165,7 @@ invariants:
   - id: INV-TOOL-003
     name: custom-tool-schema-sync
     meta_rule: MR-3
+    verification_layer: [declaration]
     severity: high
     declaration: "CUSTOM_TOOLS schema 与 tool_proxy.py 实现一致"
     checks:
@@ -135,6 +194,7 @@ invariants:
   - id: INV-CRON-001
     name: registry-crontab-interval-sync
     meta_rule: MR-3
+    verification_layer: [declaration, runtime]
     severity: critical
     declaration: "registry interval 与实际 crontab 一致"
     lesson: "2026-04-07: ArXiv registry 0 8,20 但 crontab 0 */3"
@@ -151,6 +211,7 @@ invariants:
   - id: INV-CRON-002
     name: quiet-hours-enforcement
     meta_rule: MR-4
+    verification_layer: [declaration]
     severity: high
     declaration: "00:00-07:00 零推送通知（Dream 除外）"
     lesson: "2026-04-07: watchdog 04:30 + ArXiv 04:00 打扰睡眠"
@@ -176,6 +237,7 @@ invariants:
   - id: INV-NOTIFY-001
     name: discord-channel-availability
     meta_rule: MR-4
+    verification_layer: [declaration, runtime]
     severity: critical
     declaration: "所有推送必须双通道（CLAUDE.md #16），6 个 DISCORD_CH_* 非空"
     checks:
@@ -215,6 +277,7 @@ invariants:
   - id: INV-NOTIFY-002
     name: notify-empty-channel-error
     meta_rule: MR-4
+    verification_layer: [declaration]
     severity: high
     declaration: "推送失败必须有可观测信号，空 channel 不能静默跳过"
     lesson: "2026-04-07: 空 channel ID 静默跳过，消息消失无痕迹"
@@ -229,6 +292,7 @@ invariants:
   - id: INV-ENV-001
     name: required-env-vars-in-preflight
     meta_rule: MR-2
+    verification_layer: [declaration, runtime]
     severity: high
     declaration: "registry needs_api_key 字段被代码消费，不是死文档"
     checks:
@@ -250,6 +314,7 @@ invariants:
   - id: INV-HEALTH-001
     name: health-fields-freshness
     meta_rule: MR-5
+    verification_layer: [declaration]
     severity: high
     declaration: "status.json health 字段有自动刷新 + 时间戳"
     checks:
@@ -265,6 +330,7 @@ invariants:
   - id: INV-HEALTH-002
     name: service-health-validates-content
     meta_rule: MR-2
+    verification_layer: [declaration, runtime]
     severity: high
     declaration: "services: ok 必须验证响应 body，不只是 HTTP 200"
     checks:
@@ -286,6 +352,7 @@ invariants:
   - id: INV-DEPLOY-001
     name: file-map-completeness
     meta_rule: MR-2
+    verification_layer: [declaration]
     severity: medium
     declaration: "未部署文件必须显式声明为不需要部署"
     checks:
@@ -297,6 +364,7 @@ invariants:
   - id: INV-DEPLOY-002
     name: auto-deploy-never-modifies-crontab
     meta_rule: MR-3
+    verification_layer: [declaration]
     severity: critical
     declaration: "auto_deploy 不改 crontab → 必须有漂移检测兜底"
     design_decision: "crontab 变更需人工确认（安全考虑），漂移检测是安全网"
@@ -329,6 +397,7 @@ invariants:
   - id: INV-CRON-003
     name: bash-lc-enforcement
     meta_rule: MR-1
+    verification_layer: [runtime]
     severity: critical
     declaration: "每个 enabled job 的 crontab 条目必须包含 bash -lc（否则 cron 环境缺少 env vars）"
     design_decision: "2026-04-08 教训：DBLP/Dream/Watchdog 无 bash -lc → OPENCLAW_PHONE 为占位号 → 推送连续失败 3 天"
@@ -359,6 +428,7 @@ invariants:
   - id: INV-CRON-004
     name: crontab-no-duplicates
     meta_rule: MR-3
+    verification_layer: [runtime]
     severity: high
     declaration: "每个 job 在 crontab 中最多出现一次（重复条目导致并发执行和资源浪费）"
     design_decision: "2026-04-08 教训：kb_dream 有 3 个 crontab 条目，双进程启动触发 lock contention"
@@ -391,6 +461,7 @@ invariants:
   - id: INV-ENV-002
     name: cron-env-smoke-test
     meta_rule: MR-1
+    verification_layer: [runtime]
     severity: critical
     declaration: "cron 环境（bash -lc）中 OPENCLAW_PHONE 必须是真实号码，非占位号"
     design_decision: "2026-04-08 教训：cron 无 bash -lc 时 OPENCLAW_PHONE 为 +85200000000（占位号），所有 WhatsApp 推送静默失败"
@@ -445,16 +516,30 @@ meta_rule_discovery:
     match_against: "_notify_discord_target_for_topic() case 分支"
     severity_when_missing: warn
 
+  - id: MRD-LAYER-001
+    meta_rule: MR-6
+    name: "severity=critical 的不变式应有 ≥2 层验证深度"
+    description: |
+      扫描所有 severity=critical 的不变式，检查 verification_layer 是否包含
+      ≥2 个层（如 [declaration, runtime]）。单层覆盖的 critical 不变式 = 虚假安全感。
+    scan_source: "governance_ontology.yaml invariants"
+    scan_filter: "severity == 'critical' and len(verification_layer) < 2"
+    severity_when_missing: warn
+    lesson: "2026-04-08: 声明层 12/12 全过但推送失败 3 天——单层检查的虚假安全感"
+
 # ═══════════════════════════════════════════════════════════════════════
 # 5. 审计元数据
 # ═══════════════════════════════════════════════════════════════════════
 audit_metadata:
-  version: "2.1"
+  version: "3.0"
   created: "2026-04-07"
-  upgraded: "v2.0 可执行检查 → v2.1 元规则自动发现 (Phase 0: 结构化数据源)"
-  total_checks: 28
-  meta_rule_discovery_count: 3   # Phase 0: registry + env + notify
+  upgraded: "v2.1 → v3.0: 验证深度三层模型 + MR-6 多层覆盖要求 + MRD-LAYER-001 深度盲区自动发现"
+  total_invariants: 15
+  total_checks: 32
+  meta_rules: 6         # MR-1~MR-6
+  meta_rule_discovery_count: 4   # Phase 0: registry + env + notify + layer depth
   check_types_used: [python_assert, file_contains, file_not_contains, env_var_exists, command_succeeds]
+  verification_layers_used: [declaration, runtime]  # effect 层待建设
 
   phase_roadmap:
     phase_0: "结构化数据源（jobs_registry.yaml）← 当前"

--- a/ontology/governance_ontology.yaml
+++ b/ontology/governance_ontology.yaml
@@ -380,7 +380,10 @@ invariants:
               sname = entry.split('/')[-1] if entry else ''
               if not sname:
                   continue
-              count = sum(1 for l in lines if sname in l)
+              count = 0
+              for l in lines:
+                  if sname in l:
+                      count += 1
               if count > 1:
                   dupes.append(f"{job['id']} x{count}")
           assert not dupes, f"重复 crontab: {'; '.join(dupes)}"

--- a/ontology/governance_ontology.yaml
+++ b/ontology/governance_ontology.yaml
@@ -372,15 +372,18 @@ invariants:
           data = load_yaml("jobs_registry.yaml")
           crontab = subprocess.check_output(['crontab', '-l'], text=True)
           lines = [l for l in crontab.splitlines() if l.strip() and not l.strip().startswith('#')]
+          dupes = []
           for job in data['jobs']:
               if not job.get('enabled') or job.get('scheduler') != 'system':
                   continue
               entry = job.get('entry', '')
-              script = entry.split('/')[-1] if entry else ''
-              if not script:
+              sname = entry.split('/')[-1] if entry else ''
+              if not sname:
                   continue
-              hits = [l for l in lines if script in l]
-              assert len(hits) <= 1, f"{job['id']} ({script}) 在 crontab 中出现 {len(hits)} 次"
+              count = sum(1 for l in lines if sname in l)
+              if count > 1:
+                  dupes.append(f"{job['id']} x{count}")
+          assert not dupes, f"重复 crontab: {'; '.join(dupes)}"
 
   - id: INV-ENV-002
     name: cron-env-smoke-test

--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -242,6 +242,21 @@ def filter_tools(tools, log_fn=None):
         new_tools = gateway[:_CFG_MAX_TOOLS - len(custom)] + custom
 
     kept_names = [t.get("function", {}).get("name") for t in new_tools]
+
+    # 语义观察：ontology 对每个通过的工具提供语义分类
+    # 不改变过滤行为，只产生语义信号供日志和未来策略使用
+    if _onto_engine and log_fn:
+        try:
+            high_risk = []
+            for name in kept_names:
+                cl = _onto_engine.classify_tool_call(name)
+                if cl.get("risk_level") == "high":
+                    high_risk.append(name)
+            if high_risk:
+                log_fn(f"ONTO: {len(high_risk)} high-risk tools: {','.join(high_risk)}")
+        except Exception:
+            pass  # 语义观察失败不影响主流程
+
     return new_tools, all_names, kept_names
 
 
@@ -351,13 +366,19 @@ if _ONTOLOGY_MODE:
                 "ONTOLOGY_MODE=on: loaded %d tools from ontology/tool_ontology.yaml",
                 len(ALLOWED_TOOLS))
 
-            # 清理临时变量
-            del _spec, _mod, _onto, _data
+            # 保留引擎实例供语义观察使用
+            _onto_engine = _onto
+
+            # 清理其他临时变量
+            del _spec, _mod, _data
     except Exception as _e:
         import logging as _log
         _log.getLogger("proxy_filters").warning(
             "ONTOLOGY_MODE=on but load failed, falling back to hardcoded: %s", _e)
         # 硬编码变量未被修改，安全回退
+
+# 语义引擎实例（ONTOLOGY_MODE=on 时可用，否则 None）
+_onto_engine = locals().get("_onto_engine") if _ONTOLOGY_MODE else None
 
 
 # [NO_TOOLS] 标记：消息中包含此标记时，proxy 强制清空工具列表

--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -25,12 +25,13 @@ from config_loader import (
 )
 
 # ---------------------------------------------------------------------------
-# Phase 1: Ontology 特性开关（默认 off = 使用硬编码，完全等价于改动前）
-# ONTOLOGY_MODE=on 时从 ontology/tool_ontology.yaml 加载数据
-# 任何加载失败自动回退到硬编码，等价于开关 off
-# 回退方式：ONTOLOGY_MODE=off 或 rm -rf ontology/
+# Ontology 特性开关（三档渐进切换）
+# off    — 纯硬编码，ontology 不加载（默认）
+# shadow — 双跑比对：硬编码做决策，引擎在旁边比对，差异记日志（Phase 2）
+# on     — 引擎数据替换硬编码（Phase 1，已验证等价性）
+# 任何加载失败自动回退到 off
 # ---------------------------------------------------------------------------
-_ONTOLOGY_MODE = os.environ.get("ONTOLOGY_MODE", "off").lower() == "on"
+_ONTOLOGY_MODE = os.environ.get("ONTOLOGY_MODE", "off").lower()  # "off" | "shadow" | "on"
 
 # ---------------------------------------------------------------------------
 # 配置数据（硬编码 — 始终定义，作为基线和回退）
@@ -243,8 +244,30 @@ def filter_tools(tools, log_fn=None):
 
     kept_names = [t.get("function", {}).get("name") for t in new_tools]
 
+    # Shadow 比对：引擎 vs 硬编码产生相同结果吗？
+    if _onto_shadow_data and log_fn:
+        try:
+            shadow_allowed = _onto_shadow_data["ALLOWED_TOOLS"]
+            shadow_prefixes = _onto_shadow_data["ALLOWED_PREFIXES"]
+            # 用引擎数据重新过滤同一批工具
+            shadow_kept = []
+            for t in tools:
+                name = t.get("function", {}).get("name", "")
+                if name in shadow_allowed:
+                    shadow_kept.append(name)
+                elif any(name.startswith(p) for p in shadow_prefixes):
+                    shadow_kept.append(name)
+            # 比对：硬编码 kept vs 引擎 kept（不含 custom tools）
+            hc_set = {n for n in kept_names if n not in CUSTOM_TOOL_NAMES}
+            eng_set = set(shadow_kept)
+            if hc_set != eng_set:
+                only_hc = hc_set - eng_set
+                only_eng = eng_set - hc_set
+                log_fn(f"ONTO SHADOW DRIFT: hardcoded_only={only_hc or '{}'} engine_only={only_eng or '{}'}")
+        except Exception:
+            pass  # shadow 比对失败不影响主流程
+
     # 语义观察：ontology 对每个通过的工具提供语义分类
-    # 不改变过滤行为，只产生语义信号供日志和未来策略使用
     if _onto_engine and log_fn:
         try:
             high_risk = []
@@ -337,10 +360,13 @@ CUSTOM_TOOL_NAMES = {t["function"]["name"] for t in CUSTOM_TOOLS}
 
 
 # ---------------------------------------------------------------------------
-# Phase 1: Ontology 数据覆盖（仅 ONTOLOGY_MODE=on 时生效）
-# 回退逻辑：加载失败 → 保留上方硬编码不变 → 等价于开关 off
+# Ontology 引擎加载（shadow / on 模式）
+# 回退逻辑：加载失败 → 保留上方硬编码不变 → 等价于 off
 # ---------------------------------------------------------------------------
-if _ONTOLOGY_MODE:
+_onto_engine = None
+_onto_shadow_data = None  # shadow 模式用：引擎生成的数据（不覆盖硬编码）
+
+if _ONTOLOGY_MODE in ("on", "shadow"):
     try:
         import importlib.util as _imp_util
         _onto_engine_path = os.path.join(
@@ -352,33 +378,37 @@ if _ONTOLOGY_MODE:
             _onto = _mod.ToolOntology()
             _data = _onto.generate_proxy_data()
 
-            # 覆盖硬编码（只有全部生成成功才覆盖）
-            ALLOWED_TOOLS = _data["ALLOWED_TOOLS"]
-            ALLOWED_PREFIXES = _data["ALLOWED_PREFIXES"]
-            CLEAN_SCHEMAS = _data["CLEAN_SCHEMAS"]
-            TOOL_PARAMS = _data["TOOL_PARAMS"]
-            CUSTOM_TOOLS = _data["CUSTOM_TOOLS"]
-            CUSTOM_TOOL_NAMES = _data["CUSTOM_TOOL_NAMES"]
-            VALID_BROWSER_PROFILES = _data["VALID_BROWSER_PROFILES"]
-
-            import logging as _log
-            _log.getLogger("proxy_filters").info(
-                "ONTOLOGY_MODE=on: loaded %d tools from ontology/tool_ontology.yaml",
-                len(ALLOWED_TOOLS))
-
-            # 保留引擎实例供语义观察使用
             _onto_engine = _onto
 
-            # 清理其他临时变量
+            if _ONTOLOGY_MODE == "on":
+                # Phase 1: 覆盖硬编码
+                ALLOWED_TOOLS = _data["ALLOWED_TOOLS"]
+                ALLOWED_PREFIXES = _data["ALLOWED_PREFIXES"]
+                CLEAN_SCHEMAS = _data["CLEAN_SCHEMAS"]
+                TOOL_PARAMS = _data["TOOL_PARAMS"]
+                CUSTOM_TOOLS = _data["CUSTOM_TOOLS"]
+                CUSTOM_TOOL_NAMES = _data["CUSTOM_TOOL_NAMES"]
+                VALID_BROWSER_PROFILES = _data["VALID_BROWSER_PROFILES"]
+
+                import logging as _log
+                _log.getLogger("proxy_filters").info(
+                    "ONTOLOGY_MODE=on: loaded %d tools from engine",
+                    len(ALLOWED_TOOLS))
+            else:
+                # Phase 2 shadow: 保留引擎数据但不覆盖硬编码
+                _onto_shadow_data = _data
+                import logging as _log
+                _log.getLogger("proxy_filters").info(
+                    "ONTOLOGY_MODE=shadow: engine loaded (%d tools), "
+                    "hardcoded active, comparing at runtime",
+                    len(_data["ALLOWED_TOOLS"]))
+
             del _spec, _mod, _data
     except Exception as _e:
         import logging as _log
         _log.getLogger("proxy_filters").warning(
-            "ONTOLOGY_MODE=on but load failed, falling back to hardcoded: %s", _e)
-        # 硬编码变量未被修改，安全回退
-
-# 语义引擎实例（ONTOLOGY_MODE=on 时可用，否则 None）
-_onto_engine = locals().get("_onto_engine") if _ONTOLOGY_MODE else None
+            "ONTOLOGY_MODE=%s but load failed, falling back to hardcoded: %s",
+            _ONTOLOGY_MODE, _e)
 
 
 # [NO_TOOLS] 标记：消息中包含此标记时，proxy 强制清空工具列表


### PR DESCRIPTION
## Summary
- **5 bug fixes**: smoke test python3 detection (homebrew Killed:9), notify.sh zsh queue drain, stderr visibility, UTF-8 locale
- **3 runtime invariants** (INV-CRON-003/004, INV-ENV-002): governance从声明层扩展到运行时层
- **Verification Depth Model v3**: governance自我意识盲区深度（声明/运行时/效果三层）
- **Semantic observation**: engine.classify_tool_call() 从属性推理风险等级和策略标签
- **Phase 2 shadow mode**: ONTOLOGY_MODE=shadow 双跑比对，为生产切换积累证据

## Key Changes

### Bug Fixes
- `job_smoke_test.sh`: detect working python3 (homebrew gets SIGKILL on macOS), show stderr on failure, UTF-8 locale
- `notify.sh`: queue drain `for f in $qfiles` fails in zsh (no word-split), switched to `while read`

### Governance v3 (12→15 invariants)
- INV-CRON-003: every crontab entry must have `bash -lc` (env vars)
- INV-CRON-004: no duplicate crontab entries per job
- INV-ENV-002: OPENCLAW_PHONE must be real number in cron env
- MR-6: critical invariants need ≥2 verification layers
- MRD-LAYER-001: auto-discovers single-layer critical invariants

### Ontology Semantic Engine
- `classify_tool_call()`: infers risk_level + policy_tags from properties
- Shadow comparison in `filter_tools()`: logs any drift between engine and hardcoded
- Three-mode feature flag: `off` → `shadow` → `on`

## Test plan
- [x] 832 unit tests pass (0 failures)
- [x] governance_checker --full: 15/15 invariants, 32/32 checks (Mac Mini verified)
- [x] adversarial_audit --full: 9/9 pass
- [x] Three ONTOLOGY_MODE modes verified (off/shadow/on)
- [ ] `bash preflight_check.sh --full` (Mac Mini after sync)
- [ ] Set ONTOLOGY_MODE=shadow and observe for drift

https://claude.ai/code/session_01CHUYbEh7oe612yVWES1LwX