### PR TITLE
V37.9.68-hotfix: tr: Illegal byte sequence 修复 + INV-CROSS-OS-001 quir…

### DIFF
--- a/cross_os_quirk_scanner.py
+++ b/cross_os_quirk_scanner.py
@@ -67,13 +67,24 @@ _QUIRK_ZSH_SPECIFIC = re.compile(
     r'^\s*(typeset\s+-A|autoload\s+|setopt\s+|zmodload\s+|\$\([^)]*\^\^)'
 )
 
+# ── Quirk 5: head -c N | tr 切多字节 UTF-8 中间 (V37.9.68 教训) ──
+# `head -c N` 按**字节**切, 中文 UTF-8 是 3 bytes/char, 在多字节字符中间截断后 tr
+# 看到 incomplete byte sequence 报 "tr: Illegal byte sequence" (macOS bsd LC_CTYPE=UTF-8).
+# 不阻塞功能但污染日志. 修复: tr 前加 `LC_ALL=C` 绕过 multibyte 校验.
+# 反模式: `head -c N | tr` 无 LC_ALL=C
+# 合规: `head -c N | LC_ALL=C tr ...`
+_QUIRK_HEAD_BYTE_TR = re.compile(
+    r'head\s+-c\s+\d+[^|]*\|\s*tr\s+'
+)
 
-# 4 个 quirk 检查器统一注册
+
+# 5 个 quirk 检查器统一注册
 _QUIRK_CHECKERS = (
     ("cmd_and_or_chain", "bash `cmd && X || Y` + set -eE + ERR trap false-positive FATAL"),
     ("grep_head_no_or_true", "bash `grep | head` + pipefail + set -eE 无 `|| true` 兜底"),
     ("awk_log_no_lc_all", "awk 处理 log 缺 `LC_ALL=C` 前缀 (macOS bsd multibyte 风险)"),
     ("zsh_specific_in_sh", "zsh-specific 语法在 cron .sh (POSIX sh 跑会失败)"),
+    ("head_byte_tr_no_lc_all", "`head -c N | tr` 切多字节 UTF-8 在中间, macOS bsd tr 报 Illegal byte sequence (V37.9.68 教训)"),
 )
 
 
@@ -145,6 +156,25 @@ def detect_zsh_specific_in_sh(content):
     return findings
 
 
+def detect_head_byte_tr_no_lc_all(content):
+    """检测 `head -c N | tr` 缺 LC_ALL=C (V37.9.68 教训).
+
+    macOS bsd `tr` 默认 LC_CTYPE=UTF-8, 看到 incomplete multibyte sequence 报
+    "tr: Illegal byte sequence". `head -c N` 按字节切而非字符, 中文 UTF-8 3 bytes/char,
+    在 N 处可能正好把字符切断. 修复: tr 前加 `LC_ALL=C` 绕过 multibyte 校验.
+    """
+    findings = []
+    for ln, line in enumerate(content.split("\n"), 1):
+        if _is_in_comment_or_string(line):
+            continue
+        # 匹配 `head -c <数字> [...] | tr ...` (tr 前可有空格)
+        if _QUIRK_HEAD_BYTE_TR.search(line):
+            # 豁免: tr 前紧邻 LC_ALL=C
+            if "LC_ALL=C tr" not in line:
+                findings.append((ln, "head_byte_tr_no_lc_all", line.strip()))
+    return findings
+
+
 def scan_file(path):
     """扫单文件返回所有 findings: [(line_no, quirk_name, line_text), ...]"""
     content = _read(path)
@@ -156,6 +186,7 @@ def scan_file(path):
     findings.extend(detect_grep_head_no_or_true(content))
     findings.extend(detect_awk_log_no_lc_all(content))
     findings.extend(detect_zsh_specific_in_sh(content))
+    findings.extend(detect_head_byte_tr_no_lc_all(content))
     return findings
 
 

--- a/jobs/acl_anthology/run_acl_anthology.sh
+++ b/jobs/acl_anthology/run_acl_anthology.sh
@@ -298,7 +298,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 篇 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then sleep "${backoffs[$attempt]}"; fi
             continue

--- a/jobs/ai_leaders_x/run_ai_leaders_x.sh
+++ b/jobs/ai_leaders_x/run_ai_leaders_x.sh
@@ -318,7 +318,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 条 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then sleep "${backoffs[$attempt]}"; fi
             continue
@@ -640,7 +640,7 @@ PYEOF
 
 # ── 推送 WhatsApp + Discord (V37.9.21/V37.9.37 多窗口分片: >8000 字才切, ≤8000 单段) ─
 SEND_ERR=$(mktemp)
