### PR TITLE
Add finance_news to auto_deploy + fix 12/20 broken RSS sources

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -173,6 +173,9 @@ declare -a FILE_MAP=(
     "jobs/rss_blogs/run_rss_blogs.sh|$HOME/.openclaw/jobs/rss_blogs/run_rss_blogs.sh"
     "jobs/ontology_sources/run_ontology_sources.sh|$HOME/.openclaw/jobs/ontology_sources/run_ontology_sources.sh"
 
+    # 财经/政策新闻（V37.8.2）
+    "jobs/finance_news/run_finance_news.sh|$HOME/.openclaw/jobs/finance_news/run_finance_news.sh"
+
     # AI Leaders X 技术洞察追踪（V34: 替代 karpathy_x，9位 AI 大牛）
     "jobs/karpathy_x/run_karpathy_x.sh|$HOME/.openclaw/jobs/karpathy_x/run_karpathy_x.sh"
     "jobs/ai_leaders_x/run_ai_leaders_x.sh|$HOME/.openclaw/jobs/ai_leaders_x/run_ai_leaders_x.sh"


### PR DESCRIPTION
## Summary
- Add `finance_news` to auto_deploy.sh FILE_MAP for automatic sync
- Fix 12/20 broken RSS sources: replace dead URLs with RSSHub routes and working alternatives
- Fix JSON detection bug (was checking file path instead of content)
- Add new reliable sources: BIS Speeches, Yahoo Finance, FT中文

## Test plan
- [ ] Mac Mini: `git fetch origin main && git reset --hard origin/main`
- [ ] Manual test: `bash ~/.openclaw/jobs/finance_news/run_finance_news.sh`
- [ ] Verify improved source hit rate (target: >50% sources working)

https://claude.ai/code/session_01TypFvCV2UrZHCNcrShp3VN