### PR TITLE
ops: enable ONTOLOGY_MODE=shadow by default

### DIFF
--- a/proxy_filters.py
+++ b/proxy_filters.py
@@ -31,7 +31,7 @@ from config_loader import (
 # on     — 引擎数据替换硬编码（Phase 1，已验证等价性）
 # 任何加载失败自动回退到 off
 # ---------------------------------------------------------------------------
-_ONTOLOGY_MODE = os.environ.get("ONTOLOGY_MODE", "off").lower()  # "off" | "shadow" | "on"
+_ONTOLOGY_MODE = os.environ.get("ONTOLOGY_MODE", "shadow").lower()  # "off" | "shadow" | "on"
 
 # ---------------------------------------------------------------------------
 # 配置数据（硬编码 — 始终定义，作为基线和回退）


### PR DESCRIPTION
## Summary
- Change ONTOLOGY_MODE default from `"off"` to `"shadow"` in proxy_filters.py
- Env vars don't propagate to launchd-managed services — code default is more reliable

## Impact
- **Zero behavior change**: shadow mode uses hardcoded for all decisions
- Engine runs alongside and logs any drift (`ONTO SHADOW DRIFT` in proxy log)
- Semantic observation logs high-risk tools per request

## Rollback
Change `"shadow"` back to `"off"` in proxy_filters.py line 33.

https://claude.ai/code/session_01CHUYbEh7oe612yVWES1LwX