-TOTAL_LEN=$(wc -c < "$MSG_FILE" | tr -d ' ')
+TOTAL_LEN=$(wc -c < "$MSG_FILE" | LC_ALL=C tr -d ' ')
 WA_SENT=false
 
 if [ "$TOTAL_LEN" -le 8000 ]; then

--- a/jobs/arxiv_monitor/run_arxiv.sh
+++ b/jobs/arxiv_monitor/run_arxiv.sh
@@ -306,7 +306,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 篇 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then
                 sleep "${backoffs[$attempt]}"

--- a/jobs/chaspark/run_chaspark.sh
+++ b/jobs/chaspark/run_chaspark.sh
@@ -255,7 +255,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 篇 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then
                 sleep "${backoffs[$attempt]}"

--- a/jobs/dblp/run_dblp.sh
+++ b/jobs/dblp/run_dblp.sh
@@ -305,7 +305,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 篇 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then sleep "${backoffs[$attempt]}"; fi
             continue

--- a/jobs/github_trending/run_github_trending.sh
+++ b/jobs/github_trending/run_github_trending.sh
@@ -292,7 +292,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: repo $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then
                 sleep "${backoffs[$attempt]}"

--- a/jobs/hf_papers/run_hf_papers.sh
+++ b/jobs/hf_papers/run_hf_papers.sh
@@ -337,7 +337,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: paper $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then
                 sleep "${backoffs[$attempt]}"

--- a/jobs/karpathy_x/run_karpathy_x.sh
+++ b/jobs/karpathy_x/run_karpathy_x.sh
@@ -336,7 +336,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 条 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then sleep "${backoffs[$attempt]}"; fi
             continue

--- a/jobs/ontology_sources/run_ontology_sources.sh
+++ b/jobs/ontology_sources/run_ontology_sources.sh
@@ -330,7 +330,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 篇 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then
                 sleep "${backoffs[$attempt]}"

--- a/jobs/openclaw_official/run.sh
+++ b/jobs/openclaw_official/run.sh
@@ -222,7 +222,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 篇 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then
                 sleep "${backoffs[$attempt]}"

--- a/jobs/openclaw_official/run_discussions.sh
+++ b/jobs/openclaw_official/run_discussions.sh
@@ -294,7 +294,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 条 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then sleep "${backoffs[$attempt]}"; fi
             continue

--- a/jobs/rss_blogs/run_rss_blogs.sh
+++ b/jobs/rss_blogs/run_rss_blogs.sh
@@ -286,7 +286,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 篇 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then
                 sleep "${backoffs[$attempt]}"

--- a/jobs/semantic_scholar/run_semantic_scholar.sh
+++ b/jobs/semantic_scholar/run_semantic_scholar.sh
@@ -292,7 +292,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 篇 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then
                 sleep "${backoffs[$attempt]}"

--- a/kb_dream.sh
+++ b/kb_dream.sh
@@ -1306,7 +1306,7 @@ ${BANNED_THEMES_BLOCK}
 log "LLM 调用 1/2 (DEEP): 单主题深挖 + 14 天 ban-list → 发送..."
 DEEP_RESULT=$(llm_call "$DEEP_PROMPT" 5000 0.85 300 "$DEEP_SYSTEM" || true)
 DEEP_CHARS=$(echo "$DEEP_RESULT" | wc -c | tr -d ' ')
-DEEP_HEAD=$(echo "$DEEP_RESULT" | head -c 120 | tr '\n' ' ')
+DEEP_HEAD=$(echo "$DEEP_RESULT" | head -c 120 | LC_ALL=C tr '\n' ' ')
 log "DEEP 完成: ${DEEP_CHARS} chars, head: ${DEEP_HEAD}"
 
 # DEEP fail-fast 验证（V37.9.68 用户决策：DEEP 必过，不及格 exit 1）
@@ -1390,7 +1390,7 @@ $REDUCE_MULTI_MATERIAL
 log "LLM 调用 2/2 (WIDE+RADAR): 跨领域 5 + 准期 5 → 发送..."
 WIDE_RADAR_RESULT=$(llm_call "$WIDE_RADAR_PROMPT" 6000 0.8 300 "$WIDE_RADAR_SYSTEM" || true)
 WIDE_RADAR_CHARS=$(echo "$WIDE_RADAR_RESULT" | wc -c | tr -d ' ')
