### PR TITLE
fix: scanner crontab check — quote normalize + basename fallback

### DIFF
--- a/path_consistency_scanner.py
+++ b/path_consistency_scanner.py
@@ -289,8 +289,14 @@ def scan_crontab_consistency(repo_dir: str) -> list[dict[str, str]]:
     if not crontab_lines:
         return findings  # FAIL-OPEN: empty crontab (dev environment)
 
-    # V37.9.85: normalize $HOME/ ↔ ~/ for comparison (semantically identical)
-    crontab_normalized = crontab_lines.replace("$HOME/", "~/")
+    # V37.9.85: normalize for comparison — these are semantically equivalent:
+    #   $HOME/ ↔ ~/
+    #   single quotes ↔ double quotes in bash -lc context
+    #   mkdir -p ...; bash -lc '...' wrapper (substring match)
+    def _normalize(text):
+        return text.replace("$HOME/", "~/").replace('"', "'")
+
+    crontab_normalized = _normalize(crontab_lines)
 
     enabled_jobs = load_jobs_registry(repo_dir)
     for job in enabled_jobs:
@@ -308,9 +314,27 @@ def scan_crontab_consistency(repo_dir: str) -> list[dict[str, str]]:
         except (ValueError, Exception):
             continue  # malformed job, already caught by scan_path_consistency
 
-        expected_normalized = expected_line.replace("$HOME/", "~/")
+        expected_normalized = _normalize(expected_line)
 
-        if expected_normalized not in crontab_normalized:
+        if expected_normalized in crontab_normalized:
+            continue  # exact match (best case)
+
+        # Fallback: check if interval + entry basename both appear in the
+        # same crontab line. This catches "job IS registered but with format
+        # drift" (mkdir wrapper, missing inner bash, different quoting, etc.)
+        entry_file = entry.split(None, 1)[0]
+        entry_basename = os.path.basename(entry_file)
+        interval_str = interval.strip()
+        found_by_basename = False
+        for cron_line in crontab_normalized.splitlines():
+            line_stripped = cron_line.strip()
+            if not line_stripped or line_stripped.startswith("#"):
+                continue
+            if line_stripped.startswith(interval_str) and entry_basename in line_stripped:
+                found_by_basename = True
+                break
+
+        if not found_by_basename:
             findings.append({
                 "type": "CRON_LINE_MISSING",
                 "job_id": job.get("id", "?"),

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-05-27 03:37:11",
+  "updated": "2026-05-27 03:54:58",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -335,9 +335,9 @@
   "quality": {
     "security_score": 95,
     "test_count": 3346,
-    "last_regression": "2026-05-27 03:37 pass",
+    "last_regression": "2026-05-27 03:54 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-05-27 03:37",
+    "security_score_time": "2026-05-27 03:54",
     "test_suites": 96,
     "governance_invariants": "64/64",
     "governance_checks": "350/350",


### PR DESCRIPTION
Reduce false positives in --full crontab consistency check:

1. Normalize single/double quotes before comparison (bash -lc '...' vs bash -lc "..." is stylistic, not semantic)
2. Basename fallback: if exact match fails, check interval + entry basename in same crontab line. Catches "job IS registered but with format drift" (mkdir wrapper, missing inner bash, etc.)

Combined with prior .py→python3 + $HOME/~/ fixes, expected to reduce Mac Mini violations from 18 to ~7 (truly structural drift only).

https://claude.ai/code/session_019kX5ys3pwPkmMou3s2SWJb

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
