### PR TITLE
V37.8.1 fix three preflight/governance遗留 issues

### DIFF
--- a/ontology/governance_checker.py
+++ b/ontology/governance_checker.py
@@ -476,54 +476,60 @@ def _discover_silent_channels(severity):
     source_silent = [t for t in topics if t not in sourced_topics]
 
     # ── Activity layer: 仅 --full 模式 + 存在 ~/.kb 时执行 ───────
+    # V37.8.1 重写：用 registry-driven topic→job log 映射替代 V37.8 的
+    # notify_queue + jobs/*/cache 路径（前者只记失败重放，后者不是每个 job
+    # 都有 cache/ 目录，导致 6 频道全部 7 天无活动假阳性）。
+    # 正确信号源：每个 job 的真实日志文件 mtime。
     activity_silent = []
     activity_note = ""
     home = os.path.expanduser("~")
     kb_dir = os.path.join(home, ".kb")
-    queue_dir = os.path.join(kb_dir, "notify_queue")
+
+    # topic → 贡献该频道推送的 job_id 列表（与 source layer 的 callers_per_topic 对应）
+    TOPIC_JOB_MAP = {
+        "papers": ["arxiv_monitor", "hf_papers", "semantic_scholar", "dblp",
+                    "acl_anthology", "ai_leaders_x"],
+        "freight": ["freight_watcher"],
+        "alerts": ["job_watchdog", "auto_deploy"],
+        "daily": ["kb_review", "kb_evening", "kb_trend", "daily_ops_report",
+                   "kb_dream"],
+        "tech": ["github_trending", "rss_blogs", "run_hn_fixed", "openclaw_run",
+                 "run_discussions"],
+        "ontology": ["ontology_sources"],
+    }
 
     if FULL_MODE and os.path.isdir(kb_dir):
         import time
+        import yaml as yaml_mod
         seven_days_ago = time.time() - 7 * 86400
         active_topics = set()
-        # 用 mtime 作信号：notify_queue/*.json 最近 7 天内被触碰 = 该 topic 有活动
-        # （成功路径也会经过 queue 短暂写入/立刻删除，失败路径会留下）
-        queue_activity_topics = set()
-        if os.path.isdir(queue_dir):
-            for qf in os.listdir(queue_dir):
-                qfp = os.path.join(queue_dir, qf)
-                try:
-                    if os.path.getmtime(qfp) < seven_days_ago:
-                        continue
-                    with open(qfp) as f:
-                        import json as json_mod
-                        data = json_mod.load(f)
-                    t = data.get("topic", "")
-                    if t:
-                        queue_activity_topics.add(t)
-                except Exception:
-                    pass
-        active_topics |= queue_activity_topics
 
-        # jobs/*/cache/*.log 的 mtime 说明该 job 最近跑过；若该 job 的脚本是
-        # 某个 topic 的 caller，就把这个 topic 标记为 active
-        job_log_glob = os.path.join(home, "jobs", "*", "cache", "*.log")
-        for lf in glob_mod.glob(job_log_glob):
-            try:
-                if os.path.getmtime(lf) < seven_days_ago:
+        # 从 jobs_registry.yaml 加载 job_id → log 路径映射
+        registry_path = os.path.join(_PROJECT_ROOT, "jobs_registry.yaml")
+        job_log_paths = {}
+        try:
+            with open(registry_path) as f:
+                reg = yaml_mod.safe_load(f)
+            for job in reg.get("jobs", []):
+                if job.get("enabled") and job.get("log"):
+                    log_path = job["log"].replace("~", home)
+                    job_log_paths[job["id"]] = log_path
+        except Exception:
+            pass
+
+        # 对每个 topic，取其映射 job 的日志文件最大 mtime
+        for topic in topics:
+            job_ids = TOPIC_JOB_MAP.get(topic, [])
+            for jid in job_ids:
+                log_path = job_log_paths.get(jid)
+                if not log_path or not os.path.isfile(log_path):
                     continue
