### PR TITLE
fix: strip Gateway metadata from captured conversations

### DIFF
--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -54,6 +54,17 @@ def _capture_conversation_turn(messages, assistant_content):
                 break
         if not user_msg or not assistant_content:
             return
+        # Strip Gateway system metadata prefix (WhatsApp connected, sender info)
+        # Pattern: "System: [...] ...\n```json\n{...}\n```\n\nSender...\n```json\n{...}\n```\n\n<actual>"
+        if user_msg.startswith("System:") and "```" in user_msg:
+            # Find end of last ``` block, take everything after
+            last_fence = user_msg.rfind("```")
+            if last_fence != -1:
+                after = user_msg[last_fence + 3:].strip()
+                if after:
+                    user_msg = after
+        if not user_msg:
+            return
         # Skip system/short messages (likely automated, not real conversations)
         if len(user_msg) < 5 or len(assistant_content) < 10:
             return


### PR DESCRIPTION
对话捕获时过滤 WhatsApp Gateway 注入的系统元数据前缀
（sender_id、手机号、message_id），只保留用户实际发送的内容。

https://claude.ai/code/session_01QuTC439xiWzmW64P35t4uz

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
