### PR TITLE
fix(proxy): strip <tool_call> XML from search_kb followup response

### DIFF
--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -735,6 +735,16 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 resp_body = resp.read()
                 rj = json.loads(resp_body)
                 content = rj.get("choices", [{}])[0].get("message", {}).get("content", "")
+
+                # Followup 响应也可能含 <tool_call> XML（Qwen3 训练 artifact）
+                # 必须清理，否则原样发到 WhatsApp
+                if isinstance(content, str) and "<tool_call>" in content:
+                    import re
+                    cleaned = re.sub(r'<tool_call>\s*\{.*?\}\s*</tool_call>', '', content, flags=re.DOTALL).strip()
+                    rj["choices"][0]["message"]["content"] = cleaned
+                    log(f"[{rid}] SEARCH_KB followup: stripped <tool_call> XML ({len(content)} -> {len(cleaned)} chars)")
+                    content = cleaned
+
                 log(f"[{rid}] SEARCH_KB followup result: {len(content)} chars")
                 return rj
         except Exception as e:


### PR DESCRIPTION
Root cause: _followup_llm_call() returns LLM response without <tool_call> XML filtering. When Qwen3's followup hallucinates a tool call as text (training artifact), it leaks to WhatsApp.

Evidence: proxy log shows SEARCH_KB followup returned 97 chars TEXT, matching the <tool_call>{"name":"memory_search",...} XML the user saw.

https://claude.ai/code/session_01Dqkp3znQ59EZeP2FNnUKhZ

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
