### PR TITLE
fix(ontology-sources): robust ScienceDirect description cleaning

### DIFF
--- a/jobs/ontology_sources/run_ontology_sources.sh
+++ b/jobs/ontology_sources/run_ontology_sources.sh
@@ -228,7 +228,11 @@ def clean_desc(desc):
     if not desc:
         return ""
     desc = re.sub(r'<[^>]+>', ' ', desc)
-    desc = re.sub(r'^Publication date:.*?Author\(s\):\s*[^.]+\.?\s*', '', desc, flags=re.DOTALL)
+    # Strip ScienceDirect metadata: everything up to "Abstract:" if present
+    desc = re.sub(r'^.*?Abstract\s*:\s*', '', desc, flags=re.DOTALL | re.IGNORECASE)
+    # Fallback: strip remaining Publication date / Author lines individually
+    desc = re.sub(r'Publication date:[^\n]*', '', desc)
+    desc = re.sub(r'Author\(s\):[^\n]*', '', desc)
     return re.sub(r'\s+', ' ', desc).strip()
 
 prompt = """你是本体论(Ontology)和语义网(Semantic Web)领域的学术编辑。对以下每篇文章严格输出三行（不要输出任何其他内容）：


### PR DESCRIPTION
Old regex stopped at first period in author names (e.g. "J. Smith"), leaving subsequent authors as residual text. New approach: strip everything up to "Abstract:" if present, with line-level fallback for Publication date / Author(s) fields.

https://claude.ai/code/session_01Dd9177AjTsgNZYf6Kc399W

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
