### PR TITLE
feat(V3): Provider Plugin Interface — add without modifying core code

### DIFF
--- a/docs/provider_plugin_guide.md
+++ b/docs/provider_plugin_guide.md
@@ -1,0 +1,305 @@
+# Provider Plugin Guide
+
+> How to add a new LLM provider to OpenClaw Model Bridge without modifying core code.
+
+## Overview
+
+The Provider Plugin Interface allows you to add new LLM providers by dropping a
+file into the `providers.d/` directory. No core code changes required.
+
+Two formats are supported:
+
+| Format | Use When | Complexity |
+|--------|----------|------------|
+| **YAML** | Standard OpenAI-compatible API (90% of cases) | Drop a file |
+| **Python** | Custom auth, special headers, dynamic behavior | Write a class |
+
+## Quick Start: Add a Provider in 60 Seconds
+
+### Option A: YAML (Recommended)
+
+Create `providers.d/deepseek.yaml`:
+
+```yaml
+name: deepseek
+display_name: DeepSeek
+base_url: https://api.deepseek.com/v1
+api_key_env: DEEPSEEK_API_KEY
+auth_style: bearer
+
+models:
+  - model_id: deepseek-chat
+    display_name: DeepSeek V3 (671B MoE)
+    modalities: [text]
+    context_window: 65536
+    max_output_tokens: 8192
+    is_default: true
+
+capabilities:
+  text: true
+  tool_calling: true
+  streaming: true
+  json_mode: true
+  context_window: 65536
+  max_output_tokens: 8192
+```
+
+Set the API key:
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+Verify:
+```bash
+python3 providers.py --validate
+```
+
+### Option B: Python (Custom Auth)
+
+Create `providers.d/custom.py`:
+
+```python
+from providers import BaseProvider, ModelInfo, ProviderCapabilities
+
+class CustomProvider(BaseProvider):
+    name = "custom"
+    display_name = "Custom Provider"
+    base_url = "https://api.custom.com/v1"
+    api_key_env = "CUSTOM_API_KEY"
+    auth_style = "custom"
+    models = [
+        ModelInfo(
+            model_id="custom-v1",
+            display_name="Custom Model V1",
+            modalities=["text"],
+            context_window=32768,
+            max_output_tokens=4096,
+            is_default=True,
+        ),
+    ]
+    capabilities = ProviderCapabilities(
+        text=True,
+        tool_calling=True,
+        streaming=True,
+    )
+
+    def make_auth_headers(self, api_key: str):
+        """Override for non-standard authentication."""
+        return {"X-Custom-Auth": f"Token {api_key}"}
+```
+
+## Provider Contract
+
+Every provider must satisfy these requirements:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `name` | Yes | — | Unique identifier (lowercase, no spaces) |
+| `base_url` | Yes | — | API endpoint URL |
+| `api_key_env` | Yes | — | Environment variable for the API key |
+| `models` | Yes (>=1) | — | At least one model definition |
+| `display_name` | No | `name` | Human-readable name |
+| `auth_style` | No | `"bearer"` | `"bearer"`, `"x-api-key"`, `"query-param"`, or `"custom"` |
+| `capabilities` | No | text-only | Feature declarations |
+
+### Model Fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `model_id` | Yes | — | Model identifier sent to the API |
+| `display_name` | No | `""` | Human-readable name |
+| `modalities` | No | `["text"]` | Supported modalities: `text`, `vision`, `audio`, `video` |
+| `context_window` | No | `0` | Max context tokens |
+| `max_output_tokens` | No | `0` | Max output tokens |
+| `is_default` | No | `false` | Primary model (only one per provider) |
+| `is_vision` | No | `false` | Dedicated vision model |
+
+### Capability Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | bool | Text generation |
+| `vision` | bool | Image understanding (requires a vision-capable model) |
+| `audio` | bool | Audio processing |
+| `video` | bool | Video processing |
+| `tool_calling` | bool | Function/tool calling |
+| `streaming` | bool | SSE streaming |
+| `json_mode` | bool | Structured JSON output |
+| `context_window` | int | Max context tokens (provider-level) |
+| `max_output_tokens` | int | Max output tokens (provider-level) |
+
+### Contract Validation Rules
+
+1. `name` must be non-empty
+2. `base_url` must be non-empty
+3. `api_key_env` must be non-empty
+4. At least one model with a non-empty `model_id`
+5. At most one model with `is_default: true`
+6. `auth_style` must be one of the recognized values
+7. If `capabilities.vision` is true, at least one model must support vision
+
+Run `python3 providers.py --validate` to check all providers.
+
+## File Naming Rules
+
+| Pattern | Behavior |
+|---------|----------|
+| `providers.d/deepseek.yaml` | Auto-discovered and loaded |
+| `providers.d/custom.py` | Auto-discovered and loaded |
+| `providers.d/_example.yaml` | Skipped (starts with `_`) |
+| `providers.d/.hidden.yaml` | Skipped (starts with `.`) |
+| `providers.d/readme.txt` | Skipped (not `.yaml`/`.yml`/`.py`) |
+
+## Integration with the System
+
+### How It Works
+
+```
+providers.py (import time)
+    |
+    +-- Register 7 built-in providers (Qwen, OpenAI, Gemini, Claude, Kimi, MiniMax, GLM)
+    |
+    +-- Scan providers.d/ for plugin files
+    |    +-- Load each .yaml/.yml/.py file
+    |    +-- Validate against ProviderContract
+    |    +-- Skip files that conflict with built-in names
+    |    +-- Register valid plugins
+    |
+    +-- Export PROVIDERS dict (built-in + plugins)
+         |
+         +-- adapter.py imports PROVIDERS → routing includes your provider
+```
+
+### Using Your Provider
+
+After adding a plugin, set it as the active provider:
+
+```bash
+# As primary provider
+export PROVIDER_NAME=deepseek
+export DEEPSEEK_API_KEY="sk-..."
+
+# As fallback provider
+export FALLBACK_PROVIDER=deepseek
+export DEEPSEEK_API_KEY="sk-..."
+```
+
+### Compatibility Matrix
+
+Your provider automatically appears in the compatibility matrix:
+
+```bash
+python3 providers.py          # Markdown table
+python3 providers.py --json   # JSON format
+```
+
+## Advanced: Python Plugin Features
+
+### Custom Authentication
+
+Override `make_auth_headers()` for non-standard auth:
+
+```python
+def make_auth_headers(self, api_key: str):
+    import hashlib, time
+    ts = str(int(time.time()))
+    sig = hashlib.sha256(f"{api_key}:{ts}".encode()).hexdigest()
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "X-Timestamp": ts,
+        "X-Signature": sig,
+    }
+```
+
+### Multiple Models with Vision
+
+```python
+models = [
+    ModelInfo(
+        model_id="my-text-v1",
+        display_name="Text Model",
+        modalities=["text"],
+        context_window=128000,
+        is_default=True,
+    ),
+    ModelInfo(
+        model_id="my-vision-v1",
+        display_name="Vision Model",
+        modalities=["text", "vision"],
+        context_window=32768,
+        is_vision=True,
+    ),
+]
+```
+
+## Troubleshooting
+
+### Plugin not loading?
+
+```bash
+# Check for errors
+python3 providers.py --validate
+
+# Check if providers.d/ exists
+ls providers.d/
+
+# Check file naming (no leading _ or .)
+ls -la providers.d/
+```
+
+### Name conflict?
+
+Plugin names must be unique and cannot override built-in providers.
+If you need to replace a built-in, modify `providers.py` directly.
+
+### Missing PyYAML?
+
+```bash
+pip3 install pyyaml
+```
+
+### Contract violation?
+
+Run `--validate` to see specific violations:
+
+```
+$ python3 providers.py --validate
+FAIL myprov (providers.d/myprov.yaml): name is required; at least one model is required
+```
+
+## API Reference
+
+### Classes
+
+| Class | Purpose |
+|-------|---------|
+| `BaseProvider` | Base class for all providers |
+| `ModelInfo` | Model metadata (dataclass) |
+| `ProviderCapabilities` | Feature declarations (dataclass) |
+| `ProviderContract` | Contract validation |
+| `PluginLoader` | YAML/Python plugin loading |
+| `ProviderRegistry` | Registration and discovery |
+| `ContractViolationError` | Raised on contract failure |
+
+### Key Functions
+
+```python
+from providers import get_registry, get_provider, PROVIDERS
+
+# Get the registry (includes built-in + plugins)
+registry = get_registry()
+
+# Get a specific provider
+provider = get_provider("deepseek")
+
+# Legacy dict (backward compatible with adapter.py)
+providers_dict = PROVIDERS
+```
+
+### CLI
+
+```bash
+python3 providers.py              # Compatibility matrix (Markdown)
+python3 providers.py --json        # Compatibility matrix (JSON)
+python3 providers.py --validate    # Contract validation for all providers
+```

