### PR TITLE
V37.9.58-hotfix4: 修 V37.9.58-hotfix3 两个漏洞 — set -E + caller || ALERT

### DIFF
--- a/job_watchdog.sh
+++ b/job_watchdog.sh
@@ -14,7 +14,14 @@ source "$HOME/.bash_profile" 2>/dev/null || source "$HOME/.env_shared" 2>/dev/nu
 # V31: 从6个job扩展到15个 + 服务健康 + 磁盘 + KB新鲜度 + crontab条目数 + 日志扫描加强
 # cron 环境 PATH 极简，必须显式声明（规则 #13）
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
-set -eo pipefail
+# V37.9.58-hotfix4 (2026-05-12): set -E (errtrace) 让 ERR trap 在 function 内部生效.
+# 血案: V37.9.58-hotfix3 加 trap ERR 但漏 set -E → bash 默认 function 内 fail 不
+# propagate ERR trap → fatal_handler 不触发 → silent abort 仍然发生 (16:45 实测).
+# `set -eEo pipefail` 三选项缺一不可:
+#   -e: errexit, 任一命令失败立即 abort (但 function 内 fail 默认不传播)
+#   -E: errtrace (V37.9.58-hotfix4 新增), function 内 fail 真触发 ERR trap
+#   -o pipefail: pipe 任一段 fail = pipe fail (防 silent)
+set -eEo pipefail
 
 # 防重叠执行（mkdir 原子锁，macOS 兼容）
 # 自身锁文件加陈旧检测——超过30分钟则强制清理（防止 watchdog 自身被锁死）
@@ -341,16 +348,21 @@ scan_logs() {
     recent_fails=$(echo "$recent_window" | grep -ciE "$err_pattern" || true)
     if [ "$recent_fails" -gt 0 ]; then
         local last_err
-        last_err=$(echo "$recent_window" | grep -iE "$err_pattern" | tail -1 | head -c 120)
+        # V37.9.58-hotfix4: head -c N + SIGPIPE 关 stdin 可能让 grep 收到 SIGPIPE exit 非 0
+        # → pipefail + set -e abort. 加 `|| true` 兜底.
+        last_err=$(echo "$recent_window" | grep -iE "$err_pattern" | tail -1 | head -c 120 || true)
 
         # V37.9.28 F1: 提取错误行的时间戳分布（最早/最新），让告警可读
         # 之前 bug: 只显示 "12条错误 → last_err" 看不出 12 条是分布的还是集中的
         # 用户 5/5 周一观察反馈："主要是一些 health 监控推送没有严格的时间戳"
         # 修复: grep -oE 提取 [YYYY-MM-DD HH:MM] 模式, sort -u 去重, head/tail 取最早最新
         # 边界: 全是 Traceback 多行无时间戳行 → "(时间戳缺失)" 标记
+        # V37.9.58-hotfix4 (2026-05-12): 加 `|| true` 兜底 — grep 无匹配 exit 1 +
+        #   pipefail + set -e = 整 watchdog abort. 5/5 16:30 起 + V37.9.58-hotfix3
+        #   16:45 实测两次重演. 这是 V37.9.28 F1 加 err_ts 时漏的 set-e 容错.
         local err_ts oldest newest ts_info
         err_ts=$(echo "$recent_window" | grep -iE "$err_pattern" | \
-                 grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}' | sort -u)
+                 grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}' | sort -u 2>/dev/null || true)
         if [ -n "$err_ts" ]; then
             oldest=$(echo "$err_ts" | head -1)
             newest=$(echo "$err_ts" | tail -1)
@@ -396,7 +408,11 @@ HOME_LOGS=(
 )
 for entry in "${HOME_LOGS[@]}"; do
     IFS='|' read -r logfile job_name <<< "$entry"
-    scan_logs "$logfile" "$job_name"
+    # V37.9.58-hotfix4 (2026-05-12): scan_logs 内部偶尔 fail (V37.9.28 F1 加 err_ts pipe
+    # 引入未防御 grep -oE → 无匹配时 pipefail + set -e abort). caller || ALERT 让
+    # scan_logs internal fail 可观察但**不让整 watchdog abort**, 让后续 7 个维度
+    # (服务健康/磁盘/lockdir/SLO/cron 心跳/Proxy 监控/KB 新鲜度) 都能跑.
+    scan_logs "$logfile" "$job_name" || ALERTS+=("$job_name: scan_logs 内部异常 (V37.9.58-hotfix4: function 内部某 pipe 缺 \`|| true\` 兜底, 追踪中, watchdog 继续跑后续维度)")
 done
 
 # Adapter 日志特殊扫描（FALLBACK ALSO FAILED = 双路径全挂）

