### PR TITLE
fix: capture user question even when PA responds with tool_calls

### DIFF
--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -901,6 +901,13 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                                     fn_name = tc.get('function', {}).get('name', '?')
                                     fn_args = tc.get('function', {}).get('arguments', '')
                                     log(f"[{rid}] CALL: {fn_name} ({len(fn_args)} bytes)")
+                                # Capture user question even when PA responds with tool calls
+                                tool_names = ",".join(tc.get('function', {}).get('name', '?')
+                                                      for tc in m["tool_calls"])
+                                _capture_conversation_turn(
+                                    body.get("messages", []),
+                                    f"[PA调用工具: {tool_names}]"
+                                )
                             elif m.get("content"):
                                 log(f"[{rid}] TEXT: {len(str(m['content']))} chars")
                                 # Capture conversation turn for KB harvesting


### PR DESCRIPTION
之前 tool_calls 分支不触发对话捕获，导致用户问题在 PA 只调工具
（如 sessions_spawn）时丢失。现在 tool_calls 时也记录用户消息，
assistant 内容标记为 [PA调用工具: tool_name]。

https://claude.ai/code/session_01QuTC439xiWzmW64P35t4uz

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