--- a/providers.d/_example.yaml
+++ b/providers.d/_example.yaml
@@ -1,0 +1,50 @@
+# Example Provider Plugin (YAML format)
+#
+# To add a new provider, copy this file, remove the leading '_',
+# and fill in your provider details. The file will be auto-discovered
+# when providers.py is imported.
+#
+# Filename: <provider-name>.yaml (e.g., deepseek.yaml)
+# Files starting with '_' or '.' are ignored.
+#
+# Required fields:
+#   - name: unique identifier (lowercase, no spaces)
+#   - base_url: API endpoint (OpenAI-compatible /v1 format)
+#   - api_key_env: environment variable holding the API key
+#   - models: at least one model with a model_id
+#
+# Optional fields:
+#   - display_name: human-readable name (defaults to name)
+#   - auth_style: "bearer" (default) | "x-api-key" | "query-param" | "custom"
+#   - capabilities: feature declarations for routing and fallback
+#
+# --- Example: DeepSeek ---
+#
+# name: deepseek
+# display_name: DeepSeek
+# base_url: https://api.deepseek.com/v1
+# api_key_env: DEEPSEEK_API_KEY
+# auth_style: bearer
+#
+# models:
+#   - model_id: deepseek-chat
+#     display_name: DeepSeek V3 (671B MoE)
+#     modalities: [text]
+#     context_window: 65536
+#     max_output_tokens: 8192
+#     is_default: true
+#
+#   - model_id: deepseek-reasoner
+#     display_name: DeepSeek R1
+#     modalities: [text]
+#     context_window: 65536
+#     max_output_tokens: 8192
+#
+# capabilities:
+#   text: true
+#   vision: false
+#   tool_calling: true
+#   streaming: true
+#   json_mode: true
+#   context_window: 65536
+#   max_output_tokens: 8192

--- a/providers.d/_example_provider.py
+++ b/providers.d/_example_provider.py
@@ -1,0 +1,49 @@
+# Example Provider Plugin (Python format)
+#
+# Use Python plugins when you need:
+#   - Custom authentication (non-standard headers)
+#   - Special request/response handling
+#   - Dynamic model discovery
+#
+# Requirements:
+#   - Define exactly ONE class inheriting from BaseProvider
+#   - Set all required class attributes (name, base_url, api_key_env, models)
+#   - File must NOT start with '_' or '.' to be auto-discovered
+#
+# To use: copy this file, remove the leading '_', and customize.
+#
+# from providers import BaseProvider, ModelInfo, ProviderCapabilities
+#
+#
+# class MyCustomProvider(BaseProvider):
+#     name = "custom"
+#     display_name = "My Custom Provider"
+#     base_url = "https://api.custom.example.com/v1"
+#     api_key_env = "CUSTOM_API_KEY"
+#     auth_style = "custom"
+#     models = [
+#         ModelInfo(
+#             model_id="custom-v1",
+#             display_name="Custom Model V1",
+#             modalities=["text"],
+#             context_window=32768,
+#             max_output_tokens=4096,
+#             is_default=True,
+#         ),
+#     ]
+#     capabilities = ProviderCapabilities(
+#         text=True,
+#         tool_calling=True,
+#         streaming=True,
+#     )
+#
+#     def make_auth_headers(self, api_key: str):
+#         """Custom authentication — e.g., HMAC signing."""
+#         import hashlib, time
+#         timestamp = str(int(time.time()))
+#         signature = hashlib.sha256(f"{api_key}:{timestamp}".encode()).hexdigest()
+#         return {
+#             "X-Api-Key": api_key,
+#             "X-Timestamp": timestamp,
+#             "X-Signature": signature,
+#         }

