### PR TITLE
Dream Reduce: chunked generation to bypass GPU server output token limit

### DIFF
--- a/kb_dream.sh
+++ b/kb_dream.sh
@@ -1007,113 +1007,128 @@ $REDUCE_MATERIAL
     log "回退后 prompt: ${PROMPT_BYTES} bytes"
 fi
 
-# Reduce 调用 + 短响应自动重试（V37.4.1 → V37.4.2 → V37.8.3 修复）
-# LLM 响应不稳定：同一 prompt 产出 3967/906/876 字节都有可能
-# - MIN_DREAM_CHARS=3000：≈1000 汉字，是"1500 字目标"的合理下限
-# - BEST_RESULT 追踪：始终保留最长的一次，最终 fallback 到最佳
-# - 逐步降温 0.85→0.6→0.4：retry 1 探索，retry 2/3 求稳
-# - 最低兜底 MIN_ACCEPTABLE_CHARS=1500：真短的才算失败
-# - V37.4.2 新增：retry 2/3 改写 prompt（prepend 长度强制前缀）
-#   同一 prompt hash 可能触发 server-side 缓存或收敛到确定性短路径，
-#   retry 时改 prompt hash + 显式长度强制 = 同时绕过缓存和强迫 LLM 展开
-# - V37.8.3 新增：渐进式素材降级（80K → 50K → 30K）
-#   当 prompt 超过 ~80KB 时，模型进入"读多写少"摘要收敛模式：
-#   89KB 输入 × 6节结构要求 → 模型把 token 预算花在理解上，输出仅 ~1200 chars。
-#   重试时缩减素材量，让模型从"阅读理解"切换到"深度分析写作"。
-#   同时重建 REDUCE_PROMPT 以确保素材量变化生效。
-MIN_DREAM_CHARS=3000
-MIN_ACCEPTABLE_CHARS=1500
-MAX_RETRIES=3
+# V37.8.3: 分段生成（Chunked Generation）
+# 根因：远端 GPU 服务器有 output token 上限（~300-500 tokens），单次调用最多产出 ~900 chars。
+# V37.4.2 曾成功（21871 chars），但 04-13 服务端配置变更后退化。
+# 修复：把 6 章节拆成 3 次 LLM 调用，每次只写 2 章节，拼接后达到 2000+ chars。
+# 每次调用用截断后的素材（30KB），减少处理时间。
+CHUNKED_MATERIAL=$(echo "$REDUCE_DATA" | utf8_truncate 30000)
+CHUNKED_CHARS=$(echo "$CHUNKED_MATERIAL" | wc -c | tr -d ' ')
+log "分段生成模式: 素材 ${CHUNKED_CHARS} bytes, 3 次 LLM 调用"
+
+# --- 第 1 段：选题 + 发现过程 + 隐藏关联 ---
+CHUNK1_SYSTEM="你是专业数据分析师。从提供的多源数据中选出一个最有价值的发现，写出两个章节。
+要求：
+1. 选题要有扎实的多源证据链（至少 3 个不同数据源互相印证）
+2. 每个章节至少 200 字，引用具体数据源名称和日期
+3. Markdown 格式，直接输出内容，不要多余的开头和结尾"
+
+CHUNK1_PROMPT="$REDUCE_INTRO
+
+---
+$CHUNKED_MATERIAL
+---
+
+$([ -n "$PREV_THEMES" ] && echo "最近梦境主题（避免重复）：$PREV_THEMES
+
+")请写出以下两个章节：
+
+## 🌙 今日深度发现：[一句话主题]
+
+### 发现过程
+像侦探一样描述：哪些数据源的哪些条目最先引起注意？信号是如何从不同数据源中逐步浮现并互相印证的？
+
+### 🔗 隐藏关联
+围绕这个主题，列出 3-5 个隐藏的关联，每个标注证据链：A事实([数据源, 日期]) → B事实([数据源, 日期]) → 因此C"
+
+log "Chunk 1/3: 选题+发现+关联 → 发送 LLM..."
+CHUNK1_RESULT=$(llm_call "$CHUNK1_PROMPT" 4000 0.85 300 "$CHUNK1_SYSTEM" || true)
+CHUNK1_CHARS=$(echo "$CHUNK1_RESULT" | wc -c | tr -d ' ')
+log "Chunk 1/3: ${CHUNK1_CHARS} chars"
+
+# 从第 1 段提取主题（用于后续章节保持一致）
+DREAM_THEME=$(echo "$CHUNK1_RESULT" | head -3 | grep -o '今日深度发现：.*' | head -1 || echo "")
+[ -z "$DREAM_THEME" ] && DREAM_THEME="（延续第一段主题）"
+
+# --- 第 2 段：趋势推演 + 被忽视的信号 ---
+CHUNK2_SYSTEM="你是专业数据分析师。基于已选主题继续深度分析，写出两个章节。
+要求：每个章节至少 200 字，引用具体数据源名称和日期。Markdown 格式。"
+
+CHUNK2_PROMPT="当前分析主题：$DREAM_THEME
+
+数据素材摘要：
+---
+$(echo "$CHUNKED_MATERIAL" | utf8_truncate 15000)
+---
+
+请写出以下两个章节（紧扣上述主题）：
+
+### 🔮 趋势推演
+基于证据推演 2-3 个未来走向，每个包含：趋势名 / 数据证据（具体引用） / 推演逻辑 / 时间窗口 / 影响
+
+### 💎 被忽视的信号
+找出 2-3 个容易被忽略的信号，每个包含：是什么 / 在哪发现的 / 为什么被忽视 / 为什么值得关注"
+
+log "Chunk 2/3: 趋势+信号 → 发送 LLM..."
+CHUNK2_RESULT=$(llm_call "$CHUNK2_PROMPT" 4000 0.75 300 "$CHUNK2_SYSTEM" || true)
+CHUNK2_CHARS=$(echo "$CHUNK2_RESULT" | wc -c | tr -d ' ')
+log "Chunk 2/3: ${CHUNK2_CHARS} chars"
+
+# --- 第 3 段：行动建议 + 数据质量备注 ---
+CHUNK3_SYSTEM="你是专业数据分析师。基于前面的分析写出行动建议和数据质量评估。
+要求：建议必须具体到本周可执行。Markdown 格式。"
+
+CHUNK3_PROMPT="当前分析主题：$DREAM_THEME
+
+前面的关键发现摘要：
+$(echo "$CHUNK1_RESULT" | tail -20 | utf8_truncate 2000)
+$(echo "$CHUNK2_RESULT" | tail -20 | utf8_truncate 2000)
+
+请写出以下两个章节：
+
+### 🎯 行动建议（按优先级排列）
+给出 3-5 个具体可执行的建议，每个包含：做什么 / 为什么现在做 / 怎么验证 / 预期产出
+
+### 📊 数据质量备注
+哪些数据源贡献了关键证据？哪些信息密度低？存在哪些信息盲区？"
+
+log "Chunk 3/3: 建议+质量 → 发送 LLM..."
+CHUNK3_RESULT=$(llm_call "$CHUNK3_PROMPT" 4000 0.7 300 "$CHUNK3_SYSTEM" || true)
+CHUNK3_CHARS=$(echo "$CHUNK3_RESULT" | wc -c | tr -d ' ')
+log "Chunk 3/3: ${CHUNK3_CHARS} chars"
+
+# --- 拼接结果 ---
 DREAM_RESULT=""
 DREAM_CHARS=0
-BEST_RESULT=""
-BEST_CHARS=0
-# 逐次降温：第一次放开探索，重试时求稳
-REDUCE_TEMPS=("0.85" "0.6" "0.4")
-# V37.8.3: 渐进式素材降级 — retry 时逐步缩减素材量
-REDUCE_MATERIAL_CAPS=("80000" "50000" "30000")
+SUCCESSFUL_CHUNKS=0
 
-for retry in $(seq 1 $MAX_RETRIES); do
-    cur_temp="${REDUCE_TEMPS[$((retry - 1))]}"
-    cur_cap="${REDUCE_MATERIAL_CAPS[$((retry - 1))]}"
+for chunk_var in CHUNK1_RESULT CHUNK2_RESULT CHUNK3_RESULT; do
+    chunk_content="${!chunk_var}"
+    chunk_len=$(echo "$chunk_content" | wc -c | tr -d ' ')
+    if [ -n "${chunk_content// }" ] && [ "$chunk_len" -gt 50 ]; then
+        if [ -n "$DREAM_RESULT" ]; then
+            DREAM_RESULT="$DREAM_RESULT
 
-    # V37.8.3: 重试时缩减素材量并重建 user prompt（system message 保持不变）
-    if [ "$retry" -gt 1 ]; then
-        REDUCE_MATERIAL=$(echo "$REDUCE_DATA" | utf8_truncate "$cur_cap")
-        REDUCE_CHARS=$(echo "$REDUCE_MATERIAL" | wc -c | tr -d ' ')
-        log "Reduce retry $retry: 素材降级 ${cur_cap} bytes (实际 ${REDUCE_CHARS} bytes)"
-    fi
-
-    # V37.8.3: retry 2+ 在 system message 追加重试上下文（改变 prompt hash 绕过 server cache）
-    if [ "$retry" -eq 1 ]; then
-        cur_prompt="$REDUCE_PROMPT"
-        cur_system="$REDUCE_SYSTEM"
-    else
-        # 重建 user prompt 用降级后的素材
-        cur_prompt="$REDUCE_INTRO
-
----
-$REDUCE_MATERIAL
----
-
-这些数据是花费大量算力分析的结果。每天只深挖一个主题，用全部分析维度去钻透它。
-
-从所有信号中选出最有价值的一个发现（多源互证、反直觉、可执行），严格按 6 章节展开：
-发现过程 → 隐藏关联(3-5个证据链) → 趋势推演(2-3个) → 被忽视的信号(2-3个) → 行动建议(3-5个) → 数据质量备注
-
-$([ -n "$PREV_THEMES" ] && echo "最近梦境主题（避免重复）：$PREV_THEMES")"
-
-        # 在 system 追加重试上下文
-        cur_system="$REDUCE_SYSTEM
-
-【第 $retry 次尝试】上一次回复仅 ${BEST_CHARS} 字符，严重不合格。素材已精简到 ${REDUCE_CHARS} 字节以留出充足写作空间。这次必须完整覆盖 6 个章节，总字数不少于 2500 汉字。不要只写一段总结就结束。"
-    fi
-    DREAM_RESULT=$(llm_call "$cur_prompt" 8000 "$cur_temp" 300 "$cur_system" || true)
-    DREAM_CHARS=$(echo "$DREAM_RESULT" | wc -c | tr -d ' ')
-
-    # 始终保留最佳，retry 过程中丢不掉好结果
-    if [ "$DREAM_CHARS" -gt "$BEST_CHARS" ] && [ -n "${DREAM_RESULT// }" ]; then
-        BEST_RESULT="$DREAM_RESULT"
-        BEST_CHARS=$DREAM_CHARS
-    fi
-
-    if [ -z "${DREAM_RESULT// }" ]; then
-        log "Reduce 尝试 $retry/$MAX_RETRIES (temp=$cur_temp, cap=${cur_cap}): 空响应"
-    elif [ "$DREAM_CHARS" -lt "$MIN_DREAM_CHARS" ]; then
-        log "Reduce 尝试 $retry/$MAX_RETRIES (temp=$cur_temp, cap=${cur_cap}): 响应过短 (${DREAM_CHARS} chars < ${MIN_DREAM_CHARS})，当前最佳=${BEST_CHARS}，继续重试..."
-    else
-        log "Reduce 尝试 $retry/$MAX_RETRIES (temp=$cur_temp, cap=${cur_cap}): 成功 (${DREAM_CHARS} chars)"
-        break
-    fi
-
-    if [ "$retry" -lt "$MAX_RETRIES" ]; then
-        local_wait=$((15 * retry))  # 15s, 30s
-        log "Reduce: 等待 ${local_wait}s 后重试..."
-        sleep "$local_wait"
+$chunk_content"
+        else
+            DREAM_RESULT="$chunk_content"
+        fi
+        SUCCESSFUL_CHUNKS=$((SUCCESSFUL_CHUNKS + 1))
     fi
 done
 
-# Fallback 策略：
-# 1) 如果最终结果达标，直接用
-# 2) 如果没达标但 BEST_RESULT 更长，用 BEST_RESULT
-# 3) 如果 BEST_RESULT 也 < MIN_ACCEPTABLE_CHARS，才算真失败
-if [ "$DREAM_CHARS" -lt "$MIN_DREAM_CHARS" ] && [ "$BEST_CHARS" -gt "$DREAM_CHARS" ]; then
-    log "Reduce: 最后一次 (${DREAM_CHARS} chars) 不如之前最佳 (${BEST_CHARS} chars)，使用最佳结果"
-    DREAM_RESULT="$BEST_RESULT"
-    DREAM_CHARS=$BEST_CHARS
-fi
+DREAM_CHARS=$(echo "$DREAM_RESULT" | wc -c | tr -d ' ')
+log "分段拼接完成: ${SUCCESSFUL_CHUNKS}/3 段成功, 总计 ${DREAM_CHARS} chars"
 
-if [ -z "${DREAM_RESULT// }" ] || [ "$DREAM_CHARS" -lt "$MIN_ACCEPTABLE_CHARS" ]; then
-    log "ERROR: Phase 2 所有重试均失败 (最佳 ${BEST_CHARS} chars < ${MIN_ACCEPTABLE_CHARS}, prompt was ${PROMPT_BYTES} bytes)"
-    printf '{"time":"%s","status":"llm_failed","phase":"reduce","map_count":%d,"reduce_chars":%d,"prompt_bytes":%d,"best_chars":%d}\n' \
-        "$TS" "$MAP_COUNT" "$REDUCE_CHARS" "$PROMPT_BYTES" "$BEST_CHARS" > "$STATUS_FILE"
-    dream_fail_alert "Phase 2 Reduce LLM ${MAX_RETRIES}次全部失败 (最佳 ${BEST_CHARS} chars, prompt=${PROMPT_BYTES}B, map=$MAP_COUNT sources)"
+# 最低要求：至少 2 段成功且总字数 > MIN_ACCEPTABLE_CHARS
+MIN_ACCEPTABLE_CHARS=1500
+
+if [ "$SUCCESSFUL_CHUNKS" -lt 2 ] || [ "$DREAM_CHARS" -lt "$MIN_ACCEPTABLE_CHARS" ]; then
+    log "ERROR: 分段生成失败 (${SUCCESSFUL_CHUNKS}/3 段, ${DREAM_CHARS} chars < ${MIN_ACCEPTABLE_CHARS})"
+    printf '{"time":"%s","status":"llm_failed","phase":"reduce_chunked","chunks_ok":%d,"total_chars":%d,"prompt_bytes":%d}\n' \
+        "$TS" "$SUCCESSFUL_CHUNKS" "$DREAM_CHARS" "$CHUNKED_CHARS" > "$STATUS_FILE"
+    dream_fail_alert "Phase 2 分段生成失败 (${SUCCESSFUL_CHUNKS}/3 段, ${DREAM_CHARS} chars, material=${CHUNKED_CHARS}B)"
     exit 1
-fi
-
-# 接受 MIN_ACCEPTABLE_CHARS ~ MIN_DREAM_CHARS 之间的 fallback 结果，但记录日志
-if [ "$DREAM_CHARS" -lt "$MIN_DREAM_CHARS" ]; then
-    log "Reduce: 使用 fallback 结果 (${DREAM_CHARS} chars, 低于理想 ${MIN_DREAM_CHARS} 但高于最低 ${MIN_ACCEPTABLE_CHARS})"
 fi
 
 log "最终梦境: ${DREAM_CHARS} chars (最佳候选 ${BEST_CHARS} chars)"

--- a/ontology/tests/test_dream_cache_stability.py
+++ b/ontology/tests/test_dream_cache_stability.py
@@ -223,9 +223,8 @@ class TestFixC_PerNoteCacheKey(unittest.TestCase):
 
 
 class TestV37_4_2_CacheReadStructureAndRetryVariation(unittest.TestCase):
-    """V37.4.2: Cache-only read path must emit structured, numbered headers
-    (not N copies of bland "## 用户笔记（缓存）") AND retry 2+ must vary the
-    prompt to break server-side caching and force length.
+    """V37.4.2 → V37.8.3: Cache-only read path must emit structured, numbered
+    headers. Retry logic replaced by chunked generation in V37.8.3.
 
     Background: 2026-04-11 14:01 run produced retry 1 = 876 chars and retry 2
     = *exactly* 876 chars (different temps, same output) — smoking gun for
@@ -281,51 +280,14 @@ class TestV37_4_2_CacheReadStructureAndRetryVariation(unittest.TestCase):
             "will look like 22 duplicate sections to Qwen3.",
         )
 
