### PR TITLE
ops: stop auto-pushing status.json to git — eliminate PR conflicts

### DIFF
--- a/kb_status_refresh.sh
+++ b/kb_status_refresh.sh
@@ -306,10 +306,12 @@ if [ -d "$REPO_DIR/.git" ] && [ -f "$HOME/.kb/status.json" ]; then
         cp "$SOUL_SRC" "$SOUL_DST"
     fi
 
-    # 仅在 status.json 有变化时才提交（SOUL.md 由 Claude Code 管理，不自动提交）
+    # V36.3: 停止自动 push status.json 到 git
+    # 原因：每小时 auto commit 导致每个 PR 必冲突（2026-04-08 一天解决 3 次）
+    # health 字段是信息性的，Claude Code 看到过期几小时不影响开发决策
+    # ~/.kb/status.json（本地）仍由 cron 每小时刷新，PA 和脚本不受影响
+    # repo status.json 改由 Claude Code session 收工时更新
     if ! git diff --quiet "$REPO_STATUS" 2>/dev/null; then
-        git add status.json
-        git commit -m "auto: sync status.json from kb_status_refresh" --no-gpg-sign 2>/dev/null || true
-        git push origin main 2>/dev/null || echo "[$TS] WARN: push failed (will retry next hour)"
+        git checkout -- "$REPO_STATUS" 2>/dev/null || true  # 丢弃本地变更，保持 repo 干净
     fi
 fi


### PR DESCRIPTION
kb_status_refresh.sh no longer commits/pushes status.json to main. Root cause: hourly auto-commits caused merge conflicts on every PR (resolved manually 3 times on 2026-04-08 alone).

What changes:
- ~/.kb/status.json still refreshed hourly by cron (PA + scripts unaffected)
- Repo status.json now only updated by Claude Code sessions (open/close)
- git checkout reverts any local repo changes to keep working tree clean

What doesn't change:
- priorities, recent_changes, session_context (Claude Code writes these)
- SOUL.md sync (repo → workspace, unchanged)
- Health monitoring (local status.json, unchanged)

Trade-off: Claude Code may see stale health data (hours old) at session start. Acceptable — health fields are informational, not decisional.

https://claude.ai/code/session_01CHUYbEh7oe612yVWES1LwX

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
