### PR TITLE
fix: unify HN + Freight to dual-write (notes + sources)

### DIFF
--- a/jobs/freight_watcher/run_freight.sh
+++ b/jobs/freight_watcher/run_freight.sh
@@ -25,6 +25,7 @@ ROOT="${HOME}/.openclaw"
 JOB="$ROOT/jobs/freight_watcher"
 CACHE="$JOB/cache"
 KB_SRC="${KB_BASE:-$HOME/.kb}/sources/freight_daily.md"
+KB_WRITE_SCRIPT="${KB_WRITE_SCRIPT:-$HOME/kb_write.sh}"
 KB_INBOX="${KB_BASE:-$HOME/.kb}/inbox.md"
 TO="${OPENCLAW_PHONE:-+85200000000}"
 LLM_RAW="$CACHE/llm_raw_last.txt"
@@ -305,6 +306,11 @@ fi
     echo "## ${DAY}"
     cat "$MSG_FILE"
 } >> "$KB_SRC"
+
+# 写入 KB notes（与其他 job 对齐双写模式）
+bash "$KB_WRITE_SCRIPT" "# 货代商机 ${DAY}
+
+$(cat "$MSG_FILE")" "freight" "note" 2>/dev/null || true
 
 # ── 7. rsync备份 ────────────────────────────────────────────────────────
 rsync -a --quiet "$HOME/.kb/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true

--- a/run_hn_fixed.sh
+++ b/run_hn_fixed.sh
@@ -21,6 +21,7 @@ SCRIPT_DIR="$HOME/.openclaw/jobs/hn_watcher"
 CACHE_DIR="$SCRIPT_DIR/cache"
 INBOX="$HOME/.kb/inbox.md"
 KB_SOURCE="$HOME/.kb/sources/hn_daily.md"
+KB_WRITE_SCRIPT="${KB_WRITE_SCRIPT:-$HOME/kb_write.sh}"
 KB_DIR="$HOME/.kb"
 SSD_BACKUP="/Volumes/MOVESPEED/KB/"
 MSG_FILE="$CACHE_DIR/hn_message.txt"
@@ -304,6 +305,10 @@ if [ "$SENT_COUNT" -gt 0 ]; then
         log "已推送 ${SENT_COUNT} 条AI/Tech精选（单次批量LLM）。"
         openclaw message send --channel discord --target "${DISCORD_CH_TECH:-}" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1 || true
         printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$SENT_COUNT" > "$STATUS_FILE"
+        # 写入 KB notes（与其他 10 个 job 对齐双写模式）
+        bash "$KB_WRITE_SCRIPT" "# HN AI/Tech精选 $(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M')
+
+$(cat "$MSG_FILE")" "hn-tech" "note" 2>/dev/null || true
     else
         # 过滤已知无害警告（feishu 插件 duplicate id、plugins.allow empty）
         REAL_ERR=$(grep -v -E "feishu|plugin.*duplicate|plugins\.allow|Config warnings" "$SEND_ERR" 2>/dev/null || true)
@@ -312,6 +317,9 @@ if [ "$SENT_COUNT" -gt 0 ]; then
             log "已推送 ${SENT_COUNT} 条AI/Tech精选（单次批量LLM，忽略插件警告）。"
             openclaw message send --channel discord --target "${DISCORD_CH_TECH:-}" --message "$(cat "$MSG_FILE")" --json >/dev/null 2>&1 || true
             printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$SENT_COUNT" > "$STATUS_FILE"
+            bash "$KB_WRITE_SCRIPT" "# HN AI/Tech精选 $(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M')
+
+$(cat "$MSG_FILE")" "hn-tech" "note" 2>/dev/null || true
         else
             log "ERROR: 推送失败（${SENT_COUNT} 条待发）: $(echo "$REAL_ERR" | head -3)"
             printf '{"time":"%s","status":"send_failed","new":%d,"sent":false}\n' "$TS" "$SENT_COUNT" > "$STATUS_FILE"


### PR DESCRIPTION
12 个 KB 写入 job 中只有 HN 和 Freight 只写 sources/ 不写 notes/， 导致晚间摘要漏统计、index.json 缺条目。

对齐其他 10 个 job 的双写模式：推送成功后同时调 kb_write.sh 写入 notes/。

https://claude.ai/code/session_01QuTC439xiWzmW64P35t4uz

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