-    def test_retry_prompt_variation(self):
-        """retry 2+ must use a variant prompt prefix, not just re-run the
-        exact same prompt at a different temp. Variant prompt:
-          1) changes prompt hash → bypasses server cache
-          2) injects explicit length mandate → forces LLM to elaborate"""
+    def test_chunked_generation_replaces_retry_loop(self):
+        """V37.8.3: Chunked generation replaced the single-shot retry loop.
+        The code must have CHUNK1/CHUNK2/CHUNK3 calls."""
         src = _read_kb_dream()
-        # A cur_prompt var must be assigned differently for retry==1 vs else
-        self.assertIn(
-            'cur_prompt="$REDUCE_PROMPT"',
-            src,
-            "First retry must use raw REDUCE_PROMPT — cur_prompt branching "
-            "missing.",
-        )
-        self.assertIn(
-            "第 $retry 次尝试",
-            src,
-            "Retry variant header missing — retry 2+ still sends identical "
-            "prompt, won't bypass server cache.",
-        )
-        self.assertIn(
-            "2500 汉字",
-            src,
-            "Explicit length mandate (2500 汉字) missing in retry variant — "
-            "LLM has no pressure to elaborate on retry.",
-        )
-
-    def test_llm_call_uses_cur_prompt_not_reduce_prompt(self):
-        """The actual llm_call inside retry loop must use $cur_prompt so the
-        retry variant is actually sent. If it still uses $REDUCE_PROMPT,
-        the whole variation is dead code."""
-        src = _read_kb_dream()
-        # Find the llm_call inside the retry loop — should reference cur_prompt
-        m = re.search(
-            r'DREAM_RESULT=\$\(llm_call\s+"\$([A-Za-z_]+)"\s+8000',
-            src,
-        )
-        self.assertIsNotNone(
-            m, "Reduce retry llm_call not found in expected shape"
-        )
-        self.assertEqual(
-            m.group(1),
-            "cur_prompt",
-            f"Retry llm_call uses ${m.group(1)} instead of $cur_prompt — "
-            "prompt variation is dead code.",
-        )
+        self.assertIn("CHUNK1_RESULT", src,
+                       "Chunked generation not found — old retry loop still in use")
+        self.assertIn("CHUNK2_RESULT", src)
+        self.assertIn("CHUNK3_RESULT", src)
 
 
 class TestDynamicTimeoutBudget(unittest.TestCase):
