### PR TITLE
feat: ontology 专属信息源三层建设

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -164,6 +164,7 @@ declare -a FILE_MAP=(
     "jobs/pwc/run_pwc.sh|$HOME/.openclaw/jobs/pwc/run_pwc.sh"
     "jobs/github_trending/run_github_trending.sh|$HOME/.openclaw/jobs/github_trending/run_github_trending.sh"
     "jobs/rss_blogs/run_rss_blogs.sh|$HOME/.openclaw/jobs/rss_blogs/run_rss_blogs.sh"
+    "jobs/ontology_sources/run_ontology_sources.sh|$HOME/.openclaw/jobs/ontology_sources/run_ontology_sources.sh"
 
     # AI Leaders X 技术洞察追踪（V34: 替代 karpathy_x，9位 AI 大牛）
     "jobs/karpathy_x/run_karpathy_x.sh|$HOME/.openclaw/jobs/karpathy_x/run_karpathy_x.sh"

--- a/docs/config.md
+++ b/docs/config.md
@@ -294,6 +294,7 @@ export GEMINI_API_KEY="AIzaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"   # V29.1新增
 | kb_dream | 每天05:30 | `~/kb_dream.sh` | `~/kb_dream.log` | ✅ V32新增→V36.2修复：Agent Dream v2 MapReduce 全量 KB 探索（14源+232笔记逐一提取信号→跨域关联，05:30 避开04:xx ArXiv+Watchdog冲突，输出 ~/.kb/dreams/） |
 | kb_harvest_chat | 每天06:00 | `~/kb_harvest_chat.py` | `~/kb_harvest_chat.log` | ✅ V37新增→V37.1升级MapReduce：对话精华提炼 — 从 proxy 捕获的每日对话中 LLM 提取关键点（决策/偏好/洞察/结论），分块零丢失，写入 KB notes |
 | governance_audit | 每天07:00 | `~/governance_audit_cron.sh` | `~/governance_audit.log` | ✅ V37.1新增：每日 ontology 治理审计（governance_checker --full 17不变式+6元发现 + engine --check 81规则），失败推送 alerts |
+| ontology_sources | 每天10:00,20:00 | `~/.openclaw/jobs/ontology_sources/run_ontology_sources.sh` | `~/.openclaw/logs/jobs/ontology_sources.log` | ✅ V37.1新增：Ontology 专属信息源监控 — SWJ+W3C+KG Conference RSS，关键词过滤，LLM富摘要，Discord #ontology + KB 归档 |
 | gateway-watchdog | ~~每30分钟~~ | `~/restart.sh` | `~/.openclaw/logs/gateway_watchdog.log` | ❌ **已移除**（#95：与launchd KeepAlive双主控冲突，导致误杀gateway） |
 
 当前 `crontab -l` 核心条目：

--- a/jobs/ai_leaders_x/run_ai_leaders_x.sh
+++ b/jobs/ai_leaders_x/run_ai_leaders_x.sh
@@ -51,6 +51,10 @@ LEADERS=(
     "PalantirTech|Palantir Technologies|企业AI平台/Ontology+AIP/数据治理"
     "AlexKarp|Alex Karp|Palantir CEO，企业AI+本体论落地实践"
     "ShyamSankar|Shyam Sankar|Palantir CTO，Foundry Ontology架构师"
+    "BarrySmith46|Barry Smith|BFO创建者，形式本体论奠基人"
+    "gaborguizzardi|Giancarlo Guizzardi|UFO/OntoUML创建者，概念建模"
+    "pascal_hitzler|Pascal Hitzler|Kansas State，Knowledge Graph/语义网"
+    "IanHorrocks|Ian Horrocks|Oxford，OWL/Description Logic奠基人"
 )
 
 MAX_PER_PERSON=5

--- a/jobs/dblp/run_dblp.sh
+++ b/jobs/dblp/run_dblp.sh
@@ -35,7 +35,7 @@ mkdir -p "$CACHE" "${KB_BASE:-$HOME/.kb}/sources"
 test -f "$KB_SRC" || echo "# DBLP CS论文索引" > "$KB_SRC"
 
 # ── 1. 多关键词搜索 ─────────────────────────────────────────────────
-KEYWORDS=("large language model" "LLM agent" "multimodal foundation model" "retrieval augmented generation" "RLHF alignment" "ontology knowledge graph" "neuro-symbolic reasoning" "enterprise ontology")
+KEYWORDS=("large language model" "LLM agent" "multimodal foundation model" "retrieval augmented generation" "RLHF alignment" "ontology knowledge graph" "neuro-symbolic reasoning" "enterprise ontology" "formal ontology information systems" "description logic OWL" "semantic web linked data" "knowledge representation reasoning")
 RAW_DIR="$CACHE/raw"
 mkdir -p "$RAW_DIR"
 

--- a/jobs/ontology_sources/run_ontology_sources.sh
+++ b/jobs/ontology_sources/run_ontology_sources.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# run_ontology_sources.sh — Ontology 专属信息源监控
+# 监控本体论/语义网/知识表示领域的权威 RSS 源
+# 推送到 Discord #ontology 频道 + KB 归档
+#
+# crontab: 0 10,20 * * * bash -lc 'bash ~/.openclaw/jobs/ontology_sources/run_ontology_sources.sh >> ~/.openclaw/logs/jobs/ontology_sources.log 2>&1'
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+set -eo pipefail
+
+# 防重叠执行
+LOCK="/tmp/ontology_sources.lockdir"
+mkdir "$LOCK" 2>/dev/null || { echo "[onto-src] Already running, skip"; exit 0; }
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+
+JOB_DIR="${HOME}/.openclaw/jobs/ontology_sources"
+CACHE="$JOB_DIR/cache"
+KB_SRC="${KB_BASE:-$HOME/.kb}/sources/ontology_sources.md"
+KB_WRITE_SCRIPT="${KB_WRITE_SCRIPT:-$HOME/kb_write.sh}"
+PYTHON3=/usr/bin/python3
+
+TS="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M:%S')"
+DAY="$(TZ=Asia/Hong_Kong date '+%Y-%m-%d')"
+STATUS_FILE="$CACHE/last_run.json"
+
+log() { echo "[$TS] onto-src: $1"; }
+
+mkdir -p "$CACHE" "${KB_BASE:-$HOME/.kb}/sources"
+test -f "$KB_SRC" || echo "# Ontology Sources Watcher" > "$KB_SRC"
+
+# ── 加载 notify.sh ────────────────────────────────────────────────────
+NOTIFY_LOADED=false
+for _np in "$HOME/openclaw-model-bridge/notify.sh" "$HOME/notify.sh"; do
+    if [ -f "$_np" ]; then
+        source "$_np"
+        NOTIFY_LOADED=true
+        break
+    fi
+done
+
+# ── Ontology RSS 源配置 ───────────────────────────────────────────────
+# 格式：name|feed_url|label
+RSS_FEEDS=(
+    "Semantic Web Journal|http://www.semantic-web-journal.net/rss.xml|SWJ(本体/语义网第一期刊，开放获取)"
+    "W3C Semantic Web|https://www.w3.org/blog/feed/|W3C(OWL/RDF/SPARQL/SHACL标准动态)"
+    "Knowledge Graph Blog|https://blog.knowledgegraph.tech/feed/|KG Conference(知识图谱行业实践)"
+    "Schema.org Releases|https://schema.org/docs/releases.html|Schema.org(Web结构化数据标准)"
+)
+
+SEEN_FILE="$CACHE/seen_urls.txt"
+touch "$SEEN_FILE"
+ALL_NEW_FILE="$CACHE/all_new.jsonl"
+> "$ALL_NEW_FILE"
+
+TOTAL_NEW=0
+FETCH_ERRORS=0
+
+for feed_entry in "${RSS_FEEDS[@]}"; do
+    IFS='|' read -r FEED_NAME FEED_URL FEED_LABEL <<< "$feed_entry"
+    FEED_FILE="$CACHE/feed_$(echo "$FEED_NAME" | tr ' ' '_').xml"
+
+    # 抓取 RSS
+    FETCH_OK=false
+    for attempt in 1 2 3; do
+        HTTP_CODE=$(curl -sSL --max-time 30 -w '%{http_code}' \
+            -H "User-Agent: openclaw-ontology-monitor/1.0" \
+            -o "$FEED_FILE" \
+            "$FEED_URL" 2>"$CACHE/curl_feed.err") || HTTP_CODE="000"
+
+        if [ "$HTTP_CODE" = "200" ] && [ -s "$FEED_FILE" ]; then
+            FETCH_OK=true
+            break
+        else
+            log "WARN: ${FEED_NAME} RSS HTTP ${HTTP_CODE} (attempt ${attempt})"
+        fi
+        sleep "$((attempt * 3))"
+    done
+
+    if [ "$FETCH_OK" != "true" ]; then
+        log "WARN: ${FEED_NAME} RSS 抓取失败，跳过"
+        FETCH_ERRORS=$((FETCH_ERRORS + 1))
+        continue
+    fi
+
+    # 解析 RSS XML → 提取新文章（带 ontology 关键词过滤）
+    $PYTHON3 - "$FEED_FILE" "$SEEN_FILE" "$FEED_NAME" "$FEED_LABEL" << 'PYEOF' >> "$ALL_NEW_FILE"
+import sys, json, re
+import xml.etree.ElementTree as ET
+
+feed_file = sys.argv[1]
+seen_file = sys.argv[2]
+feed_name = sys.argv[3]
+feed_label = sys.argv[4]
+
+# Ontology 关键词过滤（SWJ 全部保留，其他源按关键词过滤）
+ONTOLOGY_KEYWORDS = [
+    "ontology", "ontologies", "ontological",
+    "semantic web", "linked data", "knowledge graph",
+    "OWL", "RDF", "SPARQL", "SHACL", "SKOS",
+    "description logic", "formal ontology",
+    "knowledge representation", "knowledge engineering",
+    "upper ontology", "BFO", "UFO", "DOLCE",
+    "schema.org", "structured data",
+    "neuro-symbolic", "neurosymbolic",
+    "conceptual modeling", "knowledge base",
+]
+
+# SWJ 是专属源，不需要过滤
+SKIP_FILTER = feed_name in ("Semantic Web Journal",)
+
+with open(seen_file) as f:
+    seen_urls = set(line.strip() for line in f if line.strip())
+
+try:
+    tree = ET.parse(feed_file)
+    root = tree.getroot()
+except ET.ParseError:
+    with open(feed_file, 'r', encoding='utf-8', errors='replace') as f:
+        content = f.read()
+    try:
+        root = ET.fromstring(content)
+    except ET.ParseError:
+        print(f"[onto-src] ERROR: {feed_name} XML解析失败", file=sys.stderr)
+        sys.exit(0)
+
+# 支持 RSS 2.0 和 Atom 格式
+ns = {'atom': 'http://www.w3.org/2005/Atom',
+      'content': 'http://purl.org/rss/1.0/modules/content/',
+      'dc': 'http://purl.org/dc/elements/1.1/'}
+
+items = root.findall('.//item')  # RSS 2.0
+if not items:
+    items = root.findall('.//atom:entry', ns)  # Atom
+
+new_count = 0
+for item in items[:30]:  # 检查前30篇
+    title_el = item.find('title')
+    link_el = item.find('link')
+    desc_el = item.find('description')
+    date_el = item.find('pubDate')
+    author_el = item.find('dc:creator', ns)
+    content_el = item.find('content:encoded', ns)
+
+    # Atom fallback
+    if link_el is None:
+        link_el = item.find('atom:link', ns)
+        if link_el is not None:
+            link_el = type('obj', (object,), {'text': link_el.get('href', '')})()
+    if title_el is None:
+        title_el = item.find('atom:title', ns)
+    if date_el is None:
+        date_el = item.find('atom:published', ns) or item.find('atom:updated', ns)
+
+    title = (title_el.text or '').strip() if title_el is not None else ''
+    link = (link_el.text or '').strip() if link_el is not None else ''
+    description = ''
+    if content_el is not None and content_el.text:
+        description = re.sub(r'<[^>]+>', '', content_el.text)[:500]
+    elif desc_el is not None and desc_el.text:
+        description = re.sub(r'<[^>]+>', '', desc_el.text)[:500]
+    pub_date = (date_el.text or '').strip()[:25] if date_el is not None else ''
+    author = (author_el.text or '').strip() if author_el is not None else feed_name
+
+    if not title or not link:
+        continue
+    if link in seen_urls:
+        continue
+
+    # 关键词过滤（非专属源）
+    if not SKIP_FILTER:
+        text_to_check = (title + " " + description).lower()
+        if not any(kw.lower() in text_to_check for kw in ONTOLOGY_KEYWORDS):
+            continue
+
+    print(json.dumps({
+        "title": title,
+        "link": link,
+        "description": description,
+        "pub_date": pub_date,
+        "author": author,
+        "feed_name": feed_name,
+        "feed_label": feed_label,
+    }, ensure_ascii=False))
+    new_count += 1
+
+    if new_count >= 8:  # 每个源每次最多8篇
+        break
+
+print(f"[onto-src] {feed_name}: {new_count} 篇新文章", file=sys.stderr)
+PYEOF
+done
+
+TOTAL_NEW="$(wc -l < "$ALL_NEW_FILE" | tr -d ' ')"
+if [ "$TOTAL_NEW" -eq 0 ]; then
+    log "无新文章，跳过推送。"
+    printf '{"time":"%s","status":"ok","new":0}\n' "$TS" > "$STATUS_FILE"
+    exit 0
+fi
+log "共 ${TOTAL_NEW} 篇新文章"
+
+# ── 构建 LLM prompt ──────────────────────────────────────────────────
+PROMPT_FILE="$CACHE/llm_prompt.txt"
+$PYTHON3 - "$ALL_NEW_FILE" << 'PYEOF' > "$PROMPT_FILE"
+import sys, json
+
+articles = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if line:
+            articles.append(json.loads(line))
+
+prompt = """你是本体论(Ontology)和语义网(Semantic Web)领域的学术编辑。对以下每篇文章严格输出三行（不要输出任何其他内容）：
+第一行：中文标题（翻译或意译，≤25字）
+第二行：要点：[1句话≤60字，说明核心贡献或价值]
+第三行：价值：⭐（1到5个星，评估对本体论/知识工程从业者的参考价值）
+每篇之间用一行 --- 分隔。
+
+"""
+for i, a in enumerate(articles, 1):
+    prompt += f"文章{i}：{a['title']}\n"
+    prompt += f"来源：{a['feed_label']}\n"
+    if a.get('description'):
+        prompt += f"摘要：{a['description'][:300]}\n"
+    prompt += "\n"
+
+print(prompt)
+PYEOF
+
+# ── 调用 LLM（直接调 adapter，不经 proxy）──────────────────────────────
+LLM_RAW="$CACHE/llm_raw_last.txt"
+$PYTHON3 -c "
+import json
+prompt = open('$CACHE/llm_prompt.txt').read()
+with open('$CACHE/llm_payload.json', 'w') as f:
+    json.dump({
+        'model': 'default',
+        'messages': [{'role': 'user', 'content': prompt}],
+        'max_tokens': 4096,
+        'temperature': 0.3
+    }, f)
+"
+
+LLM_RESP=$(curl -s --max-time 120 \
+    -H "Content-Type: application/json" \
+    -d "@$CACHE/llm_payload.json" \
+    http://127.0.0.1:5001/v1/chat/completions 2>"$CACHE/llm.stderr" || true)
+
+echo "$LLM_RESP" > "$LLM_RAW"
+
+LLM_CONTENT=$($PYTHON3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d['choices'][0]['message']['content'])
+except Exception:
+    pass
+" <<< "$LLM_RESP" 2>/dev/null || true)
+
+if [ -z "${LLM_CONTENT// }" ]; then
+    log "WARN: LLM调用失败，使用原始标题推送"
+    LLM_CONTENT=""
+fi
+
+# ── 组装消息 ──────────────────────────────────────────────────────────
+MSG_FILE="$CACHE/onto_message.txt"
+$PYTHON3 - "$ALL_NEW_FILE" "$LLM_RAW" "$DAY" "$MSG_FILE" << 'PYEOF'
+import sys, json, re
+
+articles_file, llm_file, day, msg_file = sys.argv[1:5]
+
+articles = []
+with open(articles_file) as f:
+    for line in f:
+        line = line.strip()
+        if line:
+            articles.append(json.loads(line))
+
+# 尝试解析 LLM 输出
+try:
+    with open(llm_file) as f:
+        raw = json.load(f)
+    llm_content = raw.get("choices", [{}])[0].get("message", {}).get("content", "")
+except Exception:
+    llm_content = ""
+
+# 解析三行一组（中文标题/要点/价值）
+parsed_blocks = []
+lines = [l.strip() for l in llm_content.split('\n') if l.strip() and not re.match(r'^[-=*]{3,}$', l)]
+
+i = 0
+while i < len(lines):
+    # 跳过"文章N："前缀行
+    if re.match(r'^文章\d+[：:]', lines[i]):
+        i += 1
+        continue
+    cn_title = lines[i] if i < len(lines) else ""
+    highlight = lines[i+1] if i+1 < len(lines) else ""
+    stars = lines[i+2] if i+2 < len(lines) else ""
+    parsed_blocks.append((cn_title, highlight, stars))
+    i += 3
+
+msg_lines = [f"🔬 Ontology 学术动态 ({day})", ""]
+
+for idx, article in enumerate(articles):
+    if idx < len(parsed_blocks):
+        cn_title, highlight, stars = parsed_blocks[idx]
+        msg_lines.append(f"*{cn_title}*")
+    else:
+        msg_lines.append(f"*{article['title'][:60]}*")
+        highlight = "要点：本体论/语义网领域论文"
+        stars = "价值：⭐⭐⭐"
+
+    msg_lines.append(f"来源：{article['feed_label']} | {article.get('pub_date', '')[:16]}")
+    msg_lines.append(f"链接：{article['link']}")
+    if highlight:
+        msg_lines.append(highlight)
+    if stars and '⭐' in stars:
+        msg_lines.append(stars)
+    msg_lines.append("")
+
+with open(msg_file, 'w') as f:
+    f.write('\n'.join(msg_lines))
+
+print(f"[onto-src] 消息组装完成: {len(articles)} 篇", file=sys.stderr)
+PYEOF
+
+# ── 推送到 Discord #ontology（主推通道）+ WhatsApp ───────────────────
+MSG_CONTENT="$(head -c 4000 "$MSG_FILE")"
+
+if $NOTIFY_LOADED; then
+    notify "$MSG_CONTENT" --topic ontology
+    log "已推送 ${TOTAL_NEW} 篇到 #ontology"
+else
+    log "WARN: notify.sh not loaded, skipping push"
+fi
+
+# 标记为已发送
+$PYTHON3 -c "
+import json, sys
+with open('$ALL_NEW_FILE') as f:
+    for line in f:
+        line = line.strip()
+        if line:
+            d = json.loads(line)
+            print(d.get('link', ''))
+" >> "$SEEN_FILE"
+
+printf '{"time":"%s","status":"ok","new":%d,"sent":true}\n' "$TS" "$TOTAL_NEW" > "$STATUS_FILE"
+
+# ── KB 归档 ──────────────────────────────────────────────────────────
+SUMMARY="$(cat "$MSG_FILE")"
+if [ -n "$SUMMARY" ] && [ -f "$KB_WRITE_SCRIPT" ]; then
+    DATE_KB=$(TZ=Asia/Hong_Kong date '+%Y-%m-%d %H:%M')
+    CONTENT="# Ontology Sources ${DATE_KB}
+
+${SUMMARY}"
+    bash "$KB_WRITE_SCRIPT" "$CONTENT" "ontology" "note" 2>/dev/null || true
+    log "KB写入完成"
+fi
+
+# ── 永久归档 ──────────────────────────────────────────────────────────
+{
+    echo ""
+    echo "## ${DAY}"
+    cat "$MSG_FILE"
+} >> "$KB_SRC"
+
+# ── 清理 seen 缓存 ──────────────────────────────────────────────────
+if [ "$(wc -l < "$SEEN_FILE" | tr -d ' ')" -gt 500 ]; then
+    tail -300 "$SEEN_FILE" > "$SEEN_FILE.tmp" && mv "$SEEN_FILE.tmp" "$SEEN_FILE"
+fi
+
+# ── rsync 备份 ──────────────────────────────────────────────────────
+rsync -a --quiet "$HOME/.kb/" "/Volumes/MOVESPEED/KB/" 2>/dev/null || true
+log "完成"

--- a/jobs/semantic_scholar/run_semantic_scholar.sh
+++ b/jobs/semantic_scholar/run_semantic_scholar.sh
@@ -37,7 +37,7 @@ test -f "$KB_SRC" || echo "# Semantic Scholar AI论文" > "$KB_SRC"
 
 # ── 1. 多关键词搜索 + 合并去重 ──────────────────────────────────────
 # 搜索多个关键词，每个取 20 篇，合并后按引用量排序
-KEYWORDS=("large language model" "LLM agent" "RAG retrieval augmented" "multimodal AI" "RLHF alignment" "ontology knowledge graph" "neuro-symbolic reasoning" "enterprise ontology")
+KEYWORDS=("large language model" "LLM agent" "RAG retrieval augmented" "multimodal AI" "RLHF alignment" "ontology knowledge graph" "neuro-symbolic reasoning" "enterprise ontology" "formal ontology information systems" "description logic OWL" "semantic web linked data" "knowledge representation reasoning")
 RAW_DIR="$CACHE/raw"
 mkdir -p "$RAW_DIR"
 

--- a/jobs_registry.yaml
+++ b/jobs_registry.yaml
@@ -326,6 +326,16 @@ jobs:
     tier: core                       # ontology 治理基石
     description: 每日 ontology 治理审计 — governance_checker.py --full（17不变式+6元发现）+ engine.py --check（81规则），失败推送 alerts
 
+  - id: ontology_sources
+    scheduler: system
+    entry: jobs/ontology_sources/run_ontology_sources.sh
+    interval: "0 10,20 * * *"         # 每天 10:00, 20:00 HKT
+    log: ~/.openclaw/logs/jobs/ontology_sources.log
+    needs_api_key: false
+    enabled: true
+    tier: auxiliary                     # ontology 知识积累
+    description: Ontology 专属信息源监控 — Semantic Web Journal + W3C + KG Conference RSS，关键词过滤，LLM 富摘要，Discord #ontology 推送 + KB 归档
+
   - id: preference_learner
     scheduler: system
     entry: preference_learner.py


### PR DESCRIPTION
## Summary\n- **Step 1**: 新建 `ontology_sources` job — SWJ/W3C/KG Conference RSS 监控，ontology 关键词过滤，LLM 富摘要，Discord #ontology 推送 + KB 归档\n- **Step 2**: DBLP/S2 追加 4 个本体关键词（formal ontology, description logic, semantic web, knowledge representation）\n- **Step 3**: X 监控追加 4 位本体领域奠基人（Barry Smith/Guizzardi/Hitzler/Horrocks）\n\n## Test plan\n- [ ] `python3 check_registry.py` — 35 jobs validated\n- [ ] `python3 gen_jobs_doc.py --check` — 无 drift\n- [ ] Mac Mini 部署后手动测试 `bash ~/.openclaw/jobs/ontology_sources/run_ontology_sources.sh`\n- [ ] 注册 crontab: `bash ~/crontab_safe.sh add '0 10,20 * * * bash -lc ...ontology_sources...'`\n\nhttps://claude.ai/code/session_01Hexa5bqVC1R6WKUAy6cmmK