### PR TITLE
fix: daily_observer.sh bash 3.2 compatibility (ASCII comments + singl…

### DIFF
--- a/daily_observer.sh
+++ b/daily_observer.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# daily_observer.sh — V37.9.84 Daily Self-Critique thin wrapper
+# daily_observer.sh -- V37.9.84 Daily Self-Critique thin wrapper
 #
-# 每日 06:30 cron 调用 daily_observer.py, 推送到 Discord #daily (不推 WhatsApp 避免噪声).
-# Observer 是给 operator 看的质量审计, 不是给终端用户的推送.
+# Cron 06:30 calls daily_observer.py, pushes to Discord #daily only.
+# Observer is for operator quality audit, not end-user push.
 #
-# V37.5.1 同款 env-var heredoc 模式 (禁 pipe+heredoc stdin 冲突).
-# V37.9.63 同款 cron_monitor_fatal_handler helper (ERR trap 主动告警).
+# V37.5.1 env-var heredoc pattern (no pipe+heredoc stdin conflict).
+# V37.9.63 cron_monitor_fatal_handler helper (ERR trap alert).
 
 set -eEuo pipefail
 
-# ── 路径自发现 ──
+# -- path discovery --
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OBSERVER_PY=""
 for candidate in "$HOME/daily_observer.py" "$SCRIPT_DIR/daily_observer.py"; do
@@ -23,10 +23,10 @@ if [ -z "$OBSERVER_PY" ]; then
     exit 1
 fi
 
-# ── 日志 ──
+# -- logging --
 log() { echo "[observer] $(date '+%H:%M:%S') $*" >&2; }
 
-# ── 通知 ──
+# -- notification --
 NOTIFY_SH=""
 for candidate in "$HOME/notify.sh" "$SCRIPT_DIR/notify.sh"; do
     if [ -f "$candidate" ]; then
@@ -48,7 +48,7 @@ send_alert() {
     fi
 }
 
-# ── ERR trap (V37.9.63 helper 模式) ──
+# -- ERR trap (V37.9.63 helper pattern) --
 CRON_FATAL_LABEL="daily_observer"
 CRON_FATAL_LOG="${HOME}/daily_observer.log"
 CRON_FATAL_BASH_X="bash -x ~/daily_observer.sh"
@@ -68,7 +68,7 @@ else
     trap 'send_alert "FATAL exit=$? line=$LINENO"' ERR
 fi
 
-# ── 日期参数 (默认昨日) ──
+# -- date arg (default yesterday) --
 TARGET_DATE="${1:-$(date -d 'yesterday' '+%Y%m%d' 2>/dev/null || date -v-1d '+%Y%m%d' 2>/dev/null || '')}"
 if [ -z "$TARGET_DATE" ]; then
     log "WARN: cannot compute yesterday date, using default"
@@ -80,59 +80,54 @@ if [ -n "$TARGET_DATE" ]; then
     DATE_ARG="--date $TARGET_DATE"
 fi
 
-# ── 运行 observer ──
+# -- run observer (stdout=JSON, stderr=log) --
 log "starting daily_observer.py ${DATE_ARG:-'(default yesterday)'}"
 
 OBSERVER_OUTPUT=""
-# stdout = JSON 输出, stderr = log 信息 (流向 cron log, 不混入 JSON)
 OBSERVER_OUTPUT=$(python3 "$OBSERVER_PY" --json $DATE_ARG) || {
     _rc=$?
     log "observer failed (exit=$_rc)"
-    send_alert "observer.py 执行失败 (exit=$_rc)"
+    send_alert "observer.py failed (exit=$_rc)"
     exit 1
 }
 
-# ── 解析结果 ──
-STATUS=$(echo "$OBSERVER_OUTPUT" | python3 -c "
+# -- parse all fields in one Python call (avoid 3 forks) --
+PARSED=""
+PARSED=$(echo "$OBSERVER_OUTPUT" | python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
-    print(d.get('status', 'unknown'))
-except: print('parse_error')
-" 2>/dev/null || echo "parse_error")
+    status = d.get('status', 'unknown')
+    score = d.get('overall_score')
+    score_str = str(score) if score is not None else 'N/A'
+    discord = d.get('discord_summary', '')
+    print(status)
+    print(score_str)
+    print(discord)
+except Exception:
+    print('parse_error')
+    print('N/A')
+    print('')
+" 2>/dev/null) || PARSED=$'parse_error\nN/A\n'
 
-DISCORD_SUMMARY=$(echo "$OBSERVER_OUTPUT" | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    print(d.get('discord_summary', ''))
-except: print('')
-" 2>/dev/null || echo "")
-
-OVERALL_SCORE=$(echo "$OBSERVER_OUTPUT" | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    s = d.get('overall_score')
-    print(s if s is not None else 'N/A')
-except: print('N/A')
-" 2>/dev/null || echo "N/A")
+STATUS=$(echo "$PARSED" | head -n1)
+OVERALL_SCORE=$(echo "$PARSED" | sed -n '2p')
+DISCORD_SUMMARY=$(echo "$PARSED" | tail -n +3)
 
 log "status=$STATUS overall_score=$OVERALL_SCORE"
 
-# ── 保存报告 (read-only: 只写到自己的目录) ──
+# -- save report (read-only: writes only to its own directory) --
 CRITIQUE_DIR="${KB_DIR:-$HOME/.kb}/self_critique"
 mkdir -p "$CRITIQUE_DIR"
 
 REPORT_DATE="${TARGET_DATE:-$(date -d 'yesterday' '+%Y%m%d' 2>/dev/null || date -v-1d '+%Y%m%d' 2>/dev/null || date '+%Y%m%d')}"
 REPORT_FILE="$CRITIQUE_DIR/daily_critique_${REPORT_DATE}.md"
 
-# 从 JSON 提取完整 report markdown
 python3 "$OBSERVER_PY" $DATE_ARG > "$REPORT_FILE" 2>/dev/null || {
-    log "WARN: failed to write report file, continuing with push"
+    log "WARN: failed to write report file, continuing"
 }
 
-# ── 推送到 Discord only (不推 WhatsApp — observer 是 operator 工具) ──
+# -- push to Discord only (not WhatsApp, observer is operator tool) --
 if [ -n "$DISCORD_SUMMARY" ] && $NOTIFY_LOADED; then
     log "pushing to Discord #daily"
     notify "$DISCORD_SUMMARY" --topic daily 2>/dev/null || {
@@ -140,7 +135,7 @@ if [ -n "$DISCORD_SUMMARY" ] && $NOTIFY_LOADED; then
     }
 fi
 
-# ── status file ──
+# -- status file --
 STATUS_FILE="${KB_DIR:-$HOME/.kb}/last_run_self_critique.json"
 python3 -c "
 import json, sys
@@ -154,16 +149,16 @@ d = {
 json.dump(d, sys.stdout, ensure_ascii=False)
 " > "$STATUS_FILE" 2>/dev/null || true
 
-# ── 结果处理 ──
+# -- result handling --
 case "$STATUS" in
     ok)
-        log "✅ critique complete (score=$OVERALL_SCORE)"
+        log "critique complete (score=$OVERALL_SCORE)"
         ;;
     no_outputs)
-        log "⚠️ no outputs found for target date (normal on quiet days)"
+        log "no outputs found for target date (normal on quiet days)"
         ;;
     llm_failed)
-        send_alert "LLM critique 失败 — 规则检测部分已完成, LLM 评分不可用"
+        send_alert "LLM critique failed, rule-based detection completed"
         ;;
     *)
         log "status=$STATUS"


### PR DESCRIPTION
…e-fork JSON parse)

macOS bash 3.2 syntax error on CJK characters in comments following || { } blocks. Rewrote all comments to ASCII-safe, consolidated 3 separate Python JSON parse forks into 1, removed emoji from log output.

https://claude.ai/code/session_01X4yafdRXFnrTwuhMYzbRm4

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
