### PR TITLE
fix: preflight 17/19 set -e crash on kb_embed --verify

### DIFF
--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -748,8 +748,8 @@ if $FULL_MODE; then
     KB_IDX_DIR="$HOME/.kb/text_index"
     if [ -f "$KB_IDX_DIR/meta.json" ] && [ -f "$KB_IDX_DIR/vectors.bin" ]; then
         # 运行 kb_embed.py --verify（轻量级，不加载模型，只做文件比对）
-        VERIFY_OUT=$(python3 "$HOME/kb_embed.py" --verify 2>/dev/null)
-        VERIFY_RC=$?
+        VERIFY_RC=0
+        VERIFY_OUT=$(python3 "$HOME/kb_embed.py" --verify 2>/dev/null) || VERIFY_RC=$?
 
         # 提取关键指标
         FILE_COV=$(echo "$VERIFY_OUT" | grep -o '文件覆盖.*' | head -1)


### PR DESCRIPTION
Same pattern as the crontab check fix: python3 command in $() exits non-zero under set -euo pipefail, killing the script at 17/19.

https://claude.ai/code/session_01QuTC439xiWzmW64P35t4uz

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
