### PR TITLE
fix(preflight): KB index threshold from count to coverage percentage

### DIFF
--- a/ontology/tests/test_notify_activity.py
+++ b/ontology/tests/test_notify_activity.py
@@ -154,23 +154,30 @@ class TestPreflightStatusJsonExemption(unittest.TestCase):
 
 
 class TestPreflightKbIndexWarnThreshold(unittest.TestCase):
-    """V37.8.1: KB index <=5 stale files should be warn not fail."""
+    """V37.8.1: KB index uses coverage percentage threshold (>=90% = warn, <90% = fail)."""
 
-    def test_threshold_5_in_preflight(self):
+    def test_coverage_percentage_threshold(self):
         src = open(os.path.join(_PROJECT_ROOT, "preflight_check.sh")).read()
-        self.assertIn('-le 5', src,
-                      "preflight should use <=5 threshold for warn vs fail")
+        self.assertIn('-ge 90', src,
+                      "preflight should use >=90% coverage threshold")
 
-    def test_warn_for_small_count(self):
-        """Small issue count should use warn, not fail."""
+    def test_warn_for_high_coverage(self):
+        """>=90% coverage should produce warn, not fail."""
         src = open(os.path.join(_PROJECT_ROOT, "preflight_check.sh")).read()
-        # Find the section with the threshold check
-        idx = src.find('-le 5')
+        idx = src.find('-ge 90')
         self.assertGreater(idx, 0)
-        # The warn should follow the threshold check
         section = src[idx:idx + 200]
         self.assertIn('warn', section,
-                      "<=5 stale files should produce warn, not fail")
+                      ">=90% coverage should produce warn")
+
+    def test_fail_for_low_coverage(self):
+        """<90% coverage should produce fail."""
+        src = open(os.path.join(_PROJECT_ROOT, "preflight_check.sh")).read()
+        idx = src.find('-ge 90')
+        self.assertGreater(idx, 0)
+        section = src[idx:idx + 400]
+        self.assertIn('fail', section,
+                      "<90% coverage should produce fail")
 
 
 if __name__ == "__main__":

--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -780,12 +780,15 @@ if $FULL_MODE; then
             pass "KB 索引 100% 覆盖 ($FILE_COV, $CHUNKS)"
         else
             ISSUE_COUNT=$(echo "$VERIFY_OUT" | grep -c "❌\|⚠️" 2>/dev/null || echo "0")
-            # V37.8.1: 少量过期文件（<=5）是正常节奏差——kb_embed 每天 03:30 跑，
-            # 日间新增的 notes 要到次日才被索引。只有大量过期才是 cron 故障信号。
-            if [ "$ISSUE_COUNT" -le 5 ]; then
-                warn "KB 索引有 $ISSUE_COUNT 个过期文件（下次 kb_embed cron 自动补齐）"
+            # V37.8.1: 用覆盖率百分比判断——kb_embed 每天 03:30 跑一次，
+            # 33 个 cron job 白天持续产出，到晚上 23:00 自然累积 ~36 个未索引文件
+            # （约 90% 覆盖率），这是正常节奏。<90% 才说明 cron 可能故障。
+            COV_PCT=$(echo "$FILE_COV" | grep -oE '[0-9]+%' | grep -oE '[0-9]+')
+            COV_PCT=${COV_PCT:-0}
+            if [ "$COV_PCT" -ge 90 ]; then
+                warn "KB 索引覆盖 ${COV_PCT}%（${ISSUE_COUNT} 个待索引，下次 kb_embed cron 自动补齐）"
             else
-                fail "KB 索引覆盖不完整: $FILE_COV ($ISSUE_COUNT 个问题)"
+                fail "KB 索引覆盖不足: $FILE_COV ($ISSUE_COUNT 个问题，检查 kb_embed cron）"
             fi
             echo "$VERIFY_OUT" | grep "❌\|⚠️" | head -5 | while read -r line; do
                 echo "      $line"


### PR DESCRIPTION
Change KB index staleness check from fixed count (<=5) to coverage percentage (>=90% = warn, <90% = fail). The old threshold failed every evening because 33 cron jobs naturally produce ~36 new/modified files between 03:30 (kb_embed run) and 23:00 (preflight time) — that's normal daily accumulation, not a cron failure signal.

With 358 total files, 36 unindexed = 90% coverage = WARN (expected). Only when coverage drops below 90% (kb_embed cron broken) does it FAIL.

https://claude.ai/code/session_01TypFvCV2UrZHCNcrShp3VN

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
