### PR TITLE
fix: daily_observer.sh 去掉 2>&1 防 stderr log 污染 JSON stdout (MR-11 反模式)

### DIFF
--- a/daily_observer.sh
+++ b/daily_observer.sh
@@ -84,12 +84,11 @@ fi
 log "starting daily_observer.py ${DATE_ARG:-'(default yesterday)'}"
 
 OBSERVER_OUTPUT=""
-# V37.5.1 env-var heredoc 模式: 不用 pipe, 用环境变量传参
-OBSERVER_OUTPUT=$(python3 "$OBSERVER_PY" --json $DATE_ARG 2>&1) || {
+# stdout = JSON 输出, stderr = log 信息 (流向 cron log, 不混入 JSON)
+OBSERVER_OUTPUT=$(python3 "$OBSERVER_PY" --json $DATE_ARG) || {
     _rc=$?
     log "observer failed (exit=$_rc)"
     send_alert "observer.py 执行失败 (exit=$_rc)"
-    echo "$OBSERVER_OUTPUT" >&2
     exit 1
 }
 


### PR DESCRIPTION
Mac Mini 首跑发现 parse_error — Python log() 写 stderr 被 2>&1 混入 command substitution 的 stdout, 让 JSON 解析失败. 去掉 2>&1 让 stderr 自然流向 cron log.

https://claude.ai/code/session_01X4yafdRXFnrTwuhMYzbRm4

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
