### PR TITLE
fix: daily_observer job status path resolution for Mac Mini deploymen…

### DIFF
--- a/daily_observer.py
+++ b/daily_observer.py
@@ -52,6 +52,25 @@ JOBS_SUBDIRS = [
     "chaspark",
 ]
 
+# V37.9.56-hotfix same pattern: Mac Mini deploys to ~/.openclaw/jobs/
+# HN special case: subdirectory is hn_watcher not run_hn_fixed
+_MAC_MINI_JOBS_DIR = os.path.expanduser("~/.openclaw/jobs")
+
+
+def _resolve_last_run_path(jobs_dir, job_id):
+    """Find last_run.json across dev + Mac Mini candidate paths.
+
+    Returns: path if found, else None.
+    """
+    candidates = [
+        os.path.join(jobs_dir, job_id, "cache", "last_run.json"),
+        os.path.join(_MAC_MINI_JOBS_DIR, job_id, "cache", "last_run.json"),
+    ]
+    for c in candidates:
+        if os.path.isfile(c):
+            return c
+    return None
+
 
 def scan_job_statuses(jobs_dir, target_date):
     """Scan last_run.json from all known job subdirectories.
@@ -61,10 +80,10 @@ def scan_job_statuses(jobs_dir, target_date):
     """
     results = []
     for job_id in JOBS_SUBDIRS:
-        lr_path = os.path.join(jobs_dir, job_id, "cache", "last_run.json")
+        lr_path = _resolve_last_run_path(jobs_dir, job_id)
         entry = {"job_id": job_id, "found": False, "status": "unknown",
                  "time": "", "new": 0, "reason": ""}
-        if not os.path.isfile(lr_path):
+        if lr_path is None:
             results.append(entry)
             continue
         try:

--- a/test_daily_observer.py
+++ b/test_daily_observer.py
@@ -22,6 +22,64 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import daily_observer as obs
 
 
+class TestResolveLastRunPath(unittest.TestCase):
+    """Multi-candidate path resolution (V37.9.56-hotfix same pattern)."""
+
+    def test_finds_in_primary_jobs_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            job_dir = os.path.join(td, "hf_papers", "cache")
+            os.makedirs(job_dir)
+            lr = os.path.join(job_dir, "last_run.json")
+            with open(lr, "w") as f:
+                f.write("{}")
+            result = obs._resolve_last_run_path(td, "hf_papers")
+            self.assertEqual(result, lr)
+
+    def test_falls_back_to_mac_mini_path(self):
+        """When primary path missing, finds ~/.openclaw/jobs/X/cache/."""
+        with tempfile.TemporaryDirectory() as td:
+            mac_dir = os.path.join(td, "mac_openclaw", "jobs",
+                                   "hf_papers", "cache")
+            os.makedirs(mac_dir)
+            lr = os.path.join(mac_dir, "last_run.json")
+            with open(lr, "w") as f:
+                f.write("{}")
+            original = obs._MAC_MINI_JOBS_DIR
+            try:
+                obs._MAC_MINI_JOBS_DIR = os.path.join(
+                    td, "mac_openclaw", "jobs")
+                result = obs._resolve_last_run_path(
+                    os.path.join(td, "nonexistent"), "hf_papers")
+                self.assertEqual(result, lr)
+            finally:
+                obs._MAC_MINI_JOBS_DIR = original
+
+    def test_returns_none_when_all_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = obs._resolve_last_run_path(td, "nonexistent_job")
+            self.assertIsNone(result)
+
+    def test_primary_takes_precedence(self):
+        """Primary dir wins even if Mac Mini path also exists."""
+        with tempfile.TemporaryDirectory() as td:
+            primary = os.path.join(td, "primary", "dblp", "cache")
+            os.makedirs(primary)
+            with open(os.path.join(primary, "last_run.json"), "w") as f:
+                json.dump({"status": "primary"}, f)
+            mac = os.path.join(td, "mac", "dblp", "cache")
+            os.makedirs(mac)
+            with open(os.path.join(mac, "last_run.json"), "w") as f:
+                json.dump({"status": "mac"}, f)
+            original = obs._MAC_MINI_JOBS_DIR
+            try:
+                obs._MAC_MINI_JOBS_DIR = os.path.join(td, "mac")
+                result = obs._resolve_last_run_path(
+                    os.path.join(td, "primary"), "dblp")
+                self.assertIn("primary", result)
+            finally:
+                obs._MAC_MINI_JOBS_DIR = original
+
+
 class TestScanJobStatuses(unittest.TestCase):
     """Scan last_run.json from job cache directories."""
 
@@ -511,6 +569,14 @@ class TestSourceLevelGuards(unittest.TestCase):
 
     def test_default_kb_dir(self):
         self.assertIn("~/.kb", self.src)
+
+    def test_mac_mini_jobs_path_candidate(self):
+        """V37.9.56-hotfix same pattern: Mac Mini path must be a candidate."""
+        self.assertIn("_MAC_MINI_JOBS_DIR", self.src)
+        self.assertIn(".openclaw/jobs", self.src)
+
+    def test_resolve_last_run_path_helper(self):
+        self.assertIn("def _resolve_last_run_path(", self.src)
 
     def test_jobs_subdirs_defined(self):
         self.assertIn("JOBS_SUBDIRS", self.src)


### PR DESCRIPTION
…t layout

Mac Mini deploys job caches to ~/.openclaw/jobs/X/cache/ (via auto_deploy FILE_MAP), not the repo's ./jobs/X/cache/. Added _resolve_last_run_path() multi-candidate helper (V37.9.56-hotfix same pattern) that tries primary jobs_dir first, falls back to ~/.openclaw/jobs/.

Jobs 0/15 on Mac Mini -> should now find all last_run.json files.

+6 tests (resolve path: primary/fallback/none/precedence + 2 source guards)

https://claude.ai/code/session_01X4yafdRXFnrTwuhMYzbRm4

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