--- a/status.json
+++ b/status.json
@@ -1,6 +1,6 @@
 {
-  "updated": "2026-05-12 08:40:24",
-  "updated_by": "claude_code",
+  "updated": "2026-05-12 08:52:37",
+  "updated_by": "full_regression",
   "priorities": [
     {
       "task": "【战略】Stage2: 从系统构建者升级为被社区认可的系统作者",
@@ -350,10 +350,10 @@
   },
   "quality": {
     "security_score": 95,
-    "test_count": 2733,
-    "last_regression": "2026-05-12 08:38 pass",
+    "test_count": 2735,
+    "last_regression": "2026-05-12 08:52 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-05-12 08:38",
+    "security_score_time": "2026-05-12 08:52",
     "test_suites": 80,
     "governance_invariants": "64/64",
     "governance_checks": "350/350",

--- a/test_watchdog_self_monitoring.py
+++ b/test_watchdog_self_monitoring.py
@@ -237,28 +237,57 @@ class TestWatchdogSyntaxAndIntegration(unittest.TestCase):
             f"bash -n 语法检查失败: {result.stderr}")
 
     def test_set_eo_pipefail_present(self):
-        """set -eo pipefail 必须保留 (V37.9.58-hotfix3 不能因为加 trap 就移除 set -e)."""
+        """set -eEo pipefail 必须保留 (V37.9.58-hotfix4: 加 -E errtrace 让 ERR trap 在 function 内生效).
+
+        历史: V37.9.58-hotfix3 用 set -eo pipefail (无 -E) → ERR trap 在 function
+        内 fail 不触发 → silent abort 仍存在. V37.9.58-hotfix4 加 -E (errtrace).
+        """
         with open(WATCHDOG_SH, "r") as f:
             src = f.read()
-        self.assertIn("set -eo pipefail", src,
-            "V37.9.58-hotfix3 必须保留 set -eo pipefail (ERR trap 是补充而非替代)")
+        # alternation: 接受 set -eEo pipefail (V37.9.58-hotfix4) 或 set -eo pipefail (V37.9.58-hotfix3 旧)
+        self.assertTrue(
+            "set -eEo pipefail" in src or "set -eo pipefail" in src,
+            "V37.9.58-hotfix3/4 必须保留 set -e* pipefail (ERR trap 是补充而非替代)"
+        )
+
+    def test_set_E_errtrace_present_v37_9_58_hotfix4(self):
+        """V37.9.58-hotfix4: set -E (errtrace) 必须加 — 让 ERR trap 在 function 内生效."""
+        with open(WATCHDOG_SH, "r") as f:
+            src = f.read()
+        self.assertIn("set -eEo pipefail", src,
+            "V37.9.58-hotfix4: 必须 set -eEo (含 -E errtrace) 让 ERR trap 在 function 内 fail 时真触发. "
+            "5/12 16:45 实测 V37.9.58-hotfix3 (无 -E) ERR trap 仍 silent.")
+
+    def test_scan_logs_caller_has_alert_fallback_v37_9_58_hotfix4(self):
+        """V37.9.58-hotfix4: scan_logs caller 必须 || ALERTS+= 兜底, 防 scan_logs internal fail 杀整 watchdog."""
+        with open(WATCHDOG_SH, "r") as f:
+            src = f.read()
+        # 匹配 caller `scan_logs ... || ALERTS+=`
+        self.assertRegex(
+            src,
+            r'scan_logs\s+"\$logfile"\s+"\$job_name"\s+\|\|\s+ALERTS\+=',
+            "V37.9.58-hotfix4: scan_logs caller 必须有 || ALERTS+= 兜底 (scan_logs internal fail 不杀脚本)"
+        )
 
     def test_trap_err_after_set_e(self):
-        """trap ERR 必须在 set -e 之后定义 (set -e 之前 trap ERR 无效)."""
+        """trap ERR 必须在 set -e* 之后定义 (set -e 之前 trap ERR 无效).
+        V37.9.58-hotfix4 alternation: 接受 set -eEo pipefail (含 errtrace) 或旧 set -eo pipefail.
+        """
         with open(WATCHDOG_SH, "r") as f:
             lines = f.readlines()
         set_e_line = None
         trap_err_line = None
         for i, line in enumerate(lines):
-            if "set -eo pipefail" in line:
+            # V37.9.58-hotfix4 alternation: set -eEo (含 -E) 优先, fallback set -eo
+            if "set -eEo pipefail" in line or "set -eo pipefail" in line:
                 set_e_line = i
             if "trap '_watchdog_fatal_handler" in line:
                 trap_err_line = i
                 break
-        self.assertIsNotNone(set_e_line, "set -eo pipefail 行未找到")
+        self.assertIsNotNone(set_e_line, "set -e* pipefail 行未找到")
         self.assertIsNotNone(trap_err_line, "trap ERR 行未找到")
         self.assertGreater(trap_err_line, set_e_line,
-            "V37.9.58-hotfix3: trap ERR 必须在 set -e 之后注册 (否则 trap 无效)")
+            "V37.9.58-hotfix3/4: trap ERR 必须在 set -e* 之后注册 (否则 trap 无效)")
 
 
 # ── Tier 6: 反向验证 sabotage 守卫真有效 ────────────────────────────


### PR DESCRIPTION
V37.9.58-hotfix3 部署到 Mac Mini 后用户实测 watchdog 仍 silent abort. 按原则 #28 三问诊断 — V37.9.58-hotfix3 漏了两个关键点:

漏洞 1: set -eo pipefail 没有 -E (errtrace)
  bash 默认 set -e 在 function 内部 fail 不传播 ERR trap.
  V37.9.58-hotfix3 加 trap ERR 但漏 set -E → ERR trap 在 function
  内 fail 时不触发 → fatal_handler 不调用 → 仍 silent abort.

漏洞 2: scan_logs 内部 V37.9.28 F1 err_ts pipe 缺 || true
  err_ts=$(... | grep -iE ... | grep -oE ... | sort -u)
  当 recent_window 无错误行时 grep -iE 无匹配 → exit 1 → pipefail
  → set -e abort. 这个 pipe 是 V37.9.28 F1 加的, 当时漏 set -e 容错.

V37.9.58-hotfix4 三项修复:

Step 1: set -eo pipefail → set -eEo pipefail
  -E (errtrace) 让 ERR trap 在 function 内部 fail 时真触发.

Step 2: err_ts pipe + last_err pipe 加 || true
  err_ts=$(... | sort -u 2>/dev/null || true)   # 防 grep 无匹配
  last_err=$(... | head -c 120 || true)         # 防 SIGPIPE

Step 3: scan_logs caller || ALERTS+=
  for entry in HOME_LOGS:
      scan_logs "$logfile" "$job_name" || ALERTS+=("scan_logs internal 异常")
  scan_logs internal fail 时 ERR trap 触发推送告警 + caller || 让 watchdog
  继续跑后续 7 个维度 (服务健康/磁盘/lockdir/SLO/cron 心跳/Proxy/KB).
  scan_logs internal 异常作为 ALERT 追加可观察.

dev 验证 watchdog 完整跑通:
  - exit 0 (不再 abort)
  - 56 行输出 (从 1 行)
  - 推送大量真实告警 (MOVESPEED 24h 48 次 rsync 失败 / Qwen context 90% / 多个 last_run.json 不存在 / SLO 违规等)
  - 16 个 scan_logs internal 异常追踪 alert (V37.9.58-hotfix4 标记)

更新 test_watchdog_self_monitoring.py (29→31 tests):
  - test_set_eo_pipefail_present: alternation 接受 set -eEo 或 set -eo
  - test_set_E_errtrace_present_v37_9_58_hotfix4 (新): set -eEo 字面量守卫
  - test_scan_logs_caller_has_alert_fallback_v37_9_58_hotfix4 (新): caller || ALERTS+= regex 守卫
  - test_trap_err_after_set_e: alternation 接受新旧 set -e* 字面量

V37.9.58-hotfix3 治本核心架构全部保留 (LC_ALL=C / ERR trap / canary heartbeat / STALE_LOCK 5 jobs 补齐 / MR-19 + INV-WATCHDOG-SELF-001). V37.9.58-hotfix4 仅 补 V37.9.58-hotfix3 落地时漏的两处.

累计: 80 suites / 2733→2735 tests (+2 V37.9.58-hotfix4 新守卫) / 0 fail / governance v3.38 不变 (V37.9.58-hotfix4 不新增 INV/MR) / 安全 95/100 / VERSION 0.37.9.58 不变.

Mac Mini 部署后预期 (V37.9.58-hotfix4 真激活):
  - 同步 V37.9.58-hotfix4 后下次 cron 触发 watchdog 应 exit 0 + 跑全 8 维度
  - 推送大量 7 天累积告警 (MOVESPEED / SLO / KB 摘要 29h / hf/s2 lockdir 残留)
  - canary 文件 ~/watchdog_canary.json 生成
  - ALERTS=0 时推 ✅ [watchdog alive @ HH:MM] 到 Discord #alerts

血案谱系完整:
  V37.9.50-hotfix    单点 import os (semantic_scholar)
  V37.9.58-hotfix    业务层 silent (8 ALIGNED jobs)
  V37.9.58-hotfix2   治理层 silent (MR-18 + scanner)
  V37.9.58-hotfix3   监控层 silent (MR-19 + watchdog 自观察, 部分生效)
  V37.9.58-hotfix4   修 hotfix3 漏洞 (set -E + caller ||) ← 本提交

元教训: V37.9.58-hotfix3 治本设计正确 (LC_ALL=C + ERR trap + canary 三契约) 但落地时 bash 3.2 quirk (set -e + function 内 fail 不 propagate ERR trap) 导致 ERR trap 真激活失败. Mac Mini 实测才暴露. 原则 #15 测试三层 + Mac Mini E2E 兑现 — dev 29 单测全过不能替代生产环境真跑.

https://claude.ai/code/session_012YBStahDLwZgCnhG5TZC3w

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