@@ -421,189 +383,163 @@ class TestFlushPendingBatchHelper(unittest.TestCase):
         )
 
 
-class TestReduceRetryFallback(unittest.TestCase):
-    """V37.4.1: Reduce retry logic must preserve best result and fall back
-    gracefully. Fixes the 2026-04-11 13:38 bug where retry 1 gave 3967 chars
-    (usable), retry 2 gave 906 chars (worse), and the code discarded retry 1
-    to pursue ever-worse retries."""
-
-    def test_min_dream_chars_lowered_to_3000(self):
-        """4000 was too strict — 3967 chars ≈ 1300 汉字 is functionally fine."""
-        src = _read_kb_dream()
-        self.assertIn(
-            "MIN_DREAM_CHARS=3000",
-            src,
-            "MIN_DREAM_CHARS must be 3000 (≈1000 汉字 lower bound for the "
-            "'1500 字 target'). 4000 rejects borderline-good output.",
-        )
-        self.assertNotIn(
-            "MIN_DREAM_CHARS=4000",
-            src,
-            "Old 4000 threshold still present — V37.4.1 regressed.",
-        )
+class TestReduceChunkedGeneration(unittest.TestCase):
+    """V37.8.3: Chunked generation replaces single-shot retry loop.
+    Root cause: remote GPU server output token limit (~300-500 tokens) caps
+    single-call output at ~900 chars regardless of prompt engineering.
+    Fix: split 6 sections into 3 LLM calls, each producing 2 sections,
+    concatenate results. Each call stays within server token limit."""
 
     def test_min_acceptable_chars_floor(self):
