### PR TITLE
fix(governance): INV-CRON-003/004 matcher must distinguish prefix-sub…

### DIFF
--- a/full_regression.sh
+++ b/full_regression.sh
@@ -55,6 +55,9 @@ run_suite "audit_log (审计日志/链式哈希)" "python3 test_audit_log.py"
 run_suite "reliability_bench (故障场景评测)" "python3 test_reliability_bench.py"
 run_suite "memory_plane (统一记忆平面)" "python3 test_memory_plane.py"
 run_suite "slo_dashboard (SLO仪表盘)" "python3 test_slo_dashboard.py"
+if [ -f ontology/tests/test_governance_cron_matcher.py ]; then
+    run_suite "governance_cron_matcher (INV-CRON-003/004 匹配器)" "python3 -m unittest ontology.tests.test_governance_cron_matcher"
+fi
 
 # 条件性测试（仅当文件存在时运行）
 for tf in test_conv_quality.py test_kb_autotag.py test_kb_dedup.py test_token_report.py test_arxiv_parser.py test_shell_antipatterns.py; do

--- a/ontology/governance_ontology.yaml
+++ b/ontology/governance_ontology.yaml
@@ -455,14 +455,33 @@ invariants:
     verification_layer: [runtime]
     severity: critical
     declaration: "每个 enabled job 的 crontab 条目必须包含 bash -lc（否则 cron 环境缺少 env vars）"
-    design_decision: "2026-04-08 教训：DBLP/Dream/Watchdog 无 bash -lc → OPENCLAW_PHONE 为占位号 → 推送连续失败 3 天"
+    design_decision: "2026-04-08 教训：DBLP/Dream/Watchdog 无 bash -lc → OPENCLAW_PHONE 为占位号 → 推送连续失败 3 天。2026-04-11 修复匹配逻辑：原子串匹配 `script in line` 对同脚本不同参数的条目（kb_dream.sh vs kb_dream.sh --map-sources）会错误命中首条，改为 endswith + 词边界。"
     checks:
       - name: "所有 enabled job 的 crontab 条目包含 bash -lc"
         check_type: python_assert
         requires_full: true
         code: |
-          import subprocess
+          import re, subprocess
           from check_registry import load_yaml
+
+          def _cron_cmd_invokes(line, entry):
+              """Return True iff this crontab line's command invokes exactly this registry entry.
+              Uses endswith + word-boundary to avoid false-positive on shared prefixes
+              (e.g. 'kb_dream.sh' must not match 'kb_dream.sh --map-sources')."""
+              parts = line.split(None, 5)
+              if len(parts) < 6:
+                  return False
+              cmd = parts[5]
+              # Strip trailing redirection pipeline
+              cmd = re.split(r"\s*(?:>>|>|<|2>|\|)", cmd, maxsplit=1)[0]
+              cmd = cmd.rstrip(" '\"")
+              if not cmd.endswith(entry):
+                  return False
+              idx = len(cmd) - len(entry)
+              if idx == 0:
+                  return True
+              return cmd[idx - 1] in "/ \t\"'"
+
           data = load_yaml("jobs_registry.yaml")
           crontab = subprocess.check_output(['crontab', '-l'], text=True)
           missing = []
@@ -470,13 +489,14 @@ invariants:
               if not job.get('enabled') or job.get('scheduler') != 'system':
                   continue
               entry = job.get('entry', '')
-              script = entry.split('/')[-1] if entry else ''
-              if not script:
+              if not entry:
                   continue
               for line in crontab.splitlines():
-                  if script in line and not line.strip().startswith('#'):
+                  if not line.strip() or line.strip().startswith('#'):
+                      continue
+                  if _cron_cmd_invokes(line, entry):
                       if 'bash -lc' not in line:
-                          missing.append(f"{job['id']}: {script}")
+                          missing.append(f"{job['id']}: {entry}")
                       break
           assert not missing, f"缺少 bash -lc: {'; '.join(missing)}"
 
@@ -486,14 +506,31 @@ invariants:
     verification_layer: [runtime]
     severity: high
     declaration: "每个完整命令（脚本+参数）在 crontab 中最多出现一次（同一脚本不同参数视为不同 job，如 kb_dream.sh vs kb_dream.sh --map-only）"
-    design_decision: "2026-04-08 教训：kb_dream 有 3 个完全相同的 crontab 条目→双进程 lock contention；2026-04-10 澄清：同一脚本不同参数是合法的分离调度（Map-Reduce 分阶段执行）"
+    design_decision: "2026-04-08 教训：kb_dream 有 3 个完全相同的 crontab 条目→双进程 lock contention；2026-04-10 澄清：同一脚本不同参数是合法的分离调度（Map-Reduce 分阶段执行）；2026-04-11 修复 check bug：原 `sname in l` 子串匹配导致 Reduce 条目（entry=kb_dream.sh）被 --map-sources/--map-notes 误报 x3。改为 endswith + 词边界精确匹配。"
     checks:
       - name: "crontab 中无完全重复的命令条目"
         check_type: python_assert
         requires_full: true
         code: |
