### PR TITLE
fix: _format_cron_line .py→python3 + scanner $HOME/~/normalize

### DIFF
--- a/ontology/convergence.py
+++ b/ontology/convergence.py
@@ -827,8 +827,11 @@ def _format_cron_line(job):
     else:
         entry_runtime = entry
 
-    # Match V37.9.18 INV-CRON-003 pattern: bash -lc 'bash ~/{entry} >> {log} 2>&1'
-    return f"{interval} bash -lc 'bash ~/{entry_runtime} >> {log_resolved} 2>&1'"
+    # V37.9.85: .py entries use python3, .sh entries use bash
+    runner = "python3" if entry_runtime.endswith(".py") else "bash"
+
+    # Match V37.9.18 INV-CRON-003 pattern: bash -lc '{runner} ~/{entry} >> {log} 2>&1'
+    return f"{interval} bash -lc '{runner} ~/{entry_runtime} >> {log_resolved} 2>&1'"
 
 
 def _load_jobs_registry_index(spec):

--- a/path_consistency_scanner.py
+++ b/path_consistency_scanner.py
@@ -289,6 +289,9 @@ def scan_crontab_consistency(repo_dir: str) -> list[dict[str, str]]:
     if not crontab_lines:
         return findings  # FAIL-OPEN: empty crontab (dev environment)
 
+    # V37.9.85: normalize $HOME/ ↔ ~/ for comparison (semantically identical)
+    crontab_normalized = crontab_lines.replace("$HOME/", "~/")
+
     enabled_jobs = load_jobs_registry(repo_dir)
     for job in enabled_jobs:
         scheduler = job.get("scheduler", "")
@@ -305,7 +308,9 @@ def scan_crontab_consistency(repo_dir: str) -> list[dict[str, str]]:
         except (ValueError, Exception):
             continue  # malformed job, already caught by scan_path_consistency
 
-        if expected_line not in crontab_lines:
+        expected_normalized = expected_line.replace("$HOME/", "~/")
+
+        if expected_normalized not in crontab_normalized:
             findings.append({
                 "type": "CRON_LINE_MISSING",
                 "job_id": job.get("id", "?"),

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-05-27 00:58:19",
+  "updated": "2026-05-27 03:37:11",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -335,9 +335,9 @@
   "quality": {
     "security_score": 95,
     "test_count": 3346,
-    "last_regression": "2026-05-27 00:58 pass",
+    "last_regression": "2026-05-27 03:37 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-05-27 00:58",
+    "security_score_time": "2026-05-27 03:37",
     "test_suites": 96,
     "governance_invariants": "64/64",
     "governance_checks": "350/350",

--- a/test_convergence.py
+++ b/test_convergence.py
@@ -3303,7 +3303,8 @@ class TestV37966Primitives(unittest.TestCase):
         self.assertGreater(len(lines), 10)
         # 每行必须是合法 cron 行 (5-field interval + bash -lc 模式)
         for line in lines:
-            self.assertRegex(line, r"^\S+ \S+ \S+ \S+ \S+ bash -lc 'bash ~/")
+            # V37.9.85: .py entries use python3, .sh use bash
+            self.assertRegex(line, r"^\S+ \S+ \S+ \S+ \S+ bash -lc '(?:bash|python3) ~/")
 
     def test_parser_cron_lines_set_diff_returns_raw_lines_set(self):
         """新 parser 输出 raw cron 行 set (跳过 # 注释 / 空行)"""


### PR DESCRIPTION
Two fixes reducing crontab consistency false positives:

1. convergence._format_cron_line: .py entries now use python3 instead of bash (real crontab uses python3 for kb_trend.py, kb_embed.py, preference_learner.py, kb_harvest_chat.py)

2. scan_crontab_consistency: normalize $HOME/ ↔ ~/ before comparison (semantically identical, prevents false CRON_LINE_MISSING for kb_status_refresh which uses $HOME/ in real crontab)

- test_convergence regex updated for python3|bash alternation
- 96 suites / 3346 tests / 0 fail

https://claude.ai/code/session_019kX5ys3pwPkmMou3s2SWJb

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