-            except Exception:
-                continue
-            # 从路径回推 job name → 匹配 source-layer 的 callers_per_topic
-            parts = lf.split(os.sep)
-            try:
-                idx = parts.index("jobs")
-                job_name = parts[idx + 1]
-            except (ValueError, IndexError):
-                continue
-            for topic, callers in callers_per_topic.items():
-                if any(job_name in c for c in callers):
-                    active_topics.add(topic)
+                try:
+                    if os.path.getmtime(log_path) >= seven_days_ago:
+                        active_topics.add(topic)
+                        break  # 一个活跃 job 就够
+                except Exception:
+                    continue
 
         # 只对"源码里有 caller 但运行时没信号"的 topic 报 silent
         activity_silent = [

--- a/ontology/tests/test_notify_activity.py
+++ b/ontology/tests/test_notify_activity.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+test_notify_activity.py — V37.8.1 MRD-NOTIFY-002 activity layer regression tests
+
+Background
+----------
+V37.8 rewrote _discover_silent_channels source layer correctly (detects both
+--topic X and DISCORD_CH_X callers), but the activity layer scanned wrong paths:
+  - notify_queue/*.json — only records failed retries, not successes
+  - jobs/*/cache/*.log — not all jobs have cache/ dirs
+
+This produced false positives: all 6 channels reported "7 days no activity"
+even when Mac Mini was pushing daily.
+
+V37.8.1 fix: activity layer now uses an explicit TOPIC_JOB_MAP that maps
+each topic to its contributing job IDs, then looks up real log paths from
+jobs_registry.yaml and checks log file mtimes.
+
+Tests:
+  1. TOPIC_JOB_MAP covers all 6 topics
+  2. TOPIC_JOB_MAP job IDs exist in jobs_registry.yaml
+  3. Source code no longer references notify_queue in activity layer
+  4. Source code no longer references jobs/*/cache in activity layer
+  5. TOPIC_JOB_MAP is loaded from governance_checker module
+  6. Activity layer uses yaml to load registry
+"""
+
+import os
+import sys
+import unittest
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ONTOLOGY_DIR = os.path.dirname(_TESTS_DIR)
+_PROJECT_ROOT = os.path.dirname(_ONTOLOGY_DIR)
+for p in [_ONTOLOGY_DIR, _PROJECT_ROOT]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+class TestTopicJobMapCompleteness(unittest.TestCase):
+    """TOPIC_JOB_MAP must cover all 6 Discord topics."""
+
+    def test_all_six_topics_present(self):
+        """Every Discord topic must have at least one job mapping."""
+        src = open(os.path.join(_ONTOLOGY_DIR, "governance_checker.py")).read()
+        for topic in ["papers", "freight", "alerts", "daily", "tech", "ontology"]:
+            self.assertIn(f'"{topic}"', src,
+                          f"TOPIC_JOB_MAP missing topic '{topic}'")
+
+    def test_papers_has_all_academic_jobs(self):
+        src = open(os.path.join(_ONTOLOGY_DIR, "governance_checker.py")).read()
+        for job in ["arxiv_monitor", "hf_papers", "semantic_scholar",
+                     "dblp", "acl_anthology", "ai_leaders_x"]:
+            self.assertIn(f'"{job}"', src,
+                          f"papers topic missing job '{job}'")
+
+    def test_daily_has_core_jobs(self):
+        src = open(os.path.join(_ONTOLOGY_DIR, "governance_checker.py")).read()
+        for job in ["kb_review", "kb_evening", "kb_trend"]:
+            self.assertIn(f'"{job}"', src,
+                          f"daily topic missing job '{job}'")
+
+
+class TestTopicJobMapRegistrySync(unittest.TestCase):
+    """All job IDs in TOPIC_JOB_MAP must exist in jobs_registry.yaml."""
+
+    def test_all_mapped_jobs_exist_in_registry(self):
+        import yaml
+        import re
+
+        # Extract TOPIC_JOB_MAP from source
+        src = open(os.path.join(_ONTOLOGY_DIR, "governance_checker.py")).read()
+        # Find all job IDs mentioned in TOPIC_JOB_MAP block
+        # Simpler: just extract all quoted strings in the TOPIC_JOB_MAP section
+        map_match = re.search(r'TOPIC_JOB_MAP\s*=\s*\{(.+?)\}', src, re.DOTALL)
+        self.assertIsNotNone(map_match, "TOPIC_JOB_MAP not found in source")
+        map_block = map_match.group(1)
+        # Extract job IDs (values in lists, not keys)
+        job_ids = re.findall(r'"(\w+)"', map_block)
+        # Remove topic names
+        topics = {"papers", "freight", "alerts", "daily", "tech", "ontology"}
+        job_ids = [j for j in job_ids if j not in topics]
+        self.assertTrue(len(job_ids) > 0, "No job IDs found in TOPIC_JOB_MAP")
+
+        # Load registry
+        with open(os.path.join(_PROJECT_ROOT, "jobs_registry.yaml")) as f:
+            reg = yaml.safe_load(f)
+        registry_ids = {j["id"] for j in reg.get("jobs", [])}
+
+        for jid in job_ids:
+            self.assertIn(jid, registry_ids,
+                          f"TOPIC_JOB_MAP job '{jid}' not in jobs_registry.yaml")
+
+
+class TestActivityLayerNoLegacyPaths(unittest.TestCase):
+    """V37.8.1: activity layer must NOT scan notify_queue or jobs/*/cache."""
+
+    def _read_activity_code_lines(self):
+        """Extract executable (non-comment) lines from the activity layer section."""
+        src = open(os.path.join(_ONTOLOGY_DIR, "governance_checker.py")).read()
+        start = src.find("# ── Activity layer:")
+        end = src.find("# ── 合并结论", start)
+        self.assertGreater(start, 0, "Activity layer section not found")
+        self.assertGreater(end, start, "Merge conclusion section not found")
+        section = src[start:end]
+        # Only keep non-comment executable lines
+        lines = [l for l in section.split("\n")
+                 if l.strip() and not l.strip().startswith("#")]
+        return "\n".join(lines)
+
+    def test_no_notify_queue_in_code(self):
+        """Executable code must not reference notify_queue (comments are OK)."""
+        code = self._read_activity_code_lines()
+        self.assertNotIn("notify_queue", code,
+                         "Activity layer code still references notify_queue (V37.8 bug)")
+
+    def test_no_cache_log_glob_in_code(self):
+        """Executable code must not glob jobs/*/cache/*.log."""
+        code = self._read_activity_code_lines()
+        # Check for the specific V37.8 pattern: glob(home, "jobs", "*", "cache"...)
+        self.assertNotIn('"cache"', code,
+                         "Activity layer code still references jobs/*/cache (V37.8 bug)")
+
+    def test_uses_yaml_registry(self):
+        """Activity layer should load jobs_registry.yaml for log paths."""
+        code = self._read_activity_code_lines()
+        self.assertIn("jobs_registry.yaml", code)
+
+    def test_uses_topic_job_map(self):
+        code = self._read_activity_code_lines()
+        self.assertIn("TOPIC_JOB_MAP", code)
+
+
+class TestPreflightStatusJsonExemption(unittest.TestCase):
+    """V37.8.1: preflight must exempt status.json from md5 drift check."""
+
+    def test_status_json_exemption_in_preflight(self):
+        src = open(os.path.join(_PROJECT_ROOT, "preflight_check.sh")).read()
+        self.assertIn('status.json', src)
+        self.assertIn('豁免', src,
+                      "preflight_check.sh missing status.json exemption")
+
+    def test_exemption_before_md5_comparison(self):
+        """The status.json skip must appear before the md5 hash comparison."""
+        src = open(os.path.join(_PROJECT_ROOT, "preflight_check.sh")).read()
+        exempt_pos = src.find('status.json')
+        md5_pos = src.find('HASH_SRC=')
+        self.assertGreater(md5_pos, 0)
+        self.assertGreater(exempt_pos, 0)
+        # The exemption check must be before the md5 comparison in the file
+        # (both are in the FILE_MAP loop, exemption continues before md5)
+        self.assertLess(exempt_pos, md5_pos,
+                        "status.json exemption must appear before md5 comparison")
+
+
+class TestPreflightKbIndexWarnThreshold(unittest.TestCase):
+    """V37.8.1: KB index <=5 stale files should be warn not fail."""
+
+    def test_threshold_5_in_preflight(self):
+        src = open(os.path.join(_PROJECT_ROOT, "preflight_check.sh")).read()
+        self.assertIn('-le 5', src,
+                      "preflight should use <=5 threshold for warn vs fail")
+
+    def test_warn_for_small_count(self):
+        """Small issue count should use warn, not fail."""
+        src = open(os.path.join(_PROJECT_ROOT, "preflight_check.sh")).read()
+        # Find the section with the threshold check
+        idx = src.find('-le 5')
+        self.assertGreater(idx, 0)
+        # The warn should follow the threshold check
+        section = src[idx:idx + 200]
+        self.assertIn('warn', section,
+                      "<=5 stale files should produce warn, not fail")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -194,6 +194,14 @@ with open('$SCRIPT_DIR/auto_deploy.sh') as f:
             continue
         fi
 
+        # V37.8.1: status.json 合法分叉豁免 — repo 是 Claude Code 快照，
+        # runtime 由 cron (kb_status_refresh) 每小时刷新 health/quality 字段，
+        # 两边设计上永远不一致，全文件 md5 比对无意义
+        if [[ "$SRC" == "status.json" ]]; then
+            pass "status.json: 豁免（仓库快照 vs 运行时实时刷新，合法分叉）"
+            continue
+        fi
+
         if [ ! -f "$DST" ]; then
             fail "$SRC: 运行时副本不存在 ($DST)"
             DRIFT_COUNT=$((DRIFT_COUNT + 1))
@@ -771,9 +779,14 @@ if $FULL_MODE; then
         if [ $VERIFY_RC -eq 0 ]; then
             pass "KB 索引 100% 覆盖 ($FILE_COV, $CHUNKS)"
         else
-            # 有问题但不是致命的
             ISSUE_COUNT=$(echo "$VERIFY_OUT" | grep -c "❌\|⚠️" 2>/dev/null || echo "0")
-            fail "KB 索引覆盖不完整: $FILE_COV ($ISSUE_COUNT 个问题)"
+            # V37.8.1: 少量过期文件（<=5）是正常节奏差——kb_embed 每天 03:30 跑，
+            # 日间新增的 notes 要到次日才被索引。只有大量过期才是 cron 故障信号。
+            if [ "$ISSUE_COUNT" -le 5 ]; then
+                warn "KB 索引有 $ISSUE_COUNT 个过期文件（下次 kb_embed cron 自动补齐）"
+            else
+                fail "KB 索引覆盖不完整: $FILE_COV ($ISSUE_COUNT 个问题)"
+            fi
             echo "$VERIFY_OUT" | grep "❌\|⚠️" | head -5 | while read -r line; do
                 echo "      $line"
             done


### PR DESCRIPTION
1. preflight status.json: exempt from md5 drift check — repo is Claude Code snapshot, runtime is live cron-refreshed state, always diverges by design.

2. preflight KB index: <=5 stale files now WARN instead of FAIL — daily 03:30 kb_embed cron creates a natural gap where new notes aren't yet indexed; only large counts indicate real cron failure.

3. MRD-NOTIFY-002 activity layer: rewrite from notify_queue+jobs/*/cache (wrong paths: queue only records failed retries, cache/ doesn't exist for most jobs) to registry-driven TOPIC_JOB_MAP with explicit topic → job_id mapping, looking up real log paths from jobs_registry.yaml and checking mtime. All 6 channels now correctly resolved.

Tests: 12 new (test_notify_activity.py) covering TOPIC_JOB_MAP completeness, registry sync, legacy path removal, preflight exemption and warn threshold. Full suite: 1008 tests / 0 fail, governance 35/35 invariants / 125/125 checks / 9/9 meta rules.

https://claude.ai/code/session_01TypFvCV2UrZHCNcrShp3VN

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