-          import subprocess
+          import re, subprocess
           from check_registry import load_yaml
+
+          def _cron_cmd_invokes(line, entry):
+              """Return True iff this crontab line's command invokes exactly this registry entry.
+              See INV-CRON-003 for rationale."""
+              parts = line.split(None, 5)
+              if len(parts) < 6:
+                  return False
+              cmd = parts[5]
+              cmd = re.split(r"\s*(?:>>|>|<|2>|\|)", cmd, maxsplit=1)[0]
+              cmd = cmd.rstrip(" '\"")
+              if not cmd.endswith(entry):
+                  return False
+              idx = len(cmd) - len(entry)
+              if idx == 0:
+                  return True
+              return cmd[idx - 1] in "/ \t\"'"
+
           data = load_yaml("jobs_registry.yaml")
           crontab = subprocess.check_output(['crontab', '-l'], text=True)
           lines = [l for l in crontab.splitlines() if l.strip() and not l.strip().startswith('#')]
@@ -502,13 +539,9 @@ invariants:
               if not job.get('enabled') or job.get('scheduler') != 'system':
                   continue
               entry = job.get('entry', '')
-              sname = entry.split('/')[-1] if entry else ''
-              if not sname:
+              if not entry:
                   continue
-              count = 0
-              for l in lines:
-                  if sname in l:
-                      count += 1
+              count = sum(1 for l in lines if _cron_cmd_invokes(l, entry))
               if count > 1:
                   dupes.append(f"{job['id']} x{count}")
           assert not dupes, f"重复 crontab: {'; '.join(dupes)}"

