### PR TITLE
fix: add kb_harvest_chat.py to FILE_MAP + fix preflight set -e crash

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -206,6 +206,9 @@ declare -a FILE_MAP=(
     # Agent 做梦引擎（V32）
     "kb_dream.sh|$HOME/kb_dream.sh"
 
+    # 对话精华提炼（V37）
+    "kb_harvest_chat.py|$HOME/kb_harvest_chat.py"
+
     # 统一推送（V33 Discord 双通道）
     "notify.sh|$HOME/notify.sh"
 

--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -52,7 +52,7 @@ fi
 
 # V36.2: Crontab 间隔漂移检测（仅 --full 模式，需要 crontab 访问）
 if $FULL_MODE; then
-    DRIFT_OUT=$(python3 check_registry.py --check-crontab 2>&1)
+    DRIFT_OUT=$(python3 check_registry.py --check-crontab 2>&1 || true)
     if echo "$DRIFT_OUT" | grep -q "间隔漂移"; then
         DRIFT_LINES=$(echo "$DRIFT_OUT" | grep "间隔漂移")
         fail "crontab 间隔漂移（registry vs 实际 crontab 不一致）:


### PR DESCRIPTION
两个修复：
1. auto_deploy.sh: 添加 kb_harvest_chat.py 到 FILE_MAP（缺失导致 check_registry --check-crontab FILE_MAP 检查失败）
2. preflight_check.sh: --check-crontab 调用加 || true 防止 set -e 导致 preflight 在 2/19 后静默退出（Mac Mini 复现的 bug）

https://claude.ai/code/session_01QuTC439xiWzmW64P35t4uz

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