-        """Even all-retry-failures must have a floor below which we give up."""
+        """Chunked generation must have a floor below which we give up."""
         src = _read_kb_dream()
         self.assertIn(
             "MIN_ACCEPTABLE_CHARS=1500",
             src,
-            "MIN_ACCEPTABLE_CHARS floor missing — all-retry-failure logic "
-            "has no minimum bar, could emit near-empty Dream files.",
+            "MIN_ACCEPTABLE_CHARS floor missing — no minimum bar for "
+            "chunked output, could emit near-empty Dream files.",
         )
 
-    def test_best_result_tracking(self):
-        """retry loop must track the longest response across attempts."""
+    def test_three_chunks_defined(self):
+        """Must have exactly 3 chunk calls covering all 6 sections."""
+        src = _read_kb_dream()
+        for i in range(1, 4):
+            self.assertIn(
+                f"CHUNK{i}_RESULT",
+                src,
+                f"CHUNK{i}_RESULT missing — not all 3 chunks defined.",
+            )
+            self.assertIn(
+                f"CHUNK{i}_CHARS",
+                src,
+                f"CHUNK{i}_CHARS missing — can't verify chunk {i} output size.",
+            )
+
+    def test_chunk1_covers_theme_and_discovery(self):
+        """Chunk 1 must select theme and write discovery + connections."""
+        src = _read_kb_dream()
+        self.assertIn("发现过程", src)
+        self.assertIn("隐藏关联", src)
+        self.assertIn("DREAM_THEME", src,
+                       "DREAM_THEME extraction missing — chunks 2/3 won't "
+                       "know what theme to continue with.")
+
+    def test_chunk2_covers_trends_and_signals(self):
+        """Chunk 2 must cover trend projection and overlooked signals."""
+        src = _read_kb_dream()
+        self.assertIn("趋势推演", src)
+        self.assertIn("被忽视的信号", src)
+
+    def test_chunk3_covers_actions_and_quality(self):
+        """Chunk 3 must cover action recommendations and data quality."""
+        src = _read_kb_dream()
+        self.assertIn("行动建议", src)
+        self.assertIn("数据质量备注", src)
+
+    def test_chunks_use_system_messages(self):
+        """Each chunk call must use system message for meta-instructions."""
+        src = _read_kb_dream()
+        for i in range(1, 4):
+            self.assertIn(
+                f"CHUNK{i}_SYSTEM",
+                src,
+                f"CHUNK{i}_SYSTEM missing — chunk {i} has no system message, "
+                "model won't get focused instructions.",
+            )
+
+    def test_chunks_use_truncated_material(self):
+        """Chunked mode must use truncated material (30KB), not full 80KB."""
         src = _read_kb_dream()
         self.assertIn(
-            "BEST_RESULT=",
+            "CHUNKED_MATERIAL",
             src,
-            "BEST_RESULT tracking missing — retry loop will throw away good "
-            "early results when later retries are worse.",
+            "CHUNKED_MATERIAL missing — chunks still using full 80KB material.",
         )
