### PR TITLE
V37.9.85: 4 short fixes — HN metadata, README, security scan, wa_parts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
 
       - name: "Security: phone number leak scan"
         run: |
-          PHONE=$(grep -r "+852[0-9]\{8\}" . --include="*.py" --include="*.sh" 2>/dev/null | grep -v ".git" | grep -v "+85200000000" | grep -v "test_" || true)
+          # V37.9.85: +85200000001 是 governance_ontology.yaml 内嵌单测 fixture (非泄漏)
+          PHONE=$(grep -r "+852[0-9]\{8\}" . --include="*.py" --include="*.sh" 2>/dev/null | grep -v ".git" | grep -v "+85200000000\|+85200000001" | grep -v "test_" || true)
           if [ -n "$PHONE" ]; then echo "❌ Phone number leak:"; echo "$PHONE"; exit 1; fi
           echo "✅ No phone leaks"
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://img.shields.io/badge/tests-3222%20passed-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-3346%20passed-brightgreen.svg)]()
 [![Providers](https://img.shields.io/badge/providers-8%20supported-orange.svg)]()
-[![Governance](https://img.shields.io/badge/invariants-80%2F80%20%2B%2019%20MR-blueviolet.svg)]()
+[![Governance](https://img.shields.io/badge/invariants-82%2F82%20%2B%2019%20MR-blueviolet.svg)]()
 [![Security](https://img.shields.io/badge/security-95%2F100-green.svg)]()
-[![Jobs](https://img.shields.io/badge/cron%20jobs-35%20active-blue.svg)]()
+[![Jobs](https://img.shields.io/badge/cron%20jobs-36%20active-blue.svg)]()
 [![Fail-Fast](https://img.shields.io/badge/LLM%20cron%20fail--fast-17%2F21%20aligned-brightgreen.svg)]()
 [![Notifications](https://img.shields.io/badge/notifications-WhatsApp%20%2B%20Discord-informational.svg)]()
 

--- a/full_regression.sh
+++ b/full_regression.sh
@@ -231,7 +231,8 @@ else
 fi
 
 echo -n "  🔒 手机号泄漏扫描 ... "
-PHONE_LEAKED=$(grep -r "+852[0-9]\{8\}" . --include="*.py" --include="*.sh" 2>/dev/null | grep -v ".git" | grep -v "+85200000000" | grep -v "test_" || true)
+# V37.9.85: +85200000001 是 governance_ontology.yaml 内嵌单测 fixture (非泄漏)
+PHONE_LEAKED=$(grep -r "+852[0-9]\{8\}" . --include="*.py" --include="*.sh" 2>/dev/null | grep -v ".git" | grep -v "+85200000000\|+85200000001" | grep -v "test_" || true)
 if [ -z "$PHONE_LEAKED" ]; then
     echo "✅"
     PASS=$((PASS + 1))

--- a/jobs/hn_watcher/run_hn_fixed.sh
+++ b/jobs/hn_watcher/run_hn_fixed.sh
@@ -133,7 +133,15 @@ for item in items[:50]:
     title    = (item.findtext('title')    or '').strip()
     link     = (item.findtext('link')     or '').strip()
     comments = (item.findtext('comments') or link).strip()
-    desc     = (item.findtext('description') or '').strip()[:400]
+    desc_raw = (item.findtext('description') or '').strip()
+    # V37.9.85: strip HN comment metadata that leaks into LLM prompt as noise
+    # hnrss.org descriptions contain: "username | Hacker News•昨天6:22" comment attribution
+    import re as _re
+    desc_raw = _re.sub(r'<[^>]+>', ' ', desc_raw)              # strip HTML tags
+    desc_raw = _re.sub(r'Hacker News\s*[•·]\s*\S+', '', desc_raw)  # "Hacker News•昨天6:22"
+    desc_raw = _re.sub(r'\b\d+\s*(?:points?|comments?)\b', '', desc_raw, flags=_re.IGNORECASE)  # "123 points", "45 comments"
+    desc_raw = _re.sub(r'\s{2,}', ' ', desc_raw)               # collapse whitespace
+    desc     = desc_raw.strip()[:400]
     pubdate  = (item.findtext('pubDate')  or '').strip()
 
     if not title or not link:

--- a/kb_deep_dive.sh
+++ b/kb_deep_dive.sh
@@ -198,7 +198,9 @@ PICK_TITLE=$(echo "$COLLECTOR_OUTPUT" | python3 -c 'import json,sys; print(json.
 WA_CHUNK_DIR=$(mktemp -d -t kb_deep_dive_wa_XXXXXX)
 trap 'rm -rf "$WA_CHUNK_DIR"' EXIT
 
-WA_PARTS_TOTAL=$(COLLECTOR_OUTPUT="$COLLECTOR_OUTPUT" CHUNK_DIR="$WA_CHUNK_DIR" python3 << 'PYEOF'
+# V37.9.85: 用临时文件捕获 Python stderr, 便于 shell log 记录部署不一致警告
+_WA_PARTS_ERR=$(mktemp)
+WA_PARTS_TOTAL=$(COLLECTOR_OUTPUT="$COLLECTOR_OUTPUT" CHUNK_DIR="$WA_CHUNK_DIR" python3 2>"$_WA_PARTS_ERR" << 'PYEOF'
 import json, os, sys
 data = json.loads(os.environ["COLLECTOR_OUTPUT"])
 # V37.9.22: 检测部署不一致期 (新 shell + 旧 py 临时混合) — wa_parts 是 V37.9.21 引入的新字段
@@ -213,6 +215,11 @@ for idx, part in enumerate(parts):
 print(len(parts))
 PYEOF
 )
+# V37.9.85: forward Python stderr WARN to shell log (MR-4 防 silent deploy inconsistency)
+if [ -s "$_WA_PARTS_ERR" ]; then
+    log "WARN: [deploy_inconsistency] $(cat "$_WA_PARTS_ERR")"
+fi
+rm -f "$_WA_PARTS_ERR"
 
 # ── 7. 推送 ──
 # topic=deep_dive 路由到 Discord #daily（保留主 daily 频道作为深度分析归属）

--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -432,7 +432,8 @@ else
 fi
 
 # 真实手机号检查（排除占位号，只扫描 git 跟踪的文件）
-LEAK_PHONE=$(git grep -n "+852[0-9]\{8\}" -- "*.py" "*.sh" "*.md" 2>/dev/null | grep -v "+85200000000" || true)
+# V37.9.85: +85200000001 是 governance_ontology.yaml 内嵌单测 fixture (非泄漏)
+LEAK_PHONE=$(git grep -n "+852[0-9]\{8\}" -- "*.py" "*.sh" "*.md" 2>/dev/null | grep -v "+85200000000\|+85200000001" || true)
 if [ -z "$LEAK_PHONE" ]; then
     pass "无真实手机号泄漏"
 else

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-05-27 03:54:58",
+  "updated": "2026-05-27 04:21:53",
   "updated_by": "full_regression",
   "priorities": [
     {
@@ -335,9 +335,9 @@
   "quality": {
     "security_score": 95,
     "test_count": 3346,
-    "last_regression": "2026-05-27 03:54 pass",
+    "last_regression": "2026-05-27 04:21 pass",
     "coverage_pct": 0,
-    "security_score_time": "2026-05-27 03:54",
+    "security_score_time": "2026-05-27 04:21",
     "test_suites": 96,
     "governance_invariants": "64/64",
     "governance_checks": "350/350",

--- a/test_kb_business.py
+++ b/test_kb_business.py
@@ -475,7 +475,8 @@ class TestSecurityPatterns(unittest.TestCase):
             import re
             # 匹配 +852XXXXXXXX 格式但排除占位符 +85200000000
             phones = re.findall(r'\+852\d{8}', content)
-            real = [p for p in phones if p != "+85200000000"]
+            # V37.9.85: +85200000001 是 governance_ontology.yaml 内嵌单测 fixture
+            real = [p for p in phones if p not in ("+85200000000", "+85200000001")]
             self.assertEqual(real, [], f"{f} contains real phone number")
 
     def test_no_pipe_crontab_pattern(self):

--- a/test_v37_9_58_hotfix.py
+++ b/test_v37_9_58_hotfix.py
@@ -109,20 +109,24 @@ class TestV37958HotfixOsImport(unittest.TestCase):
         )
 
     def test_hn_specific_fix_at_line_283(self):
-        """V37.9.58-hotfix 锁定 HN 修复点 — line 283 必须含 import os."""
+        """V37.9.58-hotfix 锁定 HN 修复点 — prompt heredoc import 必须含 os."""
         fp = os.path.join(REPO_ROOT, "jobs/hn_watcher/run_hn_fixed.sh")
         with open(fp, "r") as f:
             lines = f.readlines()
-        # heredoc 起点 line 282 (HN 仅一个 HG_LEVEL_4_TEXT 注入)
-        # import 行是 line 283 (1-indexed) → idx 282 (0-indexed)
-        import_line = lines[282]
-        self.assertIn("import sys, json", import_line, "HN line 283 应是 import sys, json 行")
-        code_part = import_line.split("#", 1)[0]
-        self.assertRegex(
-            code_part, r"\bos\b",
-            f"V37.9.58-hotfix: HN line 283 必须含 os import (V37.9.57 注入 prompt += os.environ.get) — "
-            f"got: {import_line.strip()[:80]!r}"
-        )
+        # V37.9.85: HN metadata cleanup 加了行, import 位置漂移.
+        # 改为按内容查找: 第一个 "import sys, json" 行必须含 os
+        found = False
+        for i, line in enumerate(lines):
+            if "import sys, json" in line and not line.strip().startswith("#"):
+                code_part = line.split("#", 1)[0]
+                self.assertRegex(
+                    code_part, r"\bos\b",
+                    f"V37.9.58-hotfix: HN import line (L{i+1}) 必须含 os — "
+                    f"got: {line.strip()[:80]!r}"
+                )
+                found = True
+                break
+        self.assertTrue(found, "HN script 未找到 'import sys, json' 行")
 
     def test_v37_9_58_hotfix_marker_in_at_least_one_fix(self):
         """至少一个 V37.9.58-hotfix 修复点应有 marker 注释便于运维 grep / 历史追溯."""


### PR DESCRIPTION
[17] HN HTML metadata leak: strip comment attribution (username,
     "Hacker News•昨天6:22", points/comments counts) before passing
     RSS description to LLM prompt. Reduces noise in analysis.

[24] README badges: tests 3222→3346, invariants 80→82, jobs 35→36.

[16] Security scan grep exclusion: add +85200000001 to allowed list
     (governance_ontology.yaml test fixture, not a real number).
     Updated in preflight_check.sh + full_regression.sh + test_kb_business.py.

[13] kb_deep_dive wa_parts WARN: capture Python stderr to shell log
     via temp file, making deploy inconsistency visible in main log.

- test_v37_9_58_hotfix: HN line number search by content (not index)
- 96 suites / 3346 tests / 0 fail

https://claude.ai/code/session_019kX5ys3pwPkmMou3s2SWJb

## Summary
<!-- 1-3 句话描述变更的目的和价值 -->


## Changes
<!-- 列出主要变更点 -->
- 

## Impact Scope
<!-- 勾选受影响的组件 -->
- [ ] Proxy (tool_proxy.py / proxy_filters.py)
- [ ] Adapter (adapter.py)
- [ ] Gateway (OpenClaw config)
- [ ] KB system (kb_*.py/sh)
- [ ] Cron jobs (jobs_registry.yaml / job scripts)
- [ ] Monitoring (job_watchdog.sh / slo_checker.py)
- [ ] Config (config.yaml / config_loader.py)
- [ ] CI/CD (.github/workflows / auto_deploy.sh)
- [ ] Documentation only

## Risk Assessment
<!-- 变更风险评估 -->
- **Blast radius**: <!-- small/medium/large -->
- **Reversibility**: <!-- instant rollback / needs manual intervention / irreversible -->
- **Requires restart**: <!-- yes/no — which service? -->

## Rollback Plan
<!-- 如果出问题，如何回滚？ -->
```bash
# 回滚命令（示例）
cd ~/openclaw-model-bridge && git fetch origin main && git reset --hard <previous-commit>
bash ~/restart.sh
```

## Test Plan
- [ ] `python3 test_tool_proxy.py` (proxy_filters)
- [ ] `python3 test_check_registry.py` (registry)
- [ ] `python3 test_adapter.py` (adapter)
- [ ] `python3 test_config_slo.py` (config/SLO)
- [ ] `bash full_regression.sh` (all 430+ tests)
- [ ] `bash preflight_check.sh --full` (Mac Mini)
- [ ] WhatsApp E2E business test
- [ ] Other: <!-- 描述 -->

## Related
<!-- Issue/PR 链接 -->
- 