--- a/ontology/tests/test_governance_cron_matcher.py
+++ b/ontology/tests/test_governance_cron_matcher.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+test_governance_cron_matcher.py — regression test for INV-CRON-003/004 matcher
+
+Background:
+-----------
+The original bash-lc-enforcement and crontab-no-duplicates checks used naive
+substring matching (`script in line` / `sname in l`). This produced
+false-positives whenever one registry entry's command was a prefix of another,
+as with Map/Reduce split scheduling:
+
+    kb_dream.sh                   # Reduce job
+    kb_dream.sh --map-sources     # Map Sources job
+    kb_dream.sh --map-notes       # Map Notes job
+
+`kb_dream.sh` appears as a substring in all three crontab lines, so the
+Reduce job was mis-counted as 3 duplicates, contradicting the check's own
+declaration ("same script with different args is legal split scheduling").
+
+Fix:
+----
+Use `endswith(entry)` + word-boundary (char before entry must be path
+separator, whitespace, or quote). This isolates each entry to exactly one
+crontab line even when entries share prefixes.
+
+This test locks in the fix so the bug can't silently regress.
+"""
+
+import os
+import re
+import sys
+import unittest
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ONTOLOGY_DIR = os.path.dirname(_TESTS_DIR)
+_PROJECT_ROOT = os.path.dirname(_ONTOLOGY_DIR)
+for p in [_ONTOLOGY_DIR, _PROJECT_ROOT]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _cron_cmd_invokes(line, entry):
+    """Mirror of the matcher in governance_ontology.yaml INV-CRON-003/004.
+
+    Return True iff this crontab line's command invokes exactly this registry
+    entry. Uses endswith + word-boundary to avoid false-positives on shared
+    prefixes.
+    """
+    parts = line.split(None, 5)
+    if len(parts) < 6:
+        return False
+    cmd = parts[5]
+    cmd = re.split(r"\s*(?:>>|>|<|2>|\|)", cmd, maxsplit=1)[0]
+    cmd = cmd.rstrip(" '\"")
+    if not cmd.endswith(entry):
+        return False
+    idx = len(cmd) - len(entry)
+    if idx == 0:
+        return True
+    return cmd[idx - 1] in "/ \t\"'"
+
+
+# Real Mac Mini crontab snapshot (2026-04-11) showing the Map-Reduce split
+# scheduling that exposed the original substring-matching bug.
+SAMPLE_CRONTAB = """*/2 * * * * bash -lc 'bash ~/openclaw-model-bridge/auto_deploy.sh >> ~/.openclaw/logs/auto_deploy.log 2>&1'
+0 8,14,20 * * * bash -lc 'bash ~/.openclaw/jobs/freight_watcher/run_freight.sh >> ~/.openclaw/logs/jobs/freight_watcher.log 2>&1'
+0 3 * * * bash -lc 'bash ~/kb_dream.sh >> ~/kb_dream.log 2>&1'
+0 0 * * * cd ~ && bash kb_dream.sh --map-sources >> ~/kb_dream.log 2>&1
+40 0 * * * cd ~ && bash kb_dream.sh --map-notes >> ~/kb_dream.log 2>&1
+0 7 * * * bash -lc "~/governance_audit_cron.sh" >> ~/governance_audit.log 2>&1
+0 14 * * * mkdir -p $HOME/.openclaw/logs/jobs; bash -lc "$HOME/.openclaw/jobs/github_trending/run_github_trending.sh >> $HOME/.openclaw/logs/jobs/github_trending.log 2>&1"
+"""
+
+
+class TestCronCmdInvokes(unittest.TestCase):
+    """Unit tests for the endswith+word-boundary matcher."""
+
+    def test_exact_entry_matches_exact_line(self):
+        line = "0 3 * * * bash -lc 'bash ~/kb_dream.sh >> ~/kb_dream.log 2>&1'"
+        self.assertTrue(_cron_cmd_invokes(line, "kb_dream.sh"))
+
+    def test_reduce_entry_does_not_match_map_line(self):
+        """Regression: kb_dream.sh (Reduce) must not match --map-sources line."""
+        map_line = "0 0 * * * cd ~ && bash kb_dream.sh --map-sources >> ~/kb_dream.log 2>&1"
+        self.assertFalse(_cron_cmd_invokes(map_line, "kb_dream.sh"))
+
+    def test_map_sources_entry_matches_its_line(self):
+        line = "0 0 * * * cd ~ && bash kb_dream.sh --map-sources >> ~/kb_dream.log 2>&1"
+        self.assertTrue(_cron_cmd_invokes(line, "kb_dream.sh --map-sources"))
+
+    def test_map_sources_entry_does_not_match_map_notes_line(self):
+        map_notes_line = "40 0 * * * cd ~ && bash kb_dream.sh --map-notes >> ~/kb_dream.log 2>&1"
+        self.assertFalse(_cron_cmd_invokes(map_notes_line, "kb_dream.sh --map-sources"))
+
+    def test_entry_with_path_prefix_in_line(self):
+        line = "0 8,14,20 * * * bash -lc 'bash ~/.openclaw/jobs/freight_watcher/run_freight.sh >> ~/.openclaw/logs/jobs/freight_watcher.log 2>&1'"
+        self.assertTrue(_cron_cmd_invokes(line, "run_freight.sh"))
+
+    def test_word_boundary_rejects_partial_name(self):
+        """`dream.sh` must not match `kb_dream.sh`."""
+        line = "0 3 * * * bash -lc 'bash ~/kb_dream.sh >> ~/kb_dream.log 2>&1'"
+        self.assertFalse(_cron_cmd_invokes(line, "dream.sh"))
+
+    def test_mkdir_prefix_does_not_break_match(self):
+        line = '0 14 * * * mkdir -p $HOME/.openclaw/logs/jobs; bash -lc "$HOME/.openclaw/jobs/github_trending/run_github_trending.sh >> $HOME/.openclaw/logs/jobs/github_trending.log 2>&1"'
+        self.assertTrue(_cron_cmd_invokes(line, "run_github_trending.sh"))
+
+    def test_double_quoted_command_match(self):
+        line = '0 7 * * * bash -lc "~/governance_audit_cron.sh" >> ~/governance_audit.log 2>&1'
+        self.assertTrue(_cron_cmd_invokes(line, "governance_audit_cron.sh"))
+
+    def test_empty_line_returns_false(self):
+        self.assertFalse(_cron_cmd_invokes("", "foo.sh"))
+
+    def test_comment_style_not_enough_fields(self):
+        self.assertFalse(_cron_cmd_invokes("# comment", "foo.sh"))
+
+
+class TestInvCron004NoFalsePositive(unittest.TestCase):
+    """End-to-end regression: kb_dream Reduce must NOT be flagged as duplicate."""
+
+    def test_kb_dream_reduce_counts_as_one(self):
+        lines = [l for l in SAMPLE_CRONTAB.splitlines() if l.strip() and not l.strip().startswith("#")]
+        count = sum(1 for l in lines if _cron_cmd_invokes(l, "kb_dream.sh"))
+        self.assertEqual(count, 1, "kb_dream Reduce must match exactly 1 crontab line, got {}".format(count))
+
+    def test_kb_dream_map_sources_counts_as_one(self):
+        lines = [l for l in SAMPLE_CRONTAB.splitlines() if l.strip() and not l.strip().startswith("#")]
+        count = sum(1 for l in lines if _cron_cmd_invokes(l, "kb_dream.sh --map-sources"))
+        self.assertEqual(count, 1)
+
+    def test_kb_dream_map_notes_counts_as_one(self):
+        lines = [l for l in SAMPLE_CRONTAB.splitlines() if l.strip() and not l.strip().startswith("#")]
+        count = sum(1 for l in lines if _cron_cmd_invokes(l, "kb_dream.sh --map-notes"))
+        self.assertEqual(count, 1)
+
+
+class TestInvCron003DetectsMissingBashLc(unittest.TestCase):
+    """End-to-end regression: checker must flag real missing-bash-lc cases."""
+
+    def test_map_sources_entry_flagged_as_missing_bash_lc(self):
+        entry = "kb_dream.sh --map-sources"
+        found_line = None
+        for line in SAMPLE_CRONTAB.splitlines():
+            if not line.strip() or line.strip().startswith("#"):
+                continue
+            if _cron_cmd_invokes(line, entry):
+                found_line = line
+                break
+        self.assertIsNotNone(found_line)
+        self.assertNotIn("bash -lc", found_line)
+
+    def test_reduce_entry_finds_bash_lc_line(self):
+        entry = "kb_dream.sh"
+        found_line = None
+        for line in SAMPLE_CRONTAB.splitlines():
+            if not line.strip() or line.strip().startswith("#"):
+                continue
+            if _cron_cmd_invokes(line, entry):
+                found_line = line
+                break
+        self.assertIsNotNone(found_line)
+        self.assertIn("bash -lc", found_line)
+
+
+class TestYamlMatcherInSync(unittest.TestCase):
+    """Sanity check: the matcher logic in governance_ontology.yaml must match
+    this test file's local copy. If this fails, someone changed one side
+    without the other."""
+
+    def test_yaml_contains_endswith_matcher(self):
+        yaml_path = os.path.join(_PROJECT_ROOT, "ontology", "governance_ontology.yaml")
+        with open(yaml_path) as f:
+            content = f.read()
+        # Both INV-CRON-003 and INV-CRON-004 should use the _cron_cmd_invokes helper
+        self.assertIn("_cron_cmd_invokes", content)
+        self.assertIn("cmd.endswith(entry)", content)
+        # And must NOT fall back to the naive `sname in l` substring approach
+        self.assertNotIn("if sname in l:", content)
+        self.assertNotIn("if script in line and not line.strip().startswith('#'):", content)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-04-10 18:42:32",
+  "updated": "2026-04-11 01:27:04",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -211,11 +211,11 @@
   },
   "quality": {
     "security_score": "93",
-    "test_count": "729",
-    "last_regression": "2026-04-10 18:42 pass",
+    "test_count": "745",
+    "last_regression": "2026-04-11 01:27 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-04-10 18:42",
-    "test_suites": "26",
+    "security_score_time": "2026-04-11 01:27",
+    "test_suites": "27",
     "governance_invariants": "22/22",
     "governance_checks": "30/41",
     "version": "0.36.0"


### PR DESCRIPTION
…set entries

Root cause
----------
Both checks used naive substring matching (`script in line` / `sname in l`) to correlate a registry entry with its crontab line. This breaks for Map-Reduce split scheduling where one entry's command is a prefix of another:

    kb_dream.sh                   # Reduce job
    kb_dream.sh --map-sources     # Map Sources job
    kb_dream.sh --map-notes       # Map Notes job

Under substring matching, `kb_dream.sh` alone matches all three crontab lines, so INV-CRON-004 flagged the Reduce entry as x3 duplicate — directly contradicting its own declaration ("same script with different args is legal split scheduling"). INV-CRON-003 happened to report correctly on Mac Mini only by luck of crontab line ordering.

Fix
---
Replace substring matching with `endswith(entry)` + word-boundary check (the character immediately before `entry` must be a path separator, whitespace, or quote). This isolates each entry to exactly one crontab line even when entries share prefixes.

Verified on the real Mac Mini crontab snapshot:
- INV-CRON-004 false-positive (kb_dream x3) → 0 dupes
- INV-CRON-003 correctly identifies the 2 real offenders (kb_dream --map-sources / --map-notes are missing `bash -lc`)

Regression test
---------------
New ontology/tests/test_governance_cron_matcher.py (16 tests):
- TestCronCmdInvokes: 10 matcher unit tests including the specific "kb_dream.sh must not match --map-sources line" regression
- TestInvCron004NoFalsePositive: 3 end-to-end counts on real crontab
- TestInvCron003DetectsMissingBashLc: 2 end-to-end detection
- TestYamlMatcherInSync: 1 guard that both YAML checks use the helper

Wired into full_regression.sh so the matcher can't silently regress. Total suite: 729 → 745 tests, 26 → 27 suites.

Note: the real Mac Mini crontab still has the 2 kb_dream Map entries without `bash -lc`. That is a separate runtime fix (requires editing the Mac Mini crontab), not a check-logic issue.

https://claude.ai/code/session_01LNEfDJ9NzrSUKSXzfXbGBj

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