--- a/providers.py
+++ b/providers.py
@@ -12,9 +12,14 @@ providers.py — Provider Compatibility Layer (V34: Stage2)
 - 能力声明：每个 Provider 显式声明支持的功能，而非运行时探测
 - 可扩展：新 Provider 只需继承 BaseProvider 并注册
 """
+import importlib.util
+import logging
 import os
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +164,226 @@ class BaseProvider:
             "auth_style": self.auth_style,
             "verified": caps.verified_features(),
         }
+
+
+# ---------------------------------------------------------------------------
+# Provider Contract — registration-time validation
+# ---------------------------------------------------------------------------
+class ProviderContract:
+    """Validates that a provider meets the minimum contract requirements.
+
+    The contract ensures every registered provider has:
+    - A unique name
+    - A valid base_url
+    - An api_key_env pointing to the credential
+    - At least one model with a model_id
+    - A recognized auth_style
+    - Consistent capability declarations
+    """
+    VALID_AUTH_STYLES = {"bearer", "x-api-key", "query-param", "custom"}
+
+    @classmethod
+    def validate(cls, provider: BaseProvider) -> List[str]:
+        """Validate provider contract. Returns list of violations (empty = valid)."""
+        violations = []
+        if not getattr(provider, 'name', ''):
+            violations.append("name is required")
+        if not getattr(provider, 'base_url', ''):
+            violations.append("base_url is required")
+        if not getattr(provider, 'api_key_env', ''):
+            violations.append("api_key_env is required")
+        models = getattr(provider, 'models', [])
+        if not models:
+            violations.append("at least one model is required")
+        else:
+            for i, m in enumerate(models):
+                if not getattr(m, 'model_id', ''):
+                    violations.append(f"models[{i}].model_id is required")
+            defaults = [m for m in models if getattr(m, 'is_default', False)]
+            if len(defaults) > 1:
+                violations.append(f"only one model can be is_default (found {len(defaults)})")
+        auth = getattr(provider, 'auth_style', 'bearer')
+        if auth not in cls.VALID_AUTH_STYLES:
+            violations.append(f"auth_style '{auth}' not in {sorted(cls.VALID_AUTH_STYLES)}")
+        caps = getattr(provider, 'capabilities', None)
+        if caps and getattr(caps, 'vision', False) and models:
+            has_vision_model = any(
+                getattr(m, 'is_vision', False) or 'vision' in getattr(m, 'modalities', [])
+                for m in models
+            )
+            if not has_vision_model:
+                violations.append("capabilities declares vision=True but no model supports vision")
+        return violations
+
+
+class ContractViolationError(ValueError):
+    """Raised when a provider fails contract validation."""
+    def __init__(self, provider_name: str, violations: List[str]):
+        self.provider_name = provider_name
+        self.violations = violations
+        msg = f"Provider '{provider_name}' contract violations: {'; '.join(violations)}"
+        super().__init__(msg)
+
+
+# ---------------------------------------------------------------------------
+# Plugin Loader — discover and load providers from YAML/Python files
+# ---------------------------------------------------------------------------
+class PluginLoader:
+    """Load provider plugins from YAML definitions or Python modules.
+
+    Supports two formats:
+    - YAML (.yaml/.yml): Declarative provider definition, no code needed.
+      Covers 90% of use cases (OpenAI-compatible providers).
+    - Python (.py): For providers needing custom auth or special behavior.
+      Must export exactly one BaseProvider subclass.
+
+    Files starting with '_' or '.' are skipped (reserved for examples/hidden).
+    """
+
+    @classmethod
+    def from_yaml(cls, path: str) -> BaseProvider:
+        """Load a provider from a YAML definition file.
+
+        YAML format:
+            name: deepseek
+            display_name: DeepSeek
+            base_url: https://api.deepseek.com/v1
+            api_key_env: DEEPSEEK_API_KEY
+            auth_style: bearer          # optional, default: bearer
+            models:
+              - model_id: deepseek-chat
+                display_name: DeepSeek V3
+                modalities: [text]
+                context_window: 65536
+                max_output_tokens: 8192
+                is_default: true
+            capabilities:               # optional
+              text: true
+              tool_calling: true
+              streaming: true
+        """
+        try:
+            import yaml
+        except ImportError:
+            raise ImportError("PyYAML is required for YAML plugins: pip3 install pyyaml")
+
+        with open(path, 'r') as f:
+            data = yaml.safe_load(f)
+
+        if not isinstance(data, dict):
+            raise ValueError(f"YAML plugin must be a dict, got {type(data).__name__}")
+
+        return cls._dict_to_provider(data, source=path)
+
+    @classmethod
+    def _dict_to_provider(cls, data: dict, source: str = "") -> BaseProvider:
+        """Convert a dict (from YAML or JSON) to a BaseProvider instance."""
+        # Build models
+        models = []
+        for md in data.get('models', []):
+            models.append(ModelInfo(
+                model_id=md.get('model_id', ''),
+                display_name=md.get('display_name', ''),
+                modalities=md.get('modalities', ['text']),
+                context_window=md.get('context_window', 0),
+                max_output_tokens=md.get('max_output_tokens', 0),
+                is_default=md.get('is_default', False),
+                is_vision=md.get('is_vision', False),
+            ))
+
+        # Build capabilities
+        caps_data = data.get('capabilities', {})
+        caps = ProviderCapabilities(
+            text=caps_data.get('text', True),
+            vision=caps_data.get('vision', False),
+            audio=caps_data.get('audio', False),
+            video=caps_data.get('video', False),
+            tool_calling=caps_data.get('tool_calling', False),
+            streaming=caps_data.get('streaming', False),
+            json_mode=caps_data.get('json_mode', False),
+            context_window=caps_data.get('context_window', 0),
+            max_output_tokens=caps_data.get('max_output_tokens', 0),
+        )
+
+        # Create provider instance
+        provider = BaseProvider()
+        provider.name = data.get('name', '')
+        provider.display_name = data.get('display_name', provider.name)
+        provider.base_url = data.get('base_url', '')
+        provider.api_key_env = data.get('api_key_env', '')
+        provider.auth_style = data.get('auth_style', 'bearer')
+        provider.models = models
+        provider.capabilities = caps
+        provider._plugin_source = source
+        return provider
+
+    @classmethod
+    def from_python(cls, path: str) -> BaseProvider:
+        """Load a provider from a Python module.
+
+        The module must define exactly one class that inherits from BaseProvider.
+        The class is instantiated with no arguments.
+        """
+        module_name = Path(path).stem
+        spec = importlib.util.spec_from_file_location(
+            f"provider_plugin_{module_name}", path
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load Python plugin: {path}")
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        # Find BaseProvider subclasses defined in this module
+        candidates = []
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+            if (isinstance(attr, type)
+                    and issubclass(attr, BaseProvider)
+                    and attr is not BaseProvider
+                    and attr.__module__ == module.__name__):
+                candidates.append(attr)
+
+        if not candidates:
+            raise ValueError(f"No BaseProvider subclass found in {path}")
+        if len(candidates) > 1:
+            names = [c.__name__ for c in candidates]
+            raise ValueError(f"Multiple BaseProvider subclasses in {path}: {names}. Expected exactly one.")
+
+        provider = candidates[0]()
+        provider._plugin_source = path
+        return provider
+
+    @classmethod
+    def discover(cls, directory: str) -> List[Tuple[Optional[BaseProvider], Optional[str]]]:
+        """Discover and load all provider plugins from a directory.
+
+        Returns list of (provider, error) tuples.
+        - On success: (provider, None)
+        - On failure: (None, error_message)
+
+        Files starting with '_' or '.' are skipped.
+        """
+        results = []
+        dir_path = Path(directory)
+        if not dir_path.is_dir():
+            return results
+
+        for f in sorted(dir_path.iterdir()):
+            if f.name.startswith('_') or f.name.startswith('.'):
+                continue
+            try:
+                if f.suffix in ('.yaml', '.yml'):
+                    provider = cls.from_yaml(str(f))
+                    results.append((provider, None))
+                elif f.suffix == '.py':
+                    provider = cls.from_python(str(f))
+                    results.append((provider, None))
+            except Exception as e:
+                results.append((None, f"{f.name}: {e}"))
+                logger.warning("Failed to load plugin %s: %s", f.name, e)
+
+        return results
 
 
 # ---------------------------------------------------------------------------
@@ -432,14 +657,34 @@ class GLMProvider(BaseProvider):
 # Provider Registry — 动态注册 + 发现
 # ---------------------------------------------------------------------------
 class ProviderRegistry:
-    """Provider 注册表，支持动态注册和按名查找。"""
+    """Provider 注册表，支持动态注册、合约验证和插件发现。"""
 
     def __init__(self):
         self._providers: Dict[str, BaseProvider] = {}
+        self._plugin_errors: List[str] = []
 
-    def register(self, provider: BaseProvider):
-        """注册一个 Provider。"""
+    def register(self, provider: BaseProvider, validate: bool = True):
+        """注册一个 Provider。
+
+        Args:
+            provider: Provider instance to register.
+            validate: If True, run contract validation before registration.
+
+        Raises:
+            ContractViolationError: If validation is enabled and provider
+                fails contract checks.
+        """
+        if validate:
+            violations = ProviderContract.validate(provider)
+            if violations:
+                raise ContractViolationError(
+                    getattr(provider, 'name', '<unknown>'), violations
+                )
         self._providers[provider.name] = provider
+
+    def unregister(self, name: str) -> bool:
+        """Remove a provider by name. Returns True if it existed."""
+        return self._providers.pop(name, None) is not None
 
     def get(self, name: str) -> Optional[BaseProvider]:
         """按名获取 Provider。"""
@@ -452,6 +697,41 @@ class ProviderRegistry:
     def all(self) -> List[BaseProvider]:
         """返回所有已注册 Provider。"""
         return list(self._providers.values())
+
+    def load_plugins(self, directory: str) -> List[str]:
+        """Discover and load all provider plugins from a directory.
+
+        Returns list of error messages (empty = all loaded successfully).
+        Plugins that conflict with built-in names are skipped with a warning.
+        """
+        errors = []
+        results = PluginLoader.discover(directory)
+        for provider, error in results:
+            if error:
+                errors.append(error)
+                continue
+            if provider is None:
+                continue
+            if provider.name in self._providers:
+                src = getattr(provider, '_plugin_source', '?')
+                errors.append(
+                    f"{provider.name}: skipped (conflicts with built-in provider). "
+                    f"Source: {src}"
+                )
+                logger.warning("Plugin '%s' skipped: conflicts with built-in", provider.name)
+                continue
+            try:
+                self.register(provider, validate=True)
+                logger.info("Loaded plugin provider: %s", provider.name)
+            except ContractViolationError as e:
+                errors.append(str(e))
+        self._plugin_errors = errors
+        return errors
+
+    @property
+    def plugin_errors(self) -> List[str]:
+        """Errors from the last load_plugins() call."""
+        return self._plugin_errors
 
     def to_legacy_dict(self) -> Dict[str, dict]:
         """转换为旧格式 PROVIDERS dict（向后兼容 adapter.py）。"""
@@ -483,7 +763,7 @@ class ProviderRegistry:
 
 
 # ---------------------------------------------------------------------------
-# Default registry — 内置 4 个 Provider
+# Default registry — 7 built-in providers + auto-discovered plugins
 # ---------------------------------------------------------------------------
 _default_registry = ProviderRegistry()
 _default_registry.register(QwenProvider())
@@ -493,6 +773,14 @@ _default_registry.register(ClaudeProvider())
 _default_registry.register(KimiProvider())
 _default_registry.register(MiniMaxProvider())
 _default_registry.register(GLMProvider())
+
+# Auto-discover plugins from providers.d/ (relative to this file)
+_PLUGIN_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "providers.d")
+if os.path.isdir(_PLUGIN_DIR):
+    _plugin_errors = _default_registry.load_plugins(_PLUGIN_DIR)
+    if _plugin_errors:
+        for _err in _plugin_errors:
+            logger.warning("Plugin load error: %s", _err)
 
 
 def get_registry() -> ProviderRegistry:
@@ -519,11 +807,45 @@ if __name__ == "__main__":
     if "--json" in sys.argv:
         import json
         print(json.dumps(_default_registry.compatibility_matrix(), indent=2, ensure_ascii=False))
+    elif "--validate" in sys.argv:
+        # Validate all registered providers
+        print("# Provider Contract Validation\n")
+        all_ok = True
+        for p in _default_registry.all():
+            violations = ProviderContract.validate(p)
+            source = getattr(p, '_plugin_source', 'built-in')
+            if violations:
+                print(f"FAIL {p.name} ({source}): {'; '.join(violations)}")
+                all_ok = False
+            else:
+                print(f"  OK {p.name} ({source})")
+        if _default_registry.plugin_errors:
+            print(f"\nPlugin load errors:")
+            for err in _default_registry.plugin_errors:
+                print(f"  ERROR {err}")
+            all_ok = False
+        print(f"\n{'All providers valid.' if all_ok else 'Some providers have issues.'}")
+        sys.exit(0 if all_ok else 1)
     else:
         print("# Provider Compatibility Matrix\n")
         _default_registry.print_matrix()
-        print(f"\nTotal: {len(_default_registry.list_names())} providers registered")
+
+        # Separate built-in from plugins
+        builtins = [p for p in _default_registry.all() if not hasattr(p, '_plugin_source')]
+        plugins = [p for p in _default_registry.all() if hasattr(p, '_plugin_source')]
+        print(f"\nTotal: {len(_default_registry.list_names())} providers "
+              f"({len(builtins)} built-in, {len(plugins)} plugins)")
         print(f"Names: {', '.join(_default_registry.list_names())}")
+
+        if plugins:
+            print(f"\n## Plugins\n")
+            for p in plugins:
+                print(f"- **{p.display_name}** ({p.name}) — {p._plugin_source}")
+
+        if _default_registry.plugin_errors:
+            print(f"\n## Plugin Errors\n")
+            for err in _default_registry.plugin_errors:
+                print(f"- {err}")
 
         # 验证摘要
         print("\n## Verification Status\n")

--- a/test_providers.py
+++ b/test_providers.py
@@ -501,5 +501,624 @@ class TestChineseProviders(unittest.TestCase):
             self.assertEqual(p.auth_style, "bearer", f"{name} should use bearer auth")
 
 
+class TestProviderContract(unittest.TestCase):
+    """Provider contract validation tests"""
+
+    def _make_valid_provider(self, **overrides):
+        from providers import BaseProvider, ModelInfo, ProviderCapabilities
+        p = BaseProvider()
+        p.name = overrides.get('name', 'test')
+        p.display_name = overrides.get('display_name', 'Test Provider')
+        p.base_url = overrides.get('base_url', 'https://api.test.com/v1')
+        p.api_key_env = overrides.get('api_key_env', 'TEST_API_KEY')
+        p.auth_style = overrides.get('auth_style', 'bearer')
+        p.models = overrides.get('models', [
+            ModelInfo(model_id='test-v1', is_default=True)
+        ])
+        p.capabilities = overrides.get('capabilities', ProviderCapabilities(text=True))
+        return p
+
+    def test_valid_provider_passes(self):
+        from providers import ProviderContract
+        p = self._make_valid_provider()
+        self.assertEqual(ProviderContract.validate(p), [])
+
+    def test_missing_name(self):
+        from providers import ProviderContract
+        p = self._make_valid_provider(name='')
+        violations = ProviderContract.validate(p)
+        self.assertTrue(any('name' in v for v in violations))
+
+    def test_missing_base_url(self):
+        from providers import ProviderContract
+        p = self._make_valid_provider(base_url='')
+        violations = ProviderContract.validate(p)
+        self.assertTrue(any('base_url' in v for v in violations))
+
+    def test_missing_api_key_env(self):
+        from providers import ProviderContract
+        p = self._make_valid_provider(api_key_env='')
+        violations = ProviderContract.validate(p)
+        self.assertTrue(any('api_key_env' in v for v in violations))
+
+    def test_no_models(self):
+        from providers import ProviderContract
+        p = self._make_valid_provider(models=[])
+        violations = ProviderContract.validate(p)
+        self.assertTrue(any('model' in v.lower() for v in violations))
+
+    def test_model_without_id(self):
+        from providers import ProviderContract, ModelInfo
+        p = self._make_valid_provider(models=[ModelInfo(model_id='')])
+        violations = ProviderContract.validate(p)
+        self.assertTrue(any('model_id' in v for v in violations))
+
+    def test_multiple_defaults(self):
+        from providers import ProviderContract, ModelInfo
+        p = self._make_valid_provider(models=[
+            ModelInfo(model_id='m1', is_default=True),
+            ModelInfo(model_id='m2', is_default=True),
+        ])
+        violations = ProviderContract.validate(p)
+        self.assertTrue(any('is_default' in v for v in violations))
+
+    def test_invalid_auth_style(self):
+        from providers import ProviderContract
+        p = self._make_valid_provider(auth_style='invalid')
+        violations = ProviderContract.validate(p)
+        self.assertTrue(any('auth_style' in v for v in violations))
+
+    def test_valid_auth_styles(self):
+        from providers import ProviderContract
+        for style in ['bearer', 'x-api-key', 'query-param', 'custom']:
+            p = self._make_valid_provider(auth_style=style)
+            violations = ProviderContract.validate(p)
+            self.assertEqual(violations, [], f"auth_style '{style}' should be valid")
+
+    def test_vision_capability_without_vision_model(self):
+        from providers import ProviderContract, ProviderCapabilities, ModelInfo
+        caps = ProviderCapabilities(text=True, vision=True)
+        p = self._make_valid_provider(
+            capabilities=caps,
+            models=[ModelInfo(model_id='text-only', modalities=['text'])]
+        )
+        violations = ProviderContract.validate(p)
+        self.assertTrue(any('vision' in v for v in violations))
+
+    def test_vision_capability_with_vision_model(self):
+        from providers import ProviderContract, ProviderCapabilities, ModelInfo
+        caps = ProviderCapabilities(text=True, vision=True)
+        p = self._make_valid_provider(
+            capabilities=caps,
+            models=[ModelInfo(model_id='vis', modalities=['text', 'vision'], is_default=True)]
+        )
+        violations = ProviderContract.validate(p)
+        self.assertEqual(violations, [])
+
+    def test_all_builtin_providers_pass_contract(self):
+        from providers import ProviderContract, get_registry
+        for p in get_registry().all():
+            violations = ProviderContract.validate(p)
+            self.assertEqual(violations, [], f"{p.name} has contract violations: {violations}")
+
+
+class TestContractViolationError(unittest.TestCase):
+    """ContractViolationError tests"""
+
+    def test_error_message(self):
+        from providers import ContractViolationError
+        err = ContractViolationError("bad_provider", ["name is required", "no models"])
+        self.assertIn("bad_provider", str(err))
+        self.assertIn("name is required", str(err))
+
+    def test_error_attributes(self):
+        from providers import ContractViolationError
+        err = ContractViolationError("bad", ["v1", "v2"])
+        self.assertEqual(err.provider_name, "bad")
+        self.assertEqual(err.violations, ["v1", "v2"])
+
+    def test_is_value_error(self):
+        from providers import ContractViolationError
+        err = ContractViolationError("x", ["v"])
+        self.assertIsInstance(err, ValueError)
+
+
+class TestPluginLoaderYAML(unittest.TestCase):
+    """YAML plugin loading tests"""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir)
+
+    def _write_yaml(self, filename, content):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_load_valid_yaml(self):
+        from providers import PluginLoader
+        path = self._write_yaml("deepseek.yaml", """
+name: deepseek
+display_name: DeepSeek
+base_url: https://api.deepseek.com/v1
+api_key_env: DEEPSEEK_API_KEY
+auth_style: bearer
+models:
+  - model_id: deepseek-chat
+    display_name: DeepSeek V3
+    modalities: [text]
+    context_window: 65536
+    max_output_tokens: 8192
+    is_default: true
+capabilities:
+  text: true
+  tool_calling: true
+  streaming: true
+  context_window: 65536
+""")
+        p = PluginLoader.from_yaml(path)
+        self.assertEqual(p.name, "deepseek")
+        self.assertEqual(p.display_name, "DeepSeek")
+        self.assertEqual(p.base_url, "https://api.deepseek.com/v1")
+        self.assertEqual(p.api_key_env, "DEEPSEEK_API_KEY")
+        self.assertEqual(p.auth_style, "bearer")
+        self.assertEqual(len(p.models), 1)
+        self.assertEqual(p.models[0].model_id, "deepseek-chat")
+        self.assertTrue(p.capabilities.tool_calling)
+        self.assertTrue(p.capabilities.streaming)
+        self.assertEqual(p.capabilities.context_window, 65536)
+
+    def test_yaml_default_auth_style(self):
+        from providers import PluginLoader
+        path = self._write_yaml("minimal.yaml", """
+name: minimal
+base_url: https://api.minimal.com/v1
+api_key_env: MINIMAL_API_KEY
+models:
+  - model_id: mini-v1
+    is_default: true
+""")
+        p = PluginLoader.from_yaml(path)
+        self.assertEqual(p.auth_style, "bearer")
+
+    def test_yaml_display_name_defaults_to_name(self):
+        from providers import PluginLoader
+        path = self._write_yaml("noname.yaml", """
+name: noname
+base_url: https://api.x.com/v1
+api_key_env: X_KEY
+models:
+  - model_id: x-v1
+    is_default: true
+""")
+        p = PluginLoader.from_yaml(path)
+        self.assertEqual(p.display_name, "noname")
+
+    def test_yaml_multiple_models(self):
+        from providers import PluginLoader
+        path = self._write_yaml("multi.yaml", """
+name: multi
+base_url: https://api.multi.com/v1
+api_key_env: MULTI_KEY
+models:
+  - model_id: text-v1
+    is_default: true
+  - model_id: vision-v1
+    is_vision: true
+    modalities: [text, vision]
+""")
+        p = PluginLoader.from_yaml(path)
+        self.assertEqual(len(p.models), 2)
+        self.assertIsNotNone(p.default_model())
+        self.assertIsNotNone(p.vision_model())
+
+    def test_yaml_legacy_dict(self):
+        from providers import PluginLoader
+        path = self._write_yaml("legacy.yaml", """
+name: legtest
+base_url: https://api.leg.com/v1
+api_key_env: LEG_KEY
+models:
+  - model_id: leg-v1
+    is_default: true
+""")
+        p = PluginLoader.from_yaml(path)
+        d = p.to_legacy_dict()
+        self.assertEqual(d['base_url'], 'https://api.leg.com/v1')
+        self.assertEqual(d['model_id'], 'leg-v1')
+
+    def test_yaml_invalid_not_dict(self):
+        from providers import PluginLoader
+        path = self._write_yaml("bad.yaml", "- just a list")
+        with self.assertRaises(ValueError):
+            PluginLoader.from_yaml(path)
+
+    def test_yaml_plugin_source_recorded(self):
+        from providers import PluginLoader
+        path = self._write_yaml("src.yaml", """
+name: src
+base_url: https://api.src.com/v1
+api_key_env: SRC_KEY
+models:
+  - model_id: src-v1
+    is_default: true
+""")
+        p = PluginLoader.from_yaml(path)
+        self.assertEqual(p._plugin_source, path)
+
+
+class TestPluginLoaderPython(unittest.TestCase):
+    """Python plugin loading tests"""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir)
+
+    def _write_py(self, filename, content):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_load_valid_python_plugin(self):
+        from providers import PluginLoader
+        path = self._write_py("myprovider.py", """
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from providers import BaseProvider, ModelInfo, ProviderCapabilities
+
+class MyProvider(BaseProvider):
+    name = "myprovider"
+    display_name = "My Provider"
+    base_url = "https://api.my.com/v1"
+    api_key_env = "MY_API_KEY"
+    auth_style = "bearer"
+    models = [ModelInfo(model_id="my-v1", is_default=True)]
+    capabilities = ProviderCapabilities(text=True, streaming=True)
+""")
+        p = PluginLoader.from_python(path)
+        self.assertEqual(p.name, "myprovider")
+        self.assertTrue(p.capabilities.streaming)
+
+    def test_python_no_subclass(self):
+        from providers import PluginLoader
+        path = self._write_py("empty.py", "x = 1\n")
+        with self.assertRaises(ValueError) as ctx:
+            PluginLoader.from_python(path)
+        self.assertIn("No BaseProvider subclass", str(ctx.exception))
+
+    def test_python_multiple_subclasses(self):
+        from providers import PluginLoader
+        path = self._write_py("multi.py", """
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from providers import BaseProvider, ModelInfo
+
+class ProviderA(BaseProvider):
+    name = "a"
+    base_url = "https://a.com/v1"
+    api_key_env = "A_KEY"
+    models = [ModelInfo(model_id="a-v1", is_default=True)]
+
+class ProviderB(BaseProvider):
+    name = "b"
+    base_url = "https://b.com/v1"
+    api_key_env = "B_KEY"
+    models = [ModelInfo(model_id="b-v1", is_default=True)]
+""")
+        with self.assertRaises(ValueError) as ctx:
+            PluginLoader.from_python(path)
+        self.assertIn("Multiple", str(ctx.exception))
+
+    def test_python_custom_auth(self):
+        from providers import PluginLoader
+        path = self._write_py("customauth.py", """
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from providers import BaseProvider, ModelInfo, ProviderCapabilities
+
+class CustomAuthProvider(BaseProvider):
+    name = "customauth"
+    display_name = "Custom Auth"
+    base_url = "https://api.custom.com/v1"
+    api_key_env = "CUSTOM_KEY"
+    auth_style = "custom"
+    models = [ModelInfo(model_id="c-v1", is_default=True)]
+    capabilities = ProviderCapabilities(text=True)
+
+    def make_auth_headers(self, api_key):
+        return {"X-Custom": f"Token {api_key}"}
+""")
+        p = PluginLoader.from_python(path)
+        self.assertEqual(p.name, "customauth")
+        headers = p.make_auth_headers("mykey")
+        self.assertEqual(headers, {"X-Custom": "Token mykey"})
+
+
+class TestPluginDiscovery(unittest.TestCase):
+    """Plugin directory discovery tests"""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir)
+
+    def _write_file(self, filename, content):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_discover_empty_directory(self):
+        from providers import PluginLoader
+        results = PluginLoader.discover(self.tmpdir)
+        self.assertEqual(results, [])
+
+    def test_discover_skips_underscore_files(self):
+        from providers import PluginLoader
+        self._write_file("_example.yaml", "name: skip\n")
+        results = PluginLoader.discover(self.tmpdir)
+        self.assertEqual(results, [])
+
+    def test_discover_skips_dot_files(self):
+        from providers import PluginLoader
+        self._write_file(".hidden.yaml", "name: hidden\n")
+        results = PluginLoader.discover(self.tmpdir)
+        self.assertEqual(results, [])
+
+    def test_discover_nonexistent_directory(self):
+        from providers import PluginLoader
+        results = PluginLoader.discover("/nonexistent/path/12345")
+        self.assertEqual(results, [])
+
+    def test_discover_yaml_plugin(self):
+        from providers import PluginLoader
+        self._write_file("testprov.yaml", """
+name: testprov
+base_url: https://api.test.com/v1
+api_key_env: TEST_KEY
+models:
+  - model_id: test-v1
+    is_default: true
+""")
+        results = PluginLoader.discover(self.tmpdir)
+        self.assertEqual(len(results), 1)
+        provider, error = results[0]
+        self.assertIsNone(error)
+        self.assertEqual(provider.name, "testprov")
+
+    def test_discover_reports_errors(self):
+        from providers import PluginLoader
+        self._write_file("bad.yaml", "- not a dict")
+        results = PluginLoader.discover(self.tmpdir)
+        self.assertEqual(len(results), 1)
+        provider, error = results[0]
+        self.assertIsNone(provider)
+        self.assertIn("bad.yaml", error)
+
+    def test_discover_skips_non_plugin_extensions(self):
+        from providers import PluginLoader
+        self._write_file("readme.txt", "not a plugin")
+        self._write_file("data.json", '{"not": "plugin"}')
+        results = PluginLoader.discover(self.tmpdir)
+        self.assertEqual(results, [])
+
+    def test_discover_mixed_valid_and_invalid(self):
+        from providers import PluginLoader
+        self._write_file("good.yaml", """
+name: good
+base_url: https://api.good.com/v1
+api_key_env: GOOD_KEY
+models:
+  - model_id: good-v1
+    is_default: true
+""")
+        self._write_file("bad.yaml", "not: {valid: yaml: here")
+        results = PluginLoader.discover(self.tmpdir)
+        self.assertEqual(len(results), 2)
+        successes = [(p, e) for p, e in results if e is None]
+        failures = [(p, e) for p, e in results if e is not None]
+        self.assertEqual(len(successes), 1)
+        self.assertEqual(len(failures), 1)
+
+
+class TestRegistryWithValidation(unittest.TestCase):
+    """Registry register() with contract validation"""
+
+    def _make_valid_provider(self):
+        from providers import BaseProvider, ModelInfo, ProviderCapabilities
+        p = BaseProvider()
+        p.name = "valid"
+        p.base_url = "https://api.valid.com/v1"
+        p.api_key_env = "VALID_KEY"
+        p.models = [ModelInfo(model_id="v1", is_default=True)]
+        p.capabilities = ProviderCapabilities(text=True)
+        return p
+
+    def test_register_valid_passes(self):
+        from providers import ProviderRegistry
+        reg = ProviderRegistry()
+        reg.register(self._make_valid_provider())
+        self.assertEqual(len(reg.list_names()), 1)
+
+    def test_register_invalid_raises(self):
+        from providers import ProviderRegistry, BaseProvider, ContractViolationError
+        reg = ProviderRegistry()
+        bad = BaseProvider()  # all defaults = empty
+        with self.assertRaises(ContractViolationError):
+            reg.register(bad)
+
+    def test_register_skip_validation(self):
+        from providers import ProviderRegistry, BaseProvider
+        reg = ProviderRegistry()
+        bad = BaseProvider()
+        bad.name = "raw"
+        reg.register(bad, validate=False)
+        self.assertIn("raw", reg.list_names())
+
+    def test_unregister_existing(self):
+        from providers import ProviderRegistry
+        reg = ProviderRegistry()
+        reg.register(self._make_valid_provider())
+        self.assertTrue(reg.unregister("valid"))
+        self.assertEqual(len(reg.list_names()), 0)
+
+    def test_unregister_nonexistent(self):
+        from providers import ProviderRegistry
+        reg = ProviderRegistry()
+        self.assertFalse(reg.unregister("ghost"))
+
+
+class TestRegistryLoadPlugins(unittest.TestCase):
+    """Registry.load_plugins() integration tests"""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir)
+
+    def _write_yaml(self, filename, content):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_load_plugins_adds_to_registry(self):
+        from providers import ProviderRegistry, QwenProvider
+        reg = ProviderRegistry()
+        reg.register(QwenProvider())
+        self._write_yaml("newprov.yaml", """
+name: newprov
+base_url: https://api.new.com/v1
+api_key_env: NEW_KEY
+models:
+  - model_id: new-v1
+    is_default: true
+""")
+        errors = reg.load_plugins(self.tmpdir)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(reg.list_names()), 2)
+        self.assertIn("newprov", reg.list_names())
+
+    def test_load_plugins_skips_conflicts(self):
+        from providers import ProviderRegistry, QwenProvider
+        reg = ProviderRegistry()
+        reg.register(QwenProvider())
+        self._write_yaml("qwen.yaml", """
+name: qwen
+base_url: https://api.fake.com/v1
+api_key_env: FAKE_KEY
+models:
+  - model_id: fake-v1
+    is_default: true
+""")
+        errors = reg.load_plugins(self.tmpdir)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("conflicts", errors[0])
+        # Original should be preserved
+        self.assertEqual(reg.get("qwen").base_url, "https://hkagentx.hkopenlab.com/v1")
+
+    def test_load_plugins_skips_invalid(self):
+        from providers import ProviderRegistry
+        reg = ProviderRegistry()
+        self._write_yaml("invalid.yaml", """
+name: ""
+base_url: ""
+api_key_env: ""
+models: []
+""")
+        errors = reg.load_plugins(self.tmpdir)
+        self.assertGreater(len(errors), 0)
+        self.assertEqual(len(reg.list_names()), 0)
+
+    def test_load_plugins_in_legacy_dict(self):
+        from providers import ProviderRegistry
+        reg = ProviderRegistry()
+        self._write_yaml("plug.yaml", """
+name: plug
+base_url: https://api.plug.com/v1
+api_key_env: PLUG_KEY
+models:
+  - model_id: plug-v1
+    is_default: true
+capabilities:
+  text: true
+""")
+        reg.load_plugins(self.tmpdir)
+        legacy = reg.to_legacy_dict()
+        self.assertIn("plug", legacy)
+        self.assertEqual(legacy["plug"]["base_url"], "https://api.plug.com/v1")
+        self.assertEqual(legacy["plug"]["model_id"], "plug-v1")
+
+    def test_plugin_errors_property(self):
+        from providers import ProviderRegistry
+        reg = ProviderRegistry()
+        self._write_yaml("bad.yaml", "- list not dict")
+        reg.load_plugins(self.tmpdir)
+        self.assertGreater(len(reg.plugin_errors), 0)
+
+    def test_load_plugins_empty_dir(self):
+        from providers import ProviderRegistry
+        reg = ProviderRegistry()
+        errors = reg.load_plugins(self.tmpdir)
+        self.assertEqual(errors, [])
+
+
+class TestCLIValidate(unittest.TestCase):
+    """CLI --validate flag tests"""
+
+    def test_validate_all_pass(self):
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "providers.py", "--validate"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("All providers valid", result.stdout)
+        self.assertIn("OK", result.stdout)
+
+    def test_cli_shows_plugin_count(self):
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "providers.py"],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("built-in", result.stdout)
+
+
+class TestDefaultRegistryPluginDir(unittest.TestCase):
+    """Test that the default registry handles providers.d/ correctly"""
+
+    def test_example_files_not_loaded(self):
+        """Files starting with _ in providers.d/ should not be loaded."""
+        from providers import get_registry
+        names = get_registry().list_names()
+        # _example.yaml should be skipped
+        self.assertNotIn("deepseek", names)
+        # Only built-in providers should be present
+        self.assertEqual(len(names), 7)
+
+    def test_providers_d_exists(self):
+        """providers.d/ directory should exist for plugin discovery."""
+        providers_d = os.path.join(os.path.dirname(__file__), "providers.d")
+        self.assertTrue(os.path.isdir(providers_d))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
V3 路标第一个 P0：Provider Plugin Interface，让外部开发者无需修改
核心代码即可添加新 LLM Provider。

新增：
- ProviderContract: 注册时合约验证（name/base_url/models/auth_style）
- PluginLoader: 双模式加载 — YAML（声明式）+ Python（自定义 auth）
- providers.d/ 插件目录 + 示例文件（_example.yaml + _example_provider.py）
- Registry 增强：load_plugins(), unregister(), 合约验证集成
- CLI --validate 标志：校验所有 provider 合约
- ContractViolationError: 清晰的合约违规错误
- docs/provider_plugin_guide.md: 完整 Extension Guide

测试：107 tests (58 existing + 49 new), 666 total regression

https://claude.ai/code/session_01QuTC439xiWzmW64P35t4uz

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
