### PR TITLE
fix: daily_observer push full report to WhatsApp+Discord (not just su…

### DIFF
--- a/daily_observer.sh
+++ b/daily_observer.sh
@@ -127,12 +127,15 @@ python3 "$OBSERVER_PY" $DATE_ARG > "$REPORT_FILE" 2>/dev/null || {
     log "WARN: failed to write report file, continuing"
 }
 
-# -- push to Discord only (not WhatsApp, observer is operator tool) --
-if [ -n "$DISCORD_SUMMARY" ] && $NOTIFY_LOADED; then
-    log "pushing to Discord #daily"
-    notify "$DISCORD_SUMMARY" --topic daily 2>/dev/null || {
-        log "WARN: Discord push failed (non-fatal)"
-    }
+# -- push full report to WhatsApp + Discord dual-channel --
+if [ -f "$REPORT_FILE" ] && $NOTIFY_LOADED; then
+    REPORT_CONTENT=$(cat "$REPORT_FILE" 2>/dev/null || echo "")
+    if [ -n "$REPORT_CONTENT" ]; then
+        log "pushing full report to dual-channel (--topic daily)"
+        notify "$REPORT_CONTENT" --topic daily 2>/dev/null || {
+            log "WARN: push failed (non-fatal)"
+        }
+    fi
 fi
 
 # -- status file --

--- a/test_daily_observer.py
+++ b/test_daily_observer.py
@@ -502,10 +502,10 @@ class TestShellGuards(unittest.TestCase):
     def test_system_alert_prefix(self):
         self.assertIn("[SYSTEM_ALERT] daily_observer", self.src)
 
-    def test_discord_only_not_whatsapp(self):
+    def test_pushes_full_report_via_notify(self):
         self.assertIn("--topic daily", self.src)
-        self.assertNotIn("--topic whatsapp", self.src)
-        self.assertNotIn("--channel whatsapp", self.src)
+        self.assertIn("REPORT_CONTENT", self.src)
+        self.assertIn('cat "$REPORT_FILE"', self.src)
 
     def test_read_only_marker(self):
         self.assertIn("READ-ONLY", self.src.upper() + self.src)


### PR DESCRIPTION
…mmary)

User feedback: WhatsApp only showed 3-line summary, want full critique report with scores + issues + proposals. Changed push from discord_summary to full REPORT_FILE content via notify --topic daily dual-channel.

https://claude.ai/code/session_01X4yafdRXFnrTwuhMYzbRm4

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
