### PR TITLE
fix(shadow): enable drift detection by passing log_fn

### DIFF
--- a/tool_proxy.py
+++ b/tool_proxy.py
@@ -888,7 +888,7 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
                 # Filter tools
                 elif "tools" in body:
                     orig = len(body["tools"])
-                    body["tools"], all_names, kept_names = filter_tools(body["tools"])
+                    body["tools"], all_names, kept_names = filter_tools(body["tools"], log_fn=lambda msg: log(f"[{rid}] {msg}"))
                     log(f"[{rid}] ALL tools ({orig}): {all_names}")
                     log(f"[{rid}] Kept tools ({len(body['tools'])}): {kept_names}")
                     if not body["tools"]:


### PR DESCRIPTION
## Summary
- Pass `log_fn` to `filter_tools()` in tool_proxy.py — one-line fix
- Shadow mode was running since V36.3 (04-08) but drift comparison and risk classification never executed because `log_fn` was `None`
- Now every request will log `ONTO SHADOW DRIFT` if engine disagrees with hardcoded, and flag high-risk tools

## What to expect after deploy
- `tool_proxy.log` will show per-request ontology observations
- If no `SHADOW DRIFT` lines appear over 7 days → safe to switch `ONTOLOGY_MODE=on`
- If drift appears → investigate and fix ontology rules before switching

## Test plan
- [x] 86 proxy_filters unit tests pass
- [ ] Mac Mini: sync + restart proxy + check `tool_proxy.log` for `ONTO` entries after a few WhatsApp messages

https://claude.ai/code/session_01VsGN41oX3B79uCoqFPn36b