### PR TITLE
Extend X time window to 72h for weekend coverage

### DIFF
--- a/jobs/finance_news/run_finance_news.sh
+++ b/jobs/finance_news/run_finance_news.sh
@@ -306,7 +306,8 @@ from html import unescape
 from datetime import datetime, timedelta, timezone
 
 html_file, seen_file, handle, label, region = sys.argv[1:6]
-CUTOFF = datetime.now(timezone.utc) - timedelta(hours=36)
+# X 账号用 72h 窗口（覆盖周末，官媒周末发帖少）
+CUTOFF = datetime.now(timezone.utc) - timedelta(hours=72)
 
 with open(seen_file) as f:
     seen_ids = set(line.strip() for line in f if line.strip())


### PR DESCRIPTION
## Summary
- Extend X/Twitter account time window from 36h to 72h
- Diagnostics showed: XHNews had 97 tweets, PDChina 96, CGTN 99, globaltimesnews 98 — all filtered as ">36h old" due to weekend light posting
- 72h window ensures weekend coverage; dedup via seen_x_ids.txt prevents repeats

## Test plan
- [ ] Mac Mini: sync + test run, verify Chinese accounts now return content

https://claude.ai/code/session_01TypFvCV2UrZHCNcrShp3VN