### PR TITLE
V37.9.23 加固: spec yaml command 字段读取层 mock 化测试 (V37.9.22 hotfix 教训闭环)

### DIFF
--- a/ontology/governance_ontology.yaml
+++ b/ontology/governance_ontology.yaml
@@ -4971,8 +4971,23 @@ invariants:
       workspace。V37.9.22 把同款血案防线从声明层升级到运行时层 — 即使代码逻辑
       正确，cron 故障 / file mtime 漂移 / kb_embed.py 内部限制都可能让"代码扫了
       但 chunks 没看见"的 silent drift 发生。本 INV 把 V37.5 引入的
-      kb_source_file 字段用作 declared 真理源，与 chunks[].source_file 实际
-      runtime 事实直接 set-diff 比对。
+      kb_source_file 字段用作 declared 真理源，与 chunks[].file 实际 runtime
+      事实直接 set-diff 比对（V37.9.22 hotfix 9d60dd3 修正字段名是 file 不是
+      source_file）。
+
+      V37.9.23 加固层 (TestKbSourcesToIndexCommandRuntime, 6 单测): V37.9.22
+      hotfix 9d60dd3 教训表明 dev 单测全过 + governance 全过 + Mac Mini
+      preflight 全过 都不能保证 spec yaml 里 runtime_observable.command 的
+      python oneliner 字段名假设正确 — 只有 Mac Mini 实测 framework 才暴露
+      declared=14 observed=0 missing=14 的字段名错。原来的 dev 单测只测
+      declared extractor 逻辑层 (TestExtractRegistryKbSourceFiles), 没测
+      observer command 的实际执行路径 + JSON 字段读取语义层。V37.9.23 加固
+      构造 mock meta.json + monkey-patch HOME → tempdir + 真实跑
+      verify_convergence("kb_sources_to_index") subprocess, 字面量字段名
+      回归 (file → source_file) 立即被抓 — 反向验证已确认守卫真有效（故意
+      改回 source_file 后 6 测试 3 失败, 还原后全绿）。这是原则 #15 第三层
+      "WhatsApp 业务验证"教训在 ontology framework 层的兑现 — 从"等生产
+      实测才发现"升级为"dev 单测就能拦"。
     design_decision: |
       为什么不创建新 observer / 新 parser？
         - V37.9.19 _observe_shell_command 已能跑 python oneliner 输出
@@ -5044,8 +5059,8 @@ invariants:
         check_type: file_contains
         file: ontology/governance_ontology.yaml
         pattern: 'INV-CONVERGENCE-KB-001'
-      # ── runtime layer: V37.9.22 KB spec 测试类端到端通过 ─────────────
-      - name: "RUNTIME: test_convergence.py V37.9.22 KB spec 测试类全部通过 (TestExtractRegistryKbSourceFiles + TestVerifyKbSourcesToIndexIntegration + TestKbSpecSourceGuards)"
+      # ── runtime layer: V37.9.22 KB spec 测试类 + V37.9.23 加固层端到端通过 ─
+      - name: "RUNTIME: test_convergence.py V37.9.22+V37.9.23 KB spec 测试类全部通过 (TestExtractRegistryKbSourceFiles + TestVerifyKbSourcesToIndexIntegration + TestKbSpecSourceGuards + TestKbSourcesToIndexCommandRuntime)"
         check_type: python_assert
         assertion: |
           import subprocess
@@ -5054,10 +5069,14 @@ invariants:
           repo_root = os.environ.get("OPENCLAW_REPO_ROOT", os.getcwd())
           test_file = os.path.join(repo_root, "test_convergence.py")
           assert os.path.exists(test_file), f"test_convergence.py 不存在: {test_file}"