-        self.assertIn(
-            "BEST_CHARS=",
+        self.assertRegex(
             src,
-            "BEST_CHARS tracking missing — can't compare retries to pick "
-            "the longest.",
+            r'utf8_truncate\s+30000',
+            "Material must be truncated to 30000 for chunked mode.",
         )
 
-    def test_best_result_fallback_used(self):
-        """On sub-threshold final result, must fall back to BEST_RESULT."""
+    def test_concatenation_counts_successful_chunks(self):
+        """Must track how many chunks succeeded and require at least 2."""
+        src = _read_kb_dream()
+        self.assertIn(
+            "SUCCESSFUL_CHUNKS",
+            src,
+            "SUCCESSFUL_CHUNKS counter missing — can't verify minimum chunks.",
+        )
+
+    def test_failure_requires_fewer_than_2_chunks(self):
+        """Dream should only fail if fewer than 2 chunks succeeded."""
         src = _read_kb_dream()
         self.assertRegex(
             src,
-            r'DREAM_RESULT="\$BEST_RESULT"',
-            'Fallback assignment DREAM_RESULT="$BEST_RESULT" missing — '
-            "best-result fallback not wired up.",
+            r'SUCCESSFUL_CHUNKS.*-lt.*2',
+            "Failure check must require at least 2 successful chunks.",
         )
 
-    def test_temperature_decay_on_retry(self):
-        """Retries must decay temperature (0.85→0.6→0.4) to reduce LLM
-        sampling variance. Same prompt + high temp = gambling."""
-        src = _read_kb_dream()
-        self.assertIn(
-            "REDUCE_TEMPS=",
-            src,
-            "REDUCE_TEMPS array missing — retries still use a single fixed "
-            "temperature and will produce equally volatile outputs.",
-        )
-        # Sanity: the array must contain a monotonically decaying sequence
-        m = re.search(r'REDUCE_TEMPS=\("([\d.]+)"\s+"([\d.]+)"\s+"([\d.]+)"\)', src)
-        self.assertIsNotNone(
-            m,
-            "REDUCE_TEMPS array format unexpected — expected 3-element "
-            "decaying temperature array.",
-        )
-        t1, t2, t3 = float(m.group(1)), float(m.group(2)), float(m.group(3))
-        self.assertGreater(t1, t2, "Retry temperatures must monotonically decay")
-        self.assertGreater(t2, t3, "Retry temperatures must monotonically decay")
 
-    def test_fatal_error_uses_min_acceptable_not_min_dream(self):
-        """The true failure floor is MIN_ACCEPTABLE_CHARS (1500), not
-        MIN_DREAM_CHARS (3000). Otherwise we exit 1 on sub-optimal but
-        still usable output, defeating the whole fallback."""
+class TestV37_8_3_ChunkedGenerationStructure(unittest.TestCase):
+    """V37.8.3: Chunked generation structure tests.
+    Each chunk must pass system message to llm_call and log its output size."""
+
+    def test_each_chunk_logged(self):
+        """Each chunk call must log its output for operator visibility."""
         src = _read_kb_dream()
+        self.assertIn("Chunk 1/3:", src)
+        self.assertIn("Chunk 2/3:", src)
+        self.assertIn("Chunk 3/3:", src)
+
+    def test_chunk2_receives_theme_from_chunk1(self):
+        """Chunk 2 must reference DREAM_THEME extracted from chunk 1."""
+        src = _read_kb_dream()
+        # CHUNK2_PROMPT must contain DREAM_THEME
         self.assertRegex(
             src,
-            r"DREAM_CHARS[^\n]*-lt[^\n]*MIN_ACCEPTABLE_CHARS",
-            "Fatal error check must use MIN_ACCEPTABLE_CHARS (1500) as the "
-            "true failure floor, not MIN_DREAM_CHARS (3000).",
+            r'CHUNK2_PROMPT=.*DREAM_THEME',
+            "Chunk 2 prompt doesn't reference DREAM_THEME — sections will "
+            "be disconnected, not a coherent analysis.",
         )
 
-
-class TestV37_8_3_ProgressiveMaterialDegradation(unittest.TestCase):
-    """V37.8.3: When the Reduce prompt is too large (89KB+), the model enters
-    "read-heavy summarization collapse" mode and produces ~1200 chars output
-    regardless of retries. Fix: progressively reduce material size on retry
-    (80K → 50K → 30K) so the model shifts from reading to writing.
-
-    Background: 2026-04-13 03:00 run, all 3 retries produced ≤1192 chars from
-    a 89318B prompt. V37.4.2's variant prefix (<300B) was <0.3% of prompt —
-    insufficient to change model behavior at this scale."""
-
-    def test_material_caps_array_exists(self):
-        """Retry loop must have a REDUCE_MATERIAL_CAPS array defining per-retry
-        material size limits."""
+    def test_chunk3_receives_prior_context(self):
+        """Chunk 3 must receive findings from chunks 1 and 2."""
         src = _read_kb_dream()
+        # CHUNK3_PROMPT is a multiline heredoc, so we check that both
+        # CHUNK1_RESULT and CHUNK2_RESULT appear between CHUNK3_PROMPT= and
+        # the next CHUNK3_ variable (the prompt spans multiple lines).
+        chunk3_start = src.find('CHUNK3_PROMPT=')
+        self.assertNotEqual(chunk3_start, -1, "CHUNK3_PROMPT not found")
+        chunk3_block = src[chunk3_start:chunk3_start + 2000]
         self.assertIn(
-            "REDUCE_MATERIAL_CAPS=",
-            src,
-            "REDUCE_MATERIAL_CAPS array missing — retries still use fixed "
-            "80K material, model stays in summarization collapse.",
+            'CHUNK1_RESULT',
+            chunk3_block,
+            "Chunk 3 doesn't receive CHUNK1_RESULT — action items "
+            "won't be grounded in the analysis.",
         )
-
-    def test_material_caps_are_decreasing(self):
-        """Material caps must monotonically decrease across retries."""
-        src = _read_kb_dream()
-        m = re.search(
-            r'REDUCE_MATERIAL_CAPS=\("(\d+)"\s+"(\d+)"\s+"(\d+)"\)',
-            src,
-        )
-        self.assertIsNotNone(
-            m,
-            "REDUCE_MATERIAL_CAPS array format unexpected — expected 3 "
-            "decreasing integer elements.",
-        )
-        c1, c2, c3 = int(m.group(1)), int(m.group(2)), int(m.group(3))
-        self.assertGreater(c1, c2, "Material caps must decrease on retry")
-        self.assertGreater(c2, c3, "Material caps must decrease on retry")
-        # First cap should be the original 80K
-        self.assertEqual(c1, 80000, "First attempt should use original 80K cap")
-
-    def test_retry_rebuilds_reduce_prompt(self):
-        """On retry, REDUCE_PROMPT must be rebuilt with the new (smaller)
-        REDUCE_MATERIAL. Otherwise the variant prefix changes the hash but
-        the actual material size stays at 80K — defeating the purpose."""
-        src = _read_kb_dream()
-        # The retry block (retry > 1) must re-truncate REDUCE_DATA
-        self.assertRegex(
-            src,
-            r'retry.*-gt.*1.*\n.*REDUCE_MATERIAL=.*utf8_truncate.*cur_cap',
-            "Retry does not re-truncate REDUCE_DATA with cur_cap — material "
-            "size stays at 80K across all retries.",
-        )
-
-    def test_retry_uses_cur_cap_variable(self):
-        """The retry loop must index into REDUCE_MATERIAL_CAPS using retry."""
-        src = _read_kb_dream()
         self.assertIn(
-            "cur_cap=",
-            src,
-            "cur_cap variable missing — retry loop doesn't read from "
-            "REDUCE_MATERIAL_CAPS array.",
+            'CHUNK2_RESULT',
+            chunk3_block,
+            "Chunk 3 doesn't receive CHUNK2_RESULT — action items "
+            "won't reflect trend analysis.",
         )
 
-    def test_retry_logs_material_degradation(self):
-        """Operator must see material size changes in the log."""
+    def test_chunked_material_is_30k(self):
+        """Chunked mode uses 30KB material (not 80KB) for faster processing."""
         src = _read_kb_dream()
-        self.assertIn(
-            "素材降级",
-            src,
-            "Material degradation log line missing — operator can't verify "
-            "retry used smaller material.",
-        )
-
-    def test_retry_variant_includes_best_chars(self):
-        """V37.8.3 variant prefix should report BEST_CHARS so LLM knows
-        the previous attempt's output size."""
-        src = _read_kb_dream()
-        self.assertIn(
-            "${BEST_CHARS}",
-            src,
-            "Retry variant prefix doesn't include BEST_CHARS — LLM gets "
-            "no signal about how short the previous attempt was.",
-        )
+        m = re.search(r'CHUNKED_MATERIAL=.*utf8_truncate\s+(\d+)', src)
+        self.assertIsNotNone(m, "CHUNKED_MATERIAL truncation not found")
+        self.assertEqual(int(m.group(1)), 30000,
+                         "Chunked material should be truncated to 30000")
 
 
 class TestV37_8_3_SystemUserMessageSplit(unittest.TestCase):
-    """V37.8.3: Split Reduce prompt into system + user messages.
-    Root cause: 82KB single user message causes Qwen3 "lost in the middle" —
-    length requirements buried in 80KB of material get ignored, model produces
-    ~900 char summaries (completion_tokens=328/8000, model stops voluntarily).
-    Fix: system message carries meta-instructions (role + length mandate +
-    format), user message carries data + analysis structure template.
-    System role has highest model attention priority."""
+    """V37.8.3: System+user message split + chunked generation.
+    Root cause: remote GPU server output token limit (~300-500 tokens) caps
+    each LLM call to ~900 chars regardless of prompt size/structure.
+    Fix: llm_call() accepts 5th system_msg parameter, and Reduce uses
+    chunked generation (3 focused LLM calls × 2 sections each) to stay
+    within per-call token limits while producing full 6-section reports."""
 
     def test_reduce_system_variable_defined(self):
         """REDUCE_SYSTEM must be defined to carry meta-instructions."""
@@ -637,16 +573,17 @@ class TestV37_8_3_SystemUserMessageSplit(unittest.TestCase):
             self.assertIn(keyword, system_content,
                           f"System message missing chapter '{keyword}'")
 
-    def test_llm_call_receives_system_message(self):
-        """The Reduce llm_call must pass system message as 5th argument."""
+    def test_chunked_llm_calls_receive_system_message(self):
+        """Each chunked llm_call must pass its own system message as 5th arg."""
         src = _read_kb_dream()
-        # Pattern: llm_call "$cur_prompt" 8000 "$cur_temp" 300 "$cur_system"
-        self.assertRegex(
-            src,
-            r'llm_call\s+"\$cur_prompt"\s+8000\s+"\$cur_temp"\s+300\s+"\$cur_system"',
-            "Reduce llm_call does not pass system message — model will use "
-            "single user message and lose length requirements in long prompt.",
-        )
+        # V37.8.3 chunked generation: 3 llm_call each with CHUNKn_SYSTEM
+        for i in range(1, 4):
+            self.assertRegex(
+                src,
+                rf'llm_call\s+"\$CHUNK{i}_PROMPT"\s+\d+\s+[\d.]+\s+\d+\s+"\$CHUNK{i}_SYSTEM"',
+                f"Chunk {i} llm_call does not pass CHUNK{i}_SYSTEM — "
+                "model will use single user message without focused instructions.",
+            )
 
     def test_llm_call_function_accepts_system_msg_param(self):
         """llm_call() must accept a 5th parameter for system message."""
@@ -667,16 +604,17 @@ class TestV37_8_3_SystemUserMessageSplit(unittest.TestCase):
             "system message is dead code.",
         )
 
