### PR TITLE
fix: adapter crash when config.yaml fallback.remote_gpu is not a dict

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -21,7 +21,11 @@ _FALLBACK_CFG = {}
 try:
     from config_loader import load_config
     _cfg = load_config()
-    _FALLBACK_CFG = _cfg.get("fallback", {}).get("remote_gpu", {})
+    _fb = _cfg.get("fallback", {})
+    if isinstance(_fb, dict):
+        _rg = _fb.get("remote_gpu", {})
+        if isinstance(_rg, dict):
+            _FALLBACK_CFG = _rg
 except Exception:
     pass  # config_loader 不可用时使用默认值
 


### PR DESCRIPTION
Mac Mini 的 config.yaml 中 fallback.remote_gpu 是字符串， 调用 .get() 触发 AttributeError: 'str' object has no attribute 'get'。 加防御性 isinstance 检查。

https://claude.ai/code/session_01QuTC439xiWzmW64P35t4uz

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
