### PR TITLE
V37.9.60-hotfix2: 修 V37.9.59 我引入的两个 bug — kb_dream 路径错配 + 整数除法 UX

### DIFF
--- a/job_watchdog.sh
+++ b/job_watchdog.sh
@@ -177,7 +177,9 @@ JOBS=(
     # KB Deep Dive: 每天22:30 → 最多静默 50h (V37.9.16 新增, 漏监控至 V37.9.58 后)
     "kb_deep_dive|$HOME/.kb/last_run_deep_dive.json|180000|KB每日深度|core"
     # KB Dream: 每天03:00 + 子阶段 map_sources(00:00) + map_notes(00:40) → 最多静默 50h
-    "kb_dream|$HOME/.kb/last_run_dream.json|180000|Agent Dream|core"
+    # V37.9.60-hotfix2: kb_dream.sh:103 实际写 $DREAM_DIR/.last_run.json (= ~/.kb/dreams/.last_run.json)
+    #   V37.9.59 假设 ~/.kb/last_run_dream.json 路径错配, 导致 watchdog 永远 "状态文件不存在" 误报
+    "kb_dream|$HOME/.kb/dreams/.last_run.json|180000|Agent Dream|core"
     # Chaspark: 每天11:00 学术抓取 → 最多静默 50h
     "chaspark|$HOME/.openclaw/jobs/chaspark/cache/last_run.json|180000|Chaspark学术|auxiliary"
     # Governance Audit: 每天07:00 → 最多静默 50h
@@ -484,15 +486,26 @@ check_log_freshness() {
     fi
     local ELAPSED=$(( NOW_EPOCH - LOG_MOD ))
     if [ "$ELAPSED" -gt "$max_silence" ]; then
-        local ELAPSED_HOURS=$(( ELAPSED / 3600 ))
-        local MAX_HOURS=$(( max_silence / 3600 ))
-        local msg="${display_name}: log ${ELAPSED_HOURS}h 未更新 (阈值 ${MAX_HOURS}h, 仅有 log mtime 监控, V37.9.59)"
+        # V37.9.60-hotfix2: 整数除法 UX 修复 — max_silence=600s 在 V37.9.59 永远显示 "0h 阈值 0h"
+        # 修法: ELAPSED >= 3600 显示 h, 否则显示 m; max_silence 同理
+        local ELAPSED_UNIT MAX_UNIT
+        if [ "$ELAPSED" -ge 3600 ]; then
+            ELAPSED_UNIT="$(( ELAPSED / 3600 ))h"
+        else
+            ELAPSED_UNIT="$(( ELAPSED / 60 ))m"
+        fi
+        if [ "$max_silence" -ge 3600 ]; then
+            MAX_UNIT="$(( max_silence / 3600 ))h"
+        else
+            MAX_UNIT="$(( max_silence / 60 ))m"
+        fi
+        local msg="${display_name}: log ${ELAPSED_UNIT} 未更新 (阈值 ${MAX_UNIT}, 仅有 log mtime 监控, V37.9.59)"
         case "$tier" in
             core) CORE_ALERTS+=("🔴 ${msg}") ;;
             auxiliary) AUX_ALERTS+=("🟡 ${msg}") ;;
             *) EXP_ALERTS+=("⚪ ${msg}") ;;
         esac
-        ALERTS+=("${display_name}: log ${ELAPSED_HOURS}h 未更新（阈值 ${MAX_HOURS}h）")
+        ALERTS+=("${display_name}: log ${ELAPSED_UNIT} 未更新（阈值 ${MAX_UNIT}）")
         STATS_WARN=$((STATS_WARN + 1))
     else
         STATS_PASS=$((STATS_PASS + 1))