-    def test_retry_modifies_cur_system(self):
-        """Retry 2+ must modify cur_system (not just cur_prompt) to add
-        retry context to the system message."""
+    def test_each_chunk_has_distinct_system_message(self):
+        """Each chunk must have its own CHUNK{n}_SYSTEM with focused section
+        instructions, not a shared single system message."""
         src = _read_kb_dream()
-        self.assertIn(
-            'cur_system="$REDUCE_SYSTEM',
-            src,
-            "Retry does not build cur_system from REDUCE_SYSTEM — retry "
-            "context is not in system message.",
-        )
+        for i in range(1, 4):
+            self.assertIn(
+                f'CHUNK{i}_SYSTEM=',
+                src,
+                f"CHUNK{i}_SYSTEM not defined — chunk {i} lacks focused "
+                "section-specific system instructions.",
+            )
 
     def test_user_prompt_no_longer_contains_writing_style(self):
         """After V37.8.3 split, the main REDUCE_PROMPT (user message) should

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-04-13 06:17:56",
+  "updated": "2026-04-13 08:26:30",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -212,9 +212,9 @@
   "quality": {
     "security_score": "93",
     "test_count": "944",
-    "last_regression": "2026-04-13 06:17 pass",
+    "last_regression": "2026-04-13 08:26 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-04-13 06:17",
+    "security_score_time": "2026-04-13 08:26",
     "test_suites": "31",
     "governance_invariants": "35/35",
     "governance_checks": "125/136",


### PR DESCRIPTION
Remote GPU server now caps output at ~300-500 tokens per call. Instead of retrying the same 80KB prompt, split 6-section analysis into 3 focused LLM calls (2 sections each, 30KB material). Each chunk gets its own system message and builds on prior chunk findings. Requires 2/3 chunks to succeed. Tests updated from retry-based to chunk-based (46 tests pass).

https://claude.ai/code/session_016D5prEqwjeYKYsiaRKZxSh

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
