### PR TITLE
fix(governance): exec() scope trap in INV-CRON-004 + silent error bug

### DIFF
--- a/ontology/governance_checker.py
+++ b/ontology/governance_checker.py
@@ -554,13 +554,18 @@ def print_results(results):
                 if c["message"]:
                     print(f"          → {c['message']}")
 
-        if r["status"] == "fail":
+        # Count both hard failures (fail) and execution errors (error) as
+        # not-passing. Previously `error` status was silently ignored, so a
+        # broken check (exception in Python code) looked identical to a pass.
+        if r["status"] in ("fail", "error"):
             failed_invs += 1
 
     # Summary
     mr_used = set(r["meta_rule"] for r in results if r["meta_rule"])
     skipped = sum(1 for r in results for c in r["checks"] if c["status"] == "skip")
     executed = total_checks - skipped
+    errored_invs = sum(1 for r in results if r["status"] == "error")
+    hard_fail_invs = failed_invs - errored_invs
 
     print()
     print("─" * 70)
@@ -568,7 +573,12 @@ def print_results(results):
     print(f"  通过: {passed_checks}/{executed} checks | 元规则: {len(mr_used)}/6")
 
     if failed_invs:
-        print(f"\n  ❌ {failed_invs} 个不变式被违反")
+        if errored_invs and hard_fail_invs:
+            print(f"\n  ❌ {hard_fail_invs} 个不变式被违反, 💥 {errored_invs} 个检查执行出错")
+        elif errored_invs:
+            print(f"\n  💥 {errored_invs} 个不变式检查执行出错")
+        else:
+            print(f"\n  ❌ {failed_invs} 个不变式被违反")
     else:
         print(f"\n  ✅ 所有不变式成立")
     print("=" * 70)

--- a/ontology/governance_ontology.yaml
+++ b/ontology/governance_ontology.yaml
@@ -541,7 +541,15 @@ invariants:
               entry = job.get('entry', '')
               if not entry:
                   continue
-              count = sum(1 for l in lines if _cron_cmd_invokes(l, entry))
+              # Regular for-loop instead of generator: Python exec() puts
+              # `def _cron_cmd_invokes` into the local scope of the exec'd code,
+              # and generator expressions create their own scope that cannot see
+              # enclosing function locals (only module globals). This would fail
+              # with NameError: name '_cron_cmd_invokes' is not defined.
+              count = 0
+              for l in lines:
+                  if _cron_cmd_invokes(l, entry):
+                      count += 1
               if count > 1:
                   dupes.append(f"{job['id']} x{count}")
           assert not dupes, f"重复 crontab: {'; '.join(dupes)}"

--- a/ontology/tests/test_governance_cron_matcher.py
+++ b/ontology/tests/test_governance_cron_matcher.py
@@ -180,5 +180,62 @@ class TestYamlMatcherInSync(unittest.TestCase):
         self.assertNotIn("if script in line and not line.strip().startswith('#'):", content)
 
 
+class TestExecScopeTrap(unittest.TestCase):
+    """Regression: Python exec() puts `def helper` into local scope of the
+    exec'd code, and generator expressions create their own scope that cannot
+    see enclosing function locals (only module globals). So code like:
+
+        exec('''
+            def helper(x): return x > 0
+            xs = [1, 2, 3]
+            n = sum(1 for x in xs if helper(x))  # ← NameError!
+        ''')
+
+    fails with `NameError: name 'helper' is not defined`. This bit us on
+    2026-04-11 when INV-CRON-004 was using `sum(1 for l in lines if
+    _cron_cmd_invokes(l, entry))` inside governance_checker's _exec_python_assert.
+
+    Lock in two things:
+    1. The YAML check for INV-CRON-004 must NOT use a generator expression
+       that references a local helper — it must use a plain for-loop.
+    2. A standalone exec() reproducer shows the trap exists, so the regression
+       test is self-explanatory to anyone reading it.
+    """
+
+    def test_yaml_no_generator_expression_over_cron_cmd_invokes(self):
+        yaml_path = os.path.join(_PROJECT_ROOT, "ontology", "governance_ontology.yaml")
+        with open(yaml_path) as f:
+            content = f.read()
+        # These are the two known-broken patterns. If either reappears,
+        # governance_checker will silently error on INV-CRON-004.
+        self.assertNotIn("sum(1 for l in lines if _cron_cmd_invokes", content)
+        self.assertNotIn("sum(1 for line in lines if _cron_cmd_invokes", content)
+
+    def test_exec_scope_trap_is_real(self):
+        """Positive-control reproduction. If this starts failing, Python
+        semantics changed and we can simplify the yaml fix."""
+        gen_code = (
+            "def helper(x):\n"
+            "    return x > 0\n"
+            "xs = [1, 2, 3]\n"
+            "result = sum(1 for x in xs if helper(x))\n"
+        )
+        with self.assertRaises(NameError):
+            exec(compile(gen_code, "<trap>", "exec"))
+
+        loop_code = (
+            "def helper(x):\n"
+            "    return x > 0\n"
+            "xs = [1, 2, 3]\n"
+            "result = 0\n"
+            "for x in xs:\n"
+            "    if helper(x):\n"
+            "        result += 1\n"
+        )
+        ns = {}
+        exec(compile(loop_code, "<loop>", "exec"), ns)
+        self.assertEqual(ns["result"], 3)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-04-11 01:27:04",
+  "updated": "2026-04-11 01:41:53",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -211,10 +211,10 @@
   },
   "quality": {
     "security_score": "93",
-    "test_count": "745",
-    "last_regression": "2026-04-11 01:27 pass",
+    "test_count": "747",
+    "last_regression": "2026-04-11 01:41 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-04-11 01:27",
+    "security_score_time": "2026-04-11 01:41",
     "test_suites": "27",
     "governance_invariants": "22/22",
     "governance_checks": "30/41",


### PR DESCRIPTION
Two bugs surfaced by 2026-04-11 Mac Mini audit:

1. INV-CRON-004 python_assert errored with NameError: `_cron_cmd_invokes` was a `def` inside the exec'd code, so it lived in the exec's local scope. The subsequent `sum(1 for l in lines if _cron_cmd_invokes(l, entry))` generator expression creates its own scope that can only see enclosing function locals and module globals — not exec locals. The helper was invisible and the check blew up on every run.

   Fix: replace the generator with a plain `for`-loop so the comprehension scope is never created. Regular for-loops run in the enclosing scope and can see the helper fine.

2. `failed_invs` counter in governance_checker.print_results() only counted `status == "fail"`, silently ignoring `status == "error"`. So a broken check that raised an exception looked identical to a pass in the summary line — the audit reported "✅ 所有不变式成立" while a 💥 icon hid in the body. This masked bug #1 for an entire full-mode run.

   Fix: treat both `fail` and `error` as not-passing, and surface errored invariants in the summary ("💥 N 个不变式检查执行出错").

Regression tests added (ontology/tests/test_governance_cron_matcher.py):
- `test_yaml_no_generator_expression_over_cron_cmd_invokes`: grep-style guard that the YAML check never reintroduces the broken pattern.
- `test_exec_scope_trap_is_real`: positive-control reproduction of the underlying Python semantics, self-documenting for future readers.

Full regression: 27 suites / 747 tests / 0 fail (was 745).
Governance dev-mode: 22/22 invariants, exit 0.

https://claude.ai/code/session_01LNEfDJ9NzrSUKSXzfXbGBj

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