-WIDE_RADAR_HEAD=$(echo "$WIDE_RADAR_RESULT" | head -c 120 | tr '\n' ' ')
+WIDE_RADAR_HEAD=$(echo "$WIDE_RADAR_RESULT" | head -c 120 | LC_ALL=C tr '\n' ' ')
 log "WIDE+RADAR 完成: ${WIDE_RADAR_CHARS} chars, head: ${WIDE_RADAR_HEAD}"
 
 # 拆分 WIDE 与 RADAR 两段（用户决策：可独立降级）

--- a/run_hn_fixed.sh
+++ b/run_hn_fixed.sh
@@ -253,7 +253,7 @@ print(content)
         parse_err="$(cat "$parse_err_file" 2>/dev/null || true)"
 
         if echo "$parse_err" | grep -q '__LLM_HTTP_ERROR__\|__LLM_PARSE_FAIL__'; then
-            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr '\n' ' ')
+            LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | LC_ALL=C tr '\n' ' ')
             log "WARN: 条 $idx attempt $((attempt+1))/3: $LAST_LLM_FAIL_REASON"
             if [ $attempt -lt 2 ]; then sleep "${backoffs[$attempt]}"; fi
             continue

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-05-14 01:16:30",
+  "updated": "2026-05-14 01:37:03",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -365,11 +365,11 @@
   },
   "quality": {
     "security_score": 95,
-    "test_count": 2944,
-    "last_regression": "2026-05-14 01:16 pass",
+    "test_count": 2950,
+    "last_regression": "2026-05-14 01:36 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-05-14 01:16",
-    "test_suites": 86,
+    "security_score_time": "2026-05-14 01:36",
+    "test_suites": 85,
     "governance_invariants": "64/64",
     "governance_checks": "350/350",
     "version": "0.37.9.68"

--- a/test_cross_os_quirk_scanner.py
+++ b/test_cross_os_quirk_scanner.py
@@ -158,7 +158,51 @@ esac'''
 
 
 # ════════════════════════════════════════════════════════════════════
-# 5. 全 repo 集成 + 反向验证
+# 5. V37.9.68 教训: head -c N | tr 切多字节 UTF-8 (Mac Mini bsd tr 报警)
+# ════════════════════════════════════════════════════════════════════
+class TestQuirkHeadByteTrNoLcAll(unittest.TestCase):
+    def _scan(self, content):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("scanner", SCANNER_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.detect_head_byte_tr_no_lc_all(content)
+
+    def test_detect_head_byte_tr_no_lc_all(self):
+        """V37.9.68 血案模式: echo $x | head -c 120 | tr '\\n' ' ' → 违反"""
+        content = 'HEAD=$(echo "$DEEP_RESULT" | head -c 120 | tr \'\\n\' \' \')'
+        findings = self._scan(content)
+        self.assertEqual(len(findings), 1)
+
+    def test_detect_head_byte_tr_with_other_byte_count(self):
+        """head -c 200 | tr 同款违反 (V37.9.40-44 LAST_LLM_FAIL_REASON pattern)"""
+        content = 'LAST_LLM_FAIL_REASON=$(echo "$parse_err" | head -c 200 | tr \'\\n\' \' \')'
+        findings = self._scan(content)
+        self.assertEqual(len(findings), 1)
+
+    def test_lc_all_c_tr_exempt(self):
+        """合规模式: head -c N | LC_ALL=C tr → 不报 (V37.9.68 修复模式)"""
+        content = 'HEAD=$(echo "$x" | head -c 120 | LC_ALL=C tr \'\\n\' \' \')'
+        self.assertEqual(self._scan(content), [])
+
+    def test_no_false_positive_on_head_alone(self):
+        """head -c 不跟 tr → 不报"""
+        content = 'X=$(cat file.txt | head -c 100)'
+        self.assertEqual(self._scan(content), [])
+
+    def test_no_false_positive_on_tr_without_head(self):
+        """tr 不跟 head -c → 不报"""
+        content = 'X=$(echo "abc" | tr a-z A-Z)'
+        self.assertEqual(self._scan(content), [])
+
+    def test_comment_line_exempt(self):
+        """注释里的反模式不报 (避免血案文档触发)"""
+        content = '# 反模式: echo $x | head -c 120 | tr \'\\n\' \' \''
+        self.assertEqual(self._scan(content), [])
+
+
+# ════════════════════════════════════════════════════════════════════
+# 6. 全 repo 集成 + 反向验证
 # ════════════════════════════════════════════════════════════════════
 class TestRepoIntegration(unittest.TestCase):
     def test_repo_scan_zero_violations(self):


### PR DESCRIPTION
…k 5 + 批量修齐 14 历史 violations

Mac Mini 5/14 09:21 用户实测 V37.9.68 真激活, 日志显示 'tr: Illegal byte sequence' 2 次. 按原则 #28 三问诊断:
- Q1 之前存在? ✗ V37.9.68 引入
- Q2 我哪个改动? V37.9.68 DEEP_HEAD/WIDE_RADAR_HEAD line 1309/1393: DEEP_HEAD=$(echo "$DEEP_RESULT" | head -c 120 | tr '\n' ' ')
- Q3 最小修复? head -c 120 | tr → head -c 120 | LC_ALL=C tr

真因: `head -c N` 按**字节**切, 中文 UTF-8 3 bytes/char, 在 N 处可能切断 multibyte 字符序列, macOS bsd tr 报警 (Linux GNU tr 不报). 不阻塞功能但 污染日志.

修复 1: kb_dream.sh DEEP_HEAD/WIDE_RADAR_HEAD 2 处加 LC_ALL=C tr

按反思文档 (2026-05-13 _complexity_bug_taxonomy.md) "每次血案转化为下次 免疫力"原则, 同 session 闭环 framework 化预防:

修复 2: cross_os_quirk_scanner.py 加第 5 个 quirk 检测
- _QUIRK_HEAD_BYTE_TR regex 匹配 `head -c N | tr` pattern
- detect_head_byte_tr_no_lc_all() 函数 (含注释行/字符串豁免)
- _QUIRK_CHECKERS 4 → 5 项注册

修复 3: scanner 立即抓出 14 个潜伏历史 violations (V37.9.40-44 6 字段 batch 迁移时 LAST_LLM_FAIL_REASON pattern 引入):
- jobs/acl_anthology/run_acl_anthology.sh:L301
- jobs/ai_leaders_x/run_ai_leaders_x.sh:L321
- jobs/arxiv_monitor/run_arxiv.sh:L309
- jobs/chaspark/run_chaspark.sh:L258
- jobs/dblp/run_dblp.sh:L308
- jobs/github_trending/run_github_trending.sh:L295
- jobs/hf_papers/run_hf_papers.sh:L340
- jobs/karpathy_x/run_karpathy_x.sh:L339
- jobs/ontology_sources/run_ontology_sources.sh:L333
- jobs/openclaw_official/run.sh:L225
- jobs/openclaw_official/run_discussions.sh:L297
- jobs/rss_blogs/run_rss_blogs.sh:L289
- jobs/semantic_scholar/run_semantic_scholar.sh:L295
- run_hn_fixed.sh:L256 全部修齐 14/14 (head -c 200 | tr → head -c 200 | LC_ALL=C tr). 复扫 0 violations.

修复 4: test_cross_os_quirk_scanner.py +6 新单测 (TestQuirkHeadByteTrNoLcAll)
- test_detect_head_byte_tr_no_lc_all (V37.9.68 血案模式)
- test_detect_head_byte_tr_with_other_byte_count (V37.9.40-44 同款历史 pattern)
- test_lc_all_c_tr_exempt (合规模式不报)
- test_no_false_positive_on_head_alone (head -c 不跟 tr 不报)
- test_no_false_positive_on_tr_without_head (tr 不跟 head -c 不报)
- test_comment_line_exempt (注释豁免血案文档)

push 2/2 段观察:
按原则 #28 分析非 bug — max_chunk=4000 用 Python 字符数 (非字节). 中文 UTF-8 1 char = 3 bytes, 所以 DEEP(2356 chars)+WIDE(1245)+## 头 = 3605 chars < 4000 拼一气泡; RADAR+Overview = 1352 chars 另一气泡. 符合 V37.9.21+V37.9.35 设计 (WhatsApp 客户端按字符 ~4000-5000 折叠).

测试三层 (原则 #15) 完整闭环:
- 单测: 21 V37.9.67 + 6 V37.9.68 新 = 27 scanner 单测全过
- 全量回归: 85 suites / 2944→2950 tests / 0 fail
- WhatsApp 业务验证: Mac Mini 09:21 真激活 4/4 段成功 + 15442 chars 推送

元价值: V37.9.67 P0 行动 1 立 scanner framework 后, V37.9.68 真实 Mac Mini 测试 5 小时内暴露第 5 个 quirk + scanner 主动抓 14 潜伏 violations. 反思 文档"血案→反思→P0→framework 化预防"迭代机制硬实证. 闭环时间 <5h.

https://claude.ai/code/session_013LKkzhqUGgU9UWoHrjXiRt

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
