### PR TITLE
Fix flaky kb_evening E2E test: timezone mismatch between subprocess a…

### DIFF
--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-04-13 10:01:31",
+  "updated": "2026-04-13 16:11:40",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -212,9 +212,9 @@
   "quality": {
     "security_score": "93",
     "test_count": "951",
-    "last_regression": "2026-04-13 10:01 pass",
+    "last_regression": "2026-04-13 16:11 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-04-13 10:01",
+    "security_score_time": "2026-04-13 16:11",
     "test_suites": "31",
     "governance_invariants": "35/35",
     "governance_checks": "125/136",

--- a/test_kb_evening.py
+++ b/test_kb_evening.py
@@ -593,12 +593,15 @@ class TestKbEveningShellRuntime(unittest.TestCase):
         )
         # Should not contain JSONDecodeError (V37.5.1 blood lesson guard)
         self.assertNotIn("JSONDecodeError", result.stderr)
-        # Evening file should exist
-        evening_file = os.path.join(
-            self.tmp_home, ".kb", "daily", "evening_20260411.md"
-        )
-        # Must match today's actual date — use real date
-        today_date = datetime.now().strftime("%Y%m%d")
+        # Evening file should exist — script runs with TZ=Asia/Hong_Kong,
+        # so use the same TZ to compute expected date (fixes flaky failure
+        # when system UTC date != HK date, e.g. 16:00-24:00 UTC)
+        import subprocess as _sp
+        today_date = _sp.run(
+            ["date", "+%Y%m%d"],
+            env={"TZ": "Asia/Hong_Kong", "PATH": "/usr/bin:/bin"},
+            capture_output=True, text=True,
+        ).stdout.strip()
         evening_file_real = os.path.join(
             self.tmp_home, ".kb", "daily", f"evening_{today_date}.md"
         )


### PR DESCRIPTION
…nd assertion

The test ran kb_evening.sh with TZ=Asia/Hong_Kong but used datetime.now() (system UTC) to compute the expected filename. When UTC date != HK date (16:00-24:00 UTC), the script writes evening_20260414.md but the test looks for evening_20260413.md. Fix: use `date +%Y%m%d` with TZ=Asia/Hong_Kong to match the subprocess environment.

https://claude.ai/code/session_016D5prEqwjeYKYsiaRKZxSh

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
