### PR TITLE
Add preflight_check.sh and job_smoke_test.sh to auto_deploy FILE_MAP

### DIFF
--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -183,6 +183,10 @@ declare -a FILE_MAP=(
     # 备份脚本
     "openclaw_backup.sh|$HOME/openclaw_backup.sh"
 
+    # 体检 & 验证脚本（V37.8.3: 确保 Mac Mini ~/preflight 是最新版）
+    "preflight_check.sh|$HOME/preflight_check.sh"
+    "job_smoke_test.sh|$HOME/job_smoke_test.sh"
+
     # Multimodal Memory
     "mm_index.py|$HOME/openclaw-model-bridge/mm_index.py"
     "mm_search.py|$HOME/openclaw-model-bridge/mm_search.py"

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-04-13 16:18:30",
+  "updated": "2026-04-13 16:29:31",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -212,9 +212,9 @@
   "quality": {
     "security_score": "93",
     "test_count": "951",
-    "last_regression": "2026-04-13 16:18 pass",
+    "last_regression": "2026-04-13 16:29 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-04-13 16:18",
+    "security_score_time": "2026-04-13 16:29",
     "test_suites": "31",
     "governance_invariants": "35/35",
     "governance_checks": "125/136",


### PR DESCRIPTION
Root cause of Mac Mini preflight failures: user runs `bash preflight_check.sh` from HOME, which uses an old deployed copy at ~/preflight_check.sh that was never managed by auto_deploy. The old version (16 sections, line 638) has encoding corruption (PUSH_RC with replacement char) and reads ~/auto_deploy.sh (also old) which lacks newer FILE_MAP entries — causing 11 false "not in FILE_MAP" failures.

Fix: add both scripts to FILE_MAP so auto_deploy keeps them current at $HOME/.

https://claude.ai/code/session_016D5prEqwjeYKYsiaRKZxSh

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
