### PR TITLE
Fix finance_news wrong X handles + Dream MIN_ACCEPTABLE_CHARS too low

### DIFF
--- a/jobs/finance_news/run_finance_news.sh
+++ b/jobs/finance_news/run_finance_news.sh
@@ -78,14 +78,14 @@ FINANCE_X_ACCOUNTS=(
     "ChinaDaily|中国日报(X)|cn"
     "globaltimesnews|环球时报(X)|cn"
     "CNS1952|中新社(X)|cn"
-    "CaixinGlobal|财新英文(X)|cn"
-    "YicaiGlobal|第一财经英文(X)|cn"
+    "caixin|财新英文(X)|cn"
+    "yicaichina|第一财经(X)|cn"
     # ── 港台/亚太 ──
     "SCMPNews|南华早报(X)|cn"
     "NikkeiAsia|日经亚洲(X)|cn"
     "SingTaoDaily|星岛日报(X)|cn"
     "ChannelNewsAsia|CNA新加坡(X)|cn"
-    "STcom|海峡时报(X)|cn"
+    "straits_times|海峡时报(X)|cn"
     "asahi|朝日新闻(X)|cn"
 )
 

--- a/kb_dream.sh
+++ b/kb_dream.sh
@@ -1164,8 +1164,9 @@ done
 DREAM_CHARS=$(echo "$DREAM_RESULT" | wc -c | tr -d ' ')
 log "分段拼接完成: ${SUCCESSFUL_CHUNKS}/3 段成功, 总计 ${DREAM_CHARS} chars"
 
-# 最低要求：至少 2 段成功且总字数 > MIN_ACCEPTABLE_CHARS
-MIN_ACCEPTABLE_CHARS=1500
+# 最低要求：至少 2 段成功且总字节数 > MIN_ACCEPTABLE_CHARS
+# 注意：wc -c 计算 UTF-8 字节数，中文每字 3 字节，3000 bytes ≈ 1000 汉字
+MIN_ACCEPTABLE_CHARS=3000
 
 if [ "$SUCCESSFUL_CHUNKS" -lt 2 ] || [ "$DREAM_CHARS" -lt "$MIN_ACCEPTABLE_CHARS" ]; then
     log "ERROR: 分段生成失败 (${SUCCESSFUL_CHUNKS}/3 段, ${DREAM_CHARS} chars < ${MIN_ACCEPTABLE_CHARS})"
@@ -1175,7 +1176,7 @@ if [ "$SUCCESSFUL_CHUNKS" -lt 2 ] || [ "$DREAM_CHARS" -lt "$MIN_ACCEPTABLE_CHARS
     exit 1
 fi
 
-log "最终梦境: ${DREAM_CHARS} chars (最佳候选 ${BEST_CHARS} chars)"
+log "最终梦境: ${DREAM_CHARS} chars (${SUCCESSFUL_CHUNKS}/3 段)"
 
 # ═══════════════════════════════════════════════════════════════════
 # 6. 输出"梦境"

--- a/ontology/tests/test_dream_cache_stability.py
+++ b/ontology/tests/test_dream_cache_stability.py
@@ -394,10 +394,11 @@ class TestReduceChunkedGeneration(unittest.TestCase):
         """Chunked generation must have a floor below which we give up."""
         src = _read_kb_dream()
         self.assertIn(
-            "MIN_ACCEPTABLE_CHARS=1500",
+            "MIN_ACCEPTABLE_CHARS=3000",
             src,
             "MIN_ACCEPTABLE_CHARS floor missing — no minimum bar for "
-            "chunked output, could emit near-empty Dream files.",
+            "chunked output, could emit near-empty Dream files. "
+            "3000 bytes ≈ 1000 Chinese chars, reasonable floor for 3-chunk mode.",
         )
 
     def test_three_chunks_defined(self):

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-04-13 16:11:40",
+  "updated": "2026-04-13 16:18:30",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -212,9 +212,9 @@
   "quality": {
     "security_score": "93",
     "test_count": "951",
-    "last_regression": "2026-04-13 16:11 pass",
+    "last_regression": "2026-04-13 16:18 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-04-13 16:11",
+    "security_score_time": "2026-04-13 16:18",
     "test_suites": "31",
     "governance_invariants": "35/35",
     "governance_checks": "125/136",


### PR DESCRIPTION
1. finance_news: fix 3 wrong X/Twitter handles that returned 0 tweets
   - CaixinGlobal → caixin (correct Caixin English account)
   - YicaiGlobal → yicaichina (correct Yicai account)
   - STcom → straits_times (legacy handle, migrated to straits_times)

2. kb_dream.sh: raise MIN_ACCEPTABLE_CHARS from 1500 to 3000 bytes (≈1000 Chinese chars) — 1500 was too low for 3-chunk mode, could pass with a single half-empty chunk. Also fix undefined BEST_CHARS variable in log output.

https://claude.ai/code/session_016D5prEqwjeYKYsiaRKZxSh

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