--- a/status.json
+++ b/status.json
@@ -1,6 +1,6 @@
 {
-  "updated": "2026-05-13 00:53:03",
-  "updated_by": "claude_code",
+  "updated": "2026-05-13 01:08:43",
+  "updated_by": "full_regression",
   "priorities": [
     {
       "task": "【战略】Stage2: 从系统构建者升级为被社区认可的系统作者",
@@ -355,10 +355,10 @@
   },
   "quality": {
     "security_score": 95,
-    "test_count": 2775,
-    "last_regression": "2026-05-13 00:52 pass",
+    "test_count": 2778,
+    "last_regression": "2026-05-13 01:08 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-05-13 00:52",
+    "security_score_time": "2026-05-13 01:08",
     "test_suites": 81,
     "governance_invariants": "64/64",
     "governance_checks": "350/350",

--- a/test_watchdog_coverage.py
+++ b/test_watchdog_coverage.py
@@ -52,10 +52,21 @@ class TestV37959JobsArrayExpansion(unittest.TestCase):
         )
 
     def test_kb_dream_in_jobs(self):
-        """kb_dream (Agent Dream Reduce 03:00) 必须在 JOBS 数组."""
+        """kb_dream (Agent Dream Reduce 03:00) 必须在 JOBS 数组.
+
+        V37.9.60-hotfix2: 路径修正为 kb_dream.sh:103 实际写入的
+        $DREAM_DIR/.last_run.json (= ~/.kb/dreams/.last_run.json).
+        V37.9.59 假设 ~/.kb/last_run_dream.json 路径错配, 导致 watchdog 永远
+        "状态文件不存在" 误报触发 core alert.
+        """
         self.assertIn(
+            "kb_dream|$HOME/.kb/dreams/.last_run.json", self.src,
+            "V37.9.60-hotfix2: kb_dream 路径必须匹配 kb_dream.sh:103 STATUS_FILE"
+        )
+        # 反向守卫: 旧 V37.9.59 错配路径不得回归
+        self.assertNotIn(
             "kb_dream|$HOME/.kb/last_run_dream.json", self.src,
-            "V37.9.59: kb_dream 必须加入 JOBS 数组"
+            "V37.9.60-hotfix2: 禁止回退到 V37.9.59 错配路径 ~/.kb/last_run_dream.json"
         )
 
     def test_chaspark_in_jobs(self):
@@ -277,6 +288,39 @@ class TestSourceLevelGuards(unittest.TestCase):
             "V37.9.58-hotfix4 marker 必须保留")
         self.assertIn("set -eEo pipefail", self.src,
             "V37.9.58-hotfix4 set -eEo pipefail 必须保留")
+
+    def test_v37_9_60_hotfix2_marker_present(self):
+        """V37.9.60-hotfix2: 修 V37.9.59 我引入的两个 bug (kb_dream 路径 + 整数除法 UX)."""
+        self.assertIn("V37.9.60-hotfix2", self.src,
+            "V37.9.60-hotfix2 marker 必须在 watchdog 中可追溯")
+
+    def test_v37_9_60_hotfix2_check_log_freshness_uses_minutes(self):
+        """V37.9.60-hotfix2: check_log_freshness 必须根据 ELAPSED/max_silence 大小动态切换单位.
+
+        V37.9.59 整数除法 bug — max_silence=600s 永远显示 "0h 阈值 0h" 用户无法判断严重度.
+        修法: ELAPSED >= 3600 显示 h, 否则显示 m; max_silence 同理.
+        """
+        self.assertIn("ELAPSED_UNIT", self.src,
+            "V37.9.60-hotfix2: check_log_freshness 必须用 ELAPSED_UNIT 动态单位变量")
+        self.assertIn("MAX_UNIT", self.src,
+            "V37.9.60-hotfix2: check_log_freshness 必须用 MAX_UNIT 动态单位变量")
+        # 反向守卫: 旧整数除法字面量不得回归
+        self.assertNotIn('ELAPSED_HOURS=$(( ELAPSED / 3600 ))', self.src,
+            "V37.9.60-hotfix2: 禁止回退到 V37.9.59 整数除法 (max_silence < 3600 时永远显示 0h)")
+        self.assertNotIn('MAX_HOURS=$(( max_silence / 3600 ))', self.src,
+            "V37.9.60-hotfix2: 禁止回退到 V37.9.59 max_silence 整数除法")
+
+    def test_v37_9_60_hotfix2_alert_message_uses_dynamic_unit(self):
+        """V37.9.60-hotfix2: ALERTS+= 推送消息也必须用 ELAPSED_UNIT/MAX_UNIT."""
+        # 找含 ALERTS+ 且 含 "log" 且 含 "未更新" 的行 (check_log_freshness 内的 ALERTS+=)
+        found_dynamic_unit_in_alerts = False
+        for line in self.src.split("\n"):
+            if "ALERTS+=" in line and "log " in line and "未更新" in line:
+                if "ELAPSED_UNIT" in line and "MAX_UNIT" in line:
+                    found_dynamic_unit_in_alerts = True
+                    break
+        self.assertTrue(found_dynamic_unit_in_alerts,
+            "V37.9.60-hotfix2: ALERTS+= 推送消息必须用 ELAPSED_UNIT + MAX_UNIT 而非硬编码 h")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
血案: Mac Mini 5/13 08:30 watchdog cron 触发后用户视角看到一堆告警混合: 真问题 (KB 每日深度 130h llm_failed, MOVESPEED 17 次 rsync 失败) + **V37.9.59 我引入的两个 framework bug** 误报 (kb_dream 状态不存在 / auto_deploy 0h 阈值 0h).

按 #28 三问严格诊断 + 数据驱动 (用户跑诊断 cat last_run.json + ls -la):

Bug 1: kb_dream 路径错配
  - watchdog V37.9.59:180 JOBS 数组 `kb_dream|$HOME/.kb/last_run_dream.json`
  - kb_dream.sh:103 实际写 `$DREAM_DIR/.last_run.json` (= ~/.kb/dreams/.last_run.json)
  - 路径不一致 → watchdog 每次 cron 都报 "Agent Dream 状态文件不存在", core alert
  - Q1 之前存在? V37.9.59 引入 / Q2 我引入? ✓ / Q3 最小修复? 1 行 + 注释 + 反向守卫

Bug 2: 整数除法 UX
  - check_log_freshness `ELAPSED_HOURS=$(( ELAPSED / 3600 ))` `MAX_HOURS=$(( max_silence / 3600 ))`
  - auto_deploy max_silence=600s (10min), 永远 < 3600 → MAX_HOURS=0
  - 实际 ELAPSED 在 10min-1h 时也是 ELAPSED_HOURS=0
  - 告警文本 "log 0h 未更新 (阈值 0h)" 用户完全无法判断严重度
  - Q1 之前存在? V37.9.59 引入 / Q2 我引入? ✓ / Q3 最小修复? 动态单位切换

修复:
  - job_watchdog.sh:180 kb_dream 路径: `$HOME/.kb/last_run_dream.json` → `$HOME/.kb/dreams/.last_run.json` + V37.9.60-hotfix2 注释引用 kb_dream.sh:103
  - job_watchdog.sh:489 check_log_freshness 动态单位: if ELAPSED >= 3600: ELAPSED_UNIT="${X}h" else "${X}m" if max_silence >= 3600: MAX_UNIT="${X}h" else "${X}m" msg + ALERTS+= 同步用动态变量

反向验证守卫:
  - test_kb_dream_in_jobs: 路径必须新 hotfix2 + 旧 V37.9.59 错配 assertNotIn
  - test_v37_9_60_hotfix2_marker_present: hotfix2 marker 必在 watchdog
  - test_v37_9_60_hotfix2_check_log_freshness_uses_minutes: ELAPSED_UNIT/MAX_UNIT 必在 + 旧 ELAPSED_HOURS/MAX_HOURS 整数除法 assertNotIn
  - test_v37_9_60_hotfix2_alert_message_uses_dynamic_unit: ALERTS+= 推送消息必须用动态单位

非本 hotfix2 scope 的真问题 (历史累积, 已登记 unfinished 不在本 commit 修):
  - KB 每日深度 130h llm_failed (5/7 起 Qwen3 301 + gemini 503, V37.8.10 fallback chain)
  - MOVESPEED 17 次 rsync 失败 24h (V37.9.30 EPERM 未根治)
  - github_trending 42h stale (今天 14:00 cron 自愈)

累计: 81 suites / 2775→2778 tests (+3 V37.9.60-hotfix2 守卫) / 0 fail / 安全 95/100 / VERSION 0.37.9.60 不变 (hotfix 不 bump).

元价值: V37.9.60 framework 真激活 → 累积告警全可见 → 立即抓出
V37.9.59 我引入的 2 个 bug + 真问题 3 项. 没有 V37.9.60 框架,
这 7 天累积全部 silent invisible. V37.9.58-hotfix3 立 MR-19 "silent-monitor-must-self-alarm" 元规则的生产真激活兑现.

https://claude.ai/code/session_KWBUP

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
