### PR TITLE
docs: update OpenClaw upstream to v2026.4.15 — #59265 still open afte…

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,8 +1,8 @@
 # OpenClaw 完整配置文档
-> 最后更新：2026-04-10 (HKT)
+> 最后更新：2026-04-17 (HKT)
 > 系统：Mac Mini (macOS) | 用户：bisdom
-> 版本：v37.2（系统韧性加固 + Adapter Hot-Reload + 幻觉工具过滤）
-> OpenClaw Gateway：2026.3.13-1（当前部署，继续 hold）| 上游最新：**v2026.4.9**（#59265 agent actions 不可见仍 OPEN，经 7 个版本未修复；v2026.4.5 新增 config breaking change。详见 `docs/gateway_upgrade_eval_v2026.4.md`）
+> 版本：v37.8.15（preflight push test 速率限制 + GitHub 内容全面刷新）
+> OpenClaw Gateway：2026.3.13-1（当前部署，继续 hold）| 上游最新：**v2026.4.15**（#59265 agent actions 不可见仍 OPEN，经 **14 个版本**未修复；v2026.3.31 trusted-proxy auth 收紧可能影响 localhost proxy chain；v2026.4.5 legacy config alias 移除。详见 `docs/gateway_upgrade_eval_v2026.4.md`）
 ---
 ## 一、系统架构（V28.1 四层架构）
 


### PR DESCRIPTION
…r 14 releases

Third upgrade evaluation: continue hold.
- #59265 agent-actions-invisible persists through v2026.4.1→v2026.4.15 (14 releases)
- v2026.3.31 trusted-proxy auth tightening may break Proxy→Gateway localhost chain
- v2026.4.5 legacy config alias removal requires pre-upgrade doctor --fix
- Current v2026.3.13-1 stable, no functional gaps

https://claude.ai/code/session_01PqfnFNwFYPGV8GnfNPggNJ

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
