### PR TITLE
fix(ontology): switch ontology Discord push to notify.sh with proper …

### DIFF
--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -394,7 +394,6 @@ fi
 
 # ── 6.5 Ontology 论文单独推送到 Discord #ontology ─────────────────────────
 # 检测标题/摘要命中 ontology 关键词的论文，额外推送到 #ontology 频道
-# WhatsApp 不受影响（没有频道区分）
 ONTO_MSG_FILE="$CACHE/ontology_papers.txt"
 ONTO_FILTER="$(dirname "$0")/../ontology_filter.py"
 if [ -f "$ONTO_FILTER" ]; then
@@ -402,7 +401,14 @@ if [ -f "$ONTO_FILTER" ]; then
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)
-        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json 2>"$CACHE/onto_discord.err" || true
+        # 使用 notify.sh 统一推送（带重试+错误捕获+队列）
+        if [ -f "${HOME}/notify.sh" ]; then
+            source "${HOME}/notify.sh"
+            notify "$ONTO_CONTENT" --channel discord --topic ontology
+        else
+            log "WARN: notify.sh not found, falling back to direct send"
+            "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json 2>"$CACHE/onto_discord.err" || true
+        fi
         log "Ontology论文推送到Discord #ontology: ${ONTO_COUNT} 篇"
     fi
 fi

--- a/jobs/dblp/run_dblp.sh
+++ b/jobs/dblp/run_dblp.sh
@@ -423,7 +423,8 @@ if [ -f "$ONTO_FILTER" ]; then
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)
-        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json 2>"$CACHE/onto_discord.err" || true
+        # 使用 notify.sh 统一推送（带重试+错误捕获+队列）
+        notify "$ONTO_CONTENT" --channel discord --topic ontology
         log "Ontology论文推送到Discord #ontology: ${ONTO_COUNT} 篇"
     fi
 fi

--- a/jobs/semantic_scholar/run_semantic_scholar.sh
+++ b/jobs/semantic_scholar/run_semantic_scholar.sh
@@ -378,7 +378,14 @@ if [ -f "$ONTO_FILTER" ]; then
     if [ -s "$ONTO_MSG_FILE" ]; then
         ONTO_CONTENT="$(head -c 4000 "$ONTO_MSG_FILE")"
         ONTO_COUNT=$(grep -c '^\*' "$ONTO_MSG_FILE" || true)
-        "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json 2>"$CACHE/onto_discord.err" || true
+        # 使用 notify.sh 统一推送（带重试+错误捕获+队列）
+        if [ -f "${HOME}/notify.sh" ]; then
+            source "${HOME}/notify.sh"
+            notify "$ONTO_CONTENT" --channel discord --topic ontology
+        else
+            log "WARN: notify.sh not found, falling back to direct send"
+            "$OPENCLAW" message send --channel discord --target "${DISCORD_CH_ONTOLOGY:-}" --message "$ONTO_CONTENT" --json 2>"$CACHE/onto_discord.err" || true
+        fi
         log "Ontology论文推送到Discord #ontology: ${ONTO_COUNT} 篇"
     fi
 fi


### PR DESCRIPTION
…error handling

Three paper monitoring scripts (ArXiv, S2, DBLP) were sending ontology papers directly via `openclaw message send` with empty-defaulted DISCORD_CH_ONTOLOGY and `|| true` swallowing all errors. Switched to notify.sh which provides retry logic, error capture, queue persistence, and explicit empty-channel error reporting.

https://claude.ai/code/session_01Hexa5bqVC1R6WKUAy6cmmK

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