+          # V37.9.22 原有三类 + V37.9.23 加固层新增 TestKbSourcesToIndexCommandRuntime
+          # (mock meta.json + 真实跑 spec yaml 的 python oneliner, 闭合 4/29 hotfix
+          # 9d60dd3 字段名假设错误教训; 反向验证已确认守卫真有效)
           v9_22_kb_classes = [
               "TestExtractRegistryKbSourceFiles",
               "TestVerifyKbSourcesToIndexIntegration",
               "TestKbSpecSourceGuards",
+              "TestKbSourcesToIndexCommandRuntime",
           ]
           targets = [f"test_convergence.{c}" for c in v9_22_kb_classes]
           proc = subprocess.run(
@@ -5066,7 +5085,7 @@ invariants:
               cwd=repo_root,
           )
           assert proc.returncode == 0, (
-              f"V37.9.22 kb_sources_to_index test classes failed:\n"
+              f"V37.9.22+V37.9.23 kb_sources_to_index test classes failed:\n"
               f"STDOUT={proc.stdout[-1000:]}\nSTDERR={proc.stderr[-1500:]}"
           )
 

--- a/test_convergence.py
+++ b/test_convergence.py
@@ -15,6 +15,9 @@ Covers:
   TestFormatResultForLog — single-line output for ops grep
   TestRealJobsToCrontabSpec — real convergence_ontology.yaml jobs_to_crontab spec smoke
   TestSourceLevelGuards — convergence.py + convergence_ontology.yaml structural guards
+  TestKbSourcesToIndexCommandRuntime — V37.9.23 加固: mock meta.json 真跑 spec
+    yaml 的 python oneliner, 闭合 V37.9.22 4/29 hotfix 教训 (yaml command 字段名
+    假设错误 dev 单测全过仅 Mac Mini 实测才暴露). MR-4 silent-failure 防御.
 """
 
 import json
@@ -1433,6 +1436,212 @@ class TestKbSpecSourceGuards(unittest.TestCase):
             end = idx + 5000
         mr17_block = self.gov_src[idx:end]
         self.assertIn("INV-CONVERGENCE-KB-001", mr17_block)
+
+
+class TestKbSourcesToIndexCommandRuntime(unittest.TestCase):
+    """V37.9.23 加固层 — Mock meta.json + 真实跑 spec yaml 的 python oneliner.
+
+    为什么需要 (V37.9.22 4/29 hotfix 9d60dd3 教训, MR-4 silent-failure 新形态):
+        spec yaml 里 runtime_observable.command 是字面量 python oneliner, 引用
+        ~/.kb/text_index/meta.json 的 chunks[].file 字段名. V37.9.22 第一次
+        部署假设字段名是 source_file — dev 单测全过 (1664 tests) + governance
+        全过 (66 inv / 372 checks) + Mac Mini preflight 全过 (81/0/3) — 但
+        Mac Mini 实测 framework 才暴露字段名错: declared=14 observed=0 missing=14.
+
+        dev 单测只测 declared extractor 逻辑层 (TestExtractRegistryKbSourceFiles),
+        没测 observer command 的实际执行路径 + JSON 字段读取语义层. source-level
+        grep guard (TestKbSpecSourceGuards) 也只是字面量 grep — source_file 和
+        file 都是合法的 Python identifier 拼写, grep 通过 ≠ 字段名正确.
+
+        本类构造 mock meta.json + monkey-patch HOME → tempdir + 调
+        verify_convergence("kb_sources_to_index") 真实跑 yaml 里的 python
+        oneliner subprocess. 字段名一旦再被改回 source_file (无论是 typo / refactor
+        / merge conflict / 未来 schema 变更未同步) 单测立即抓到, 而不是等到
+        生产实测.
+
+    设计契约:
+        - 不 mock subprocess (真实跑 yaml 里的 python oneliner)
+        - 通过 HOME env var 重定向 ~/ 解析 (subprocess 继承父进程 env;
+          os.path.expanduser 优先看 HOME 环境变量, macOS/Linux 一致)
+        - 同时验证: (1) 正常路径 — observed 集合反映 mock 数据 basename
+                    (2) 反例守卫 — 错字段名 (source_file) 数据不应被读取
+                    (3) 字面量守卫 — yaml command 必须读 'file' 字面量
+                    (4) 空 chunks — 合法状态非 error
+                    (5) declared 外 basename — line_contains_identifier 框架契约
+    """
+
+    def _verify_with_mock_meta(self, meta_content):
+        """Helper: 写 mock meta.json + 跑 verify_convergence + 还原 HOME.
+
+        Args:
+            meta_content: dict (json.dumps 序列化) 或 str (raw 字面量, 用于
+                          损坏 JSON 测试). 写入 $TMPDIR/.kb/text_index/meta.json.
+
+        Returns: ConvergenceResult (verify_convergence 返回值)
+        """
+        td = tempfile.mkdtemp(prefix="kb_meta_test_")
+        try:
+            kb_dir = Path(td) / ".kb" / "text_index"
+            kb_dir.mkdir(parents=True)
+            meta_file = kb_dir / "meta.json"
+            if isinstance(meta_content, str):
+                meta_file.write_text(meta_content, encoding="utf-8")
+            else:
+                meta_file.write_text(json.dumps(meta_content), encoding="utf-8")
+
+            old_home = os.environ.get("HOME")
+            os.environ["HOME"] = td
+            try:
+                result = cv.verify_convergence("kb_sources_to_index")
+            finally:
+                if old_home is not None:
+                    os.environ["HOME"] = old_home
+                else:
+                    os.environ.pop("HOME", None)
+        finally:
+            import shutil
+            shutil.rmtree(td, ignore_errors=True)
+        return result
+
+    def test_mock_meta_observed_set_matches_chunks_file_field(self):
+        """核心: mock chunks 含真实 declared 文件名 → 应被 observed 提取出来.
+
+        V37.9.22 4/29 hotfix 教训直接复现场景: 若 yaml command 用 'source_file'
+        字段名 (错), 此测试 observed 会是空集 (因为 mock 数据用 'file' 字段),
+        断言 sample_names[0] in observed 立即失败.
+        """
+        spec = cv.get_spec("kb_sources_to_index")
+        self.assertIsNotNone(spec, "kb_sources_to_index spec missing (V37.9.22 contract)")
+
+        # 从 registry 读真实 declared kb_source_file 列表 (如 arxiv_daily.md 等)
+        declared_set = cv._extract_registry_kb_source_files(spec)
+        self.assertGreater(len(declared_set), 0,
+            "registry 应至少声明一个 kb_source_file (V37.9.22 第四 spec 前提)")
+
+        # 取至少 2 个真实 declared 名字构造 mock chunks
+        sample_names = sorted(declared_set)[:2]
+
+        # mock 数据: 2 条用正确 'file' 字段 + 1 条用错误 'source_file' 字段反例
+        # (反例不应进 observed — 验证 yaml command 字段名读取正确)
+        mock_data = {
+            "chunks": [
+                {"file": f"/Users/test/.kb/sources/{sample_names[0]}",
+                 "file_hash": "h1", "source_type": "test", "chunk_idx": 0},
+                {"file": f"/Users/test/.kb/sources/{sample_names[1]}",
+                 "file_hash": "h2", "source_type": "test", "chunk_idx": 0},
+                # 反例: 错字段名 (V37.9.22 hotfix 前的字面量), yaml command
+                # 不应读取这条
+                {"source_file": "/Users/test/.kb/sources/wrong_field_should_not_appear.md",
+                 "file_hash": "h3"},
+            ]
+        }
+        result = self._verify_with_mock_meta(mock_data)
+
+        # observed 应包含 mock 里两个真实 file basename
+        for name in sample_names:
+            self.assertIn(name, result.observed,
+                f"observed 应包含 mock chunks[].file 解析出的 {name}, "
+                f"得到 observed={sorted(result.observed)} error={result.error} — "
+                f"如果 yaml command 字段名错 (回归 V37.9.22 hotfix), 此断言会失败")
+
+        # observed 不应包含反例 (错字段名 source_file 的内容)
+        self.assertNotIn("wrong_field_should_not_appear.md", result.observed,
+            "yaml command 必须只读 chunks[].file, 不能读 chunks[].source_file "
+            "(V37.9.22 4/29 hotfix 字面量教训)")
+
+        # 没有 error: extractor + observer + parser 全程顺利
+        self.assertIsNone(result.error,
+            f"mock meta.json 已构造, command 应无 error, got: {result.error}")
+
+    def test_yaml_command_reads_file_field_not_source_file_field(self):
+        """字面量守卫: 直接 grep yaml command 必须含 c.get('file' 不含 c.get('source_file').
+
+        V37.9.22 hotfix 字面量回归守卫. 如果未来有人 (typo / refactor /
+        merge conflict / schema 变更未同步) 把 c.get('file', '') 改回
+        c.get('source_file', ''), 本测试立即失败.
+
+        与 mock 测试互补: 即便 mock 测试因环境问题被 skip, 这个静态守卫
+        仍能拦住字面量回归.
+        """
+        spec = cv.get_spec("kb_sources_to_index")
+        self.assertIsNotNone(spec)
+        cmd = spec["runtime_observable"]["command"]
+
+        # 必须出现的字面量 (V37.9.22 4/29 hotfix 后的正确字段名)
+        self.assertIn("c.get('file'", cmd,
+            "V37.9.22 hotfix 契约: command 必须读 chunks[].file 字段")
+
+        # 反例字面量必须消失 — 排除 yaml 内 # 开头的注释行 (yaml 注释里可能
+        # 有 'source_file' 历史词作教训说明)
+        active_lines = [
+            line for line in cmd.split("\n")
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        active_code = "\n".join(active_lines)
+        self.assertNotIn("c.get('source_file'", active_code,
+            "V37.9.22 4/29 hotfix 契约: command active code 不得再读 'source_file' "
+            "字段 (meta.json 真实字段名是 'file', 反例若回归历史 bug 立即抓到)")
+
+    def test_empty_chunks_array_yields_empty_observed_no_error(self):
+        """合法状态: meta.json 存在但 chunks=[] (KB index 已建但无 source) →
+        observed=set() + 无 error. drift_detected 视 declared 是否非空."""
+        result = self._verify_with_mock_meta({"chunks": []})
+
+        self.assertEqual(len(result.observed), 0,
+            "空 chunks 应产生空 observed 集合")
+        self.assertIsNone(result.error,
+            f"空 chunks 是合法状态不是 error, got: {result.error}")
+        # declared 来自 registry 仍非空, 因此 drift_detected=True (declared > ∅)
+        self.assertGreater(len(result.declared), 0,
+            "declared 应非空 (registry 有 kb_source_file 声明)")
+        self.assertTrue(result.drift_detected,
+            "declared > 0 + observed = 0 应触发 drift_detected")
+
+    def test_mock_chunks_with_unknown_basename_dropped_from_observed(self):
+        """框架契约 (line_contains_identifier): observed 严格 ⊆ declared.
+        registry 外的 basename 即便出现在 chunks 也不进 observed.
+        """
+        mock_data = {
+            "chunks": [
+                {"file": "/Users/test/.kb/sources/_xxx_nonexistent_unknown_999_xxx_.md"},
+            ]
+        }
+        result = self._verify_with_mock_meta(mock_data)
+
+        self.assertNotIn("_xxx_nonexistent_unknown_999_xxx_.md", result.observed,
+            "framework 契约: observed ⊆ declared, registry 外 basename 不应进 observed")
+        self.assertIsNone(result.error,
+            f"未知 basename 是合法 chunks 数据不应触发 error, got: {result.error}")
+
+    def test_meta_missing_chunks_key_treated_as_empty(self):
+        """meta.json 存在但缺 chunks key (异常 schema) → observed=set() + 无 error.
+        yaml command 用 d.get('chunks', []) 兜底, 缺 key 也不崩溃."""
+        result = self._verify_with_mock_meta({"version": "test", "other_key": []})
+
+        self.assertEqual(len(result.observed), 0,
+            "缺 chunks key 应被 d.get(..., []) 兜底为空")
+        self.assertIsNone(result.error,
+            f"缺 chunks key 不应触发 error (yaml 用 .get 兜底), got: {result.error}")
+
+    def test_mock_chunks_with_empty_file_string_skipped(self):
+        """yaml command 内 `if sf: print(...)` 跳过空字符串 file 字段, 不输出空行."""
+        spec = cv.get_spec("kb_sources_to_index")
+        declared_set = cv._extract_registry_kb_source_files(spec)
+        sample_name = sorted(declared_set)[0] if declared_set else "fallback.md"
+        mock_data = {
+            "chunks": [
+                {"file": ""},                                              # 空字符串应被跳过
+                {"file": f"/Users/test/.kb/sources/{sample_name}"},        # 真实文件
+                {"file_hash": "h_no_file"},                                # 缺 file 字段, .get('') 返回 ''
+            ]
+        }
+        result = self._verify_with_mock_meta(mock_data)
+
+        if sample_name in declared_set:
+            self.assertIn(sample_name, result.observed,
+                "真实文件应被识别")
+        self.assertIsNone(result.error,
+            f"空 file 字段应被 yaml command `if sf:` 优雅跳过, got error: {result.error}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
V37.9.22 4/29 hotfix 9d60dd3 教训: spec yaml runtime_observable.command 内嵌 python oneliner 引用 ~/.kb/text_index/meta.json 字段名 (chunks[].file vs source_file) — dev 单测全过 (1664 tests) + governance 全过 (66 inv) + preflight 全过 (81/0/3) 但 Mac Mini 实测 framework 才暴露字段名错 (declared=14 observed=0 missing=14).

根因: 原 dev 单测只覆盖 declared extractor 逻辑层 (TestExtractRegistryKbSourceFiles), 没测 observer command 实际执行路径 + JSON 字段读取语义层. source-level grep guard 也只是字面量匹配 — source_file 和 file 都是合法 Python identifier, grep 通过 ≠ 字段名正确.

加固层 (TestKbSourcesToIndexCommandRuntime, 6 单测):
  test_mock_meta_observed_set_matches_chunks_file_field — 核心: 真跑 subprocess
    mock chunks 含真实 declared 文件名 + 反例 source_file 字段污染 → observed
    应只反映 file 字段, 不污染
  test_yaml_command_reads_file_field_not_source_file_field — 字面量守卫:
    yaml command 必须含 c.get('file' 不含 c.get('source_file'
  test_empty_chunks_array_yields_empty_observed_no_error — 空 chunks 合法
  test_mock_chunks_with_unknown_basename_dropped_from_observed — observed ⊆ declared
  test_meta_missing_chunks_key_treated_as_empty — 异常 schema 兜底
  test_mock_chunks_with_empty_file_string_skipped — 空字符串 file 优雅跳过

设计契约:
  - 不 mock subprocess (真实跑 yaml 里的 python oneliner)
  - 通过 monkey-patch HOME env 重定向 ~/ 解析 (subprocess 继承 env)
  - mock 数据同时含正确字段 + 反例错字段, 单测验证字段读取正确
  - tempfile.mkdtemp() + shutil.rmtree() 隔离, 不污染真实 ~/.kb/

反向验证 (negative control 已确认守卫真有效):
  故意把 yaml 字段改回 source_file → 6 单测中 3 失败 (核心 mock + 字面量
  守卫 + 反例数据测试) → 还原后 6/6 全绿. 字面量回归 100% 被抓.

INV-CONVERGENCE-KB-001 runtime python_assert 扩展 v9_22_kb_classes 列表 +TestKbSourcesToIndexCommandRuntime, governance audit 主动消费加固层 (从 "测试时调用"升级为"每次 audit cron 验证"). lesson 段记录 V37.9.22 hotfix 教训 + V37.9.23 加固层来源 + 原则 #15 第三层 "WhatsApp 业务验证" 在 ontology framework 层的兑现.

累计: 47 → 47 suites (test_convergence 内扩 1 类) / 1664 → 1670 tests (+6) / 0 fail / governance 66 inv 不变 (扩展现有 INV-CONVERGENCE-KB-001 内涵 非新增) / 372 checks 不变 / 安全 95/100 / VERSION 仍 0.37.9.22 (V37.9.23 加固为同 minor 版本内的工程加固而非业务增量, 等任务 1 jobs_to_crontab
machine_sync 落地后再 bump 0.37.9.23).

下次 (V37.9.24+ 候选): 同款 mock-based runtime test 扩展模式应用于 openclaw_config_to_runtime spec — 它也用 yaml 内嵌 json_paths 引用 openclaw.json 字段名, 同款字段名假设错风险. 不在本次 V37.9.23 范围因为
横向扩展价值递减且 dev 环境无 openclaw.json (mock 复杂度高于 KB spec).

https://claude.ai/code/session_01XDPttFUEaYdHhd8Vh5QFbT

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